### PR TITLE
docs: add .env.example for local development setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Browser/client gateway URL
+NEXT_PUBLIC_GATEWAY_URL=ws://localhost:18789
+
+# App server
+# PORT=3000
+# HOST=127.0.0.1
+
+# Optional: required only for public/remote deployments
+# STUDIO_ACCESS_TOKEN=
+
+# Optional: voice features
+# ELEVENLABS_API_KEY=
+# ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+# ELEVENLABS_MODEL_ID=eleven_flash_v2_5


### PR DESCRIPTION

## Summary

Adds `.env.example` so new contributors have a clear reference for running Claw3D locally.

## Motivation

The README documents:

`npm install && cp .env.example .env && npm run dev`

…but `.env.example` was missing from the repo.

## Changes

Adds `.env.example` with:

- `NEXT_PUBLIC_GATEWAY_URL`
- `PORT` / `HOST` (commented, optional)
- `STUDIO_ACCESS_TOKEN` (commented, optional for public/remote deployments)
- `ELEVENLABS_*` vars (commented, optional for voice features)

`OPENCLAW_GATEWAY_TOKEN` is not included because Luke confirmed token handling comes from `openclaw.json`, and some setups may not require a token.

## Testing

- `npm install` succeeds
- `npm run lint` passes
- `npm run typecheck` currently fails due to the existing TS blocker reported separately in #13
