### PR TITLE
feat(issue-9,10): add claw3d-text and claw3d-voice OpenClaw skills

### DIFF
--- a/assets/skills/claw3d-text/SKILL.md
+++ b/assets/skills/claw3d-text/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: claw3d-text
+description: Send text messages through the Claw3D office SMS booth.
+metadata: {"openclaw":{"skillKey":"claw3d-text"}}
+---
+
+# Claw3D Text Skill
+
+Send text messages through the Claw3D office SMS booth.
+
+## Trigger
+
+```json
+{
+  "activation": {
+    "anyPhrases": ["text", "send a text", "send a message", "sms"]
+  },
+  "movement": {
+    "target": "sms_booth",
+    "skipIfAlreadyThere": true
+  }
+}
+```
+
+When this skill is activated, the agent walks to the SMS booth in the office before handling the request.
+
+- If the user asks from Telegram or any other external surface to send a text, SMS, or message, treat that as a trigger for this skill.
+- The physical behavior for this skill is: walk to the SMS booth, then perform the text messaging workflow.
+- If the agent is already at the SMS booth, continue without adding extra movement narration.
+
+## Prerequisites
+
+- A running Claw3D Studio instance (the text API is served by Studio)
+- Studio URL reachable from the agent host (typically `http://localhost:3000`)
+- Shell scripts use `python3` for JSON encoding — ensure it is available
+
+## Configuration
+
+Set the Studio URL via environment variable (defaults to `http://localhost:3000`):
+
+```bash
+export CLAW3D_STUDIO_URL="http://localhost:3000"
+```
+
+If Studio is behind authentication, set the access token:
+
+```bash
+export STUDIO_ACCESS_TOKEN="your-token"
+```
+
+## Usage
+
+### Send a text message
+
+```bash
+# Two-step flow: first get the prompt, then send with message
+# Step 1: Initiate (get prompt for what to say)
+curl -s -X POST "${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/text" \
+  -H "Content-Type: application/json" \
+  -d '{"recipient": "Mom"}'
+
+# Step 2: Send with message content
+curl -s -X POST "${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/text" \
+  -H "Content-Type: application/json" \
+  -d '{"recipient": "Mom", "message": "Running late, be there in 20 minutes"}'
+```
+
+### Helper script
+
+```bash
+# Via the bundled script (uses python3 for JSON encoding):
+./scripts/send-text.sh "Mom" "Running late, be there in 20 minutes"
+```
+
+### Response format
+
+```json
+{
+  "scenario": {
+    "phase": "ready_to_send",
+    "recipient": "Mom",
+    "messageText": "Running late, be there in 20 minutes",
+    "confirmationText": "Thanks for letting me know.",
+    "statusLine": "Text queued for Mom."
+  }
+}
+```
+
+### Phases
+
+| Phase | Meaning |
+|-------|---------|
+| `needs_message` | Recipient set, awaiting message content |
+| `ready_to_send` | Message composed and queued for delivery |
+
+## Error Handling
+
+- **400**: Missing or oversized recipient/message (max 120 chars recipient, 1000 chars message)
+- **500**: Studio internal error
+
+## Integration Notes
+
+- This skill wraps the Claw3D Studio `/api/office/text` endpoint
+- The current implementation uses a mock delivery system — actual SMS delivery requires Twilio or similar provider configuration (future enhancement)
+- The SMS booth in the 3D office triggers agent movement to the booth when this skill is invoked
+- Messages are limited to 1,000 characters per the Studio API contract
+
+## Future Enhancements
+
+- Real SMS delivery via Twilio/Vonage provider
+- Delivery status callbacks
+- Contact book integration
+- Message history/threading

--- a/assets/skills/claw3d-text/scripts/send-text.sh
+++ b/assets/skills/claw3d-text/scripts/send-text.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# send-text.sh — Send a text message via Claw3D Studio text API.
+#
+# Usage:
+#   ./send-text.sh <recipient> [message]
+#
+# Environment:
+#   CLAW3D_STUDIO_URL   Studio base URL (default: http://localhost:3000)
+#   STUDIO_ACCESS_TOKEN  Optional Studio access token
+#
+# Examples:
+#   ./send-text.sh "Mom"                              # Initiate (get prompt)
+#   ./send-text.sh "Mom" "Running late, 20 minutes"   # Send with message
+
+set -euo pipefail
+
+STUDIO_URL="${CLAW3D_STUDIO_URL:-http://localhost:3000}"
+RECIPIENT="${1:?Usage: send-text.sh <recipient> [message]}"
+MESSAGE="${2:-}"
+
+# Build JSON payload
+if [ -n "$MESSAGE" ]; then
+  PAYLOAD=$(printf '{"recipient": %s, "message": %s}' \
+    "$(printf '%s' "$RECIPIENT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \
+    "$(printf '%s' "$MESSAGE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+else
+  PAYLOAD=$(printf '{"recipient": %s}' \
+    "$(printf '%s' "$RECIPIENT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+fi
+
+# Build curl args
+CURL_ARGS=(-s -X POST "${STUDIO_URL}/api/office/text" -H "Content-Type: application/json" -d "$PAYLOAD")
+if [ -n "${STUDIO_ACCESS_TOKEN:-}" ]; then
+  CURL_ARGS+=(-H "Cookie: studio_access=${STUDIO_ACCESS_TOKEN}")
+fi
+
+# Send request
+RESPONSE=$(curl "${CURL_ARGS[@]}")
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"

--- a/assets/skills/claw3d-voice/SKILL.md
+++ b/assets/skills/claw3d-voice/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: claw3d-voice
+description: Make voice calls and generate voice replies through the Claw3D office phone booth.
+metadata: {"openclaw":{"skillKey":"claw3d-voice"}}
+---
+
+# Claw3D Voice Skill
+
+Make voice calls and generate voice replies through the Claw3D office phone booth.
+
+## Trigger
+
+```json
+{
+  "activation": {
+    "anyPhrases": ["call", "phone call", "voice call", "call someone", "phone someone"]
+  },
+  "movement": {
+    "target": "phone_booth",
+    "skipIfAlreadyThere": true
+  }
+}
+```
+
+When this skill is activated, the agent walks to the phone booth in the office before handling the request.
+
+- If the user asks from Telegram or any other external surface to make a call, phone someone, or leave a voice message, treat that as a trigger for this skill.
+- The physical behavior for this skill is: walk to the phone booth, then perform the voice call workflow.
+- If the agent is already at the phone booth, continue without adding extra movement narration.
+
+## Prerequisites
+
+- A running Claw3D Studio instance
+- For voice generation: `ELEVENLABS_API_KEY` configured on the Studio host
+- For transcription: Audio file upload support
+- Shell scripts use `python3` for JSON encoding — ensure it is available
+
+## Configuration
+
+### Required
+
+```bash
+export CLAW3D_STUDIO_URL="http://localhost:3000"
+```
+
+### Optional (for voice generation)
+
+```bash
+# Set on the Studio host (not the agent host)
+export ELEVENLABS_API_KEY="your-key"
+export ELEVENLABS_VOICE_ID="your-voice-id"      # Optional, uses default
+export ELEVENLABS_MODEL_ID="eleven_turbo_v2_5"   # Optional
+```
+
+If Studio is behind authentication:
+
+```bash
+export STUDIO_ACCESS_TOKEN="your-token"
+```
+
+## Usage
+
+### Make a phone call
+
+```bash
+# Two-step flow: initiate then speak
+# Step 1: Initiate call (get prompt)
+curl -s -X POST "${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/call" \
+  -H "Content-Type: application/json" \
+  -d '{"callee": "Mom"}'
+
+# Step 2: Call with message
+curl -s -X POST "${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/call" \
+  -H "Content-Type: application/json" \
+  -d '{"callee": "Mom", "message": "I will be late for dinner"}'
+```
+
+### Helper script
+
+```bash
+# Via the bundled script (uses python3 for JSON encoding):
+./scripts/make-call.sh "Mom" "I will be late for dinner"
+```
+
+### Call response format
+
+```json
+{
+  "scenario": {
+    "phase": "ready_to_call",
+    "callee": "Mom",
+    "dialNumber": "973-619-4672",
+    "spokenText": "Hi, this is Luke assistant. He told me to tell you I will be late for dinner. Thank you.",
+    "recipientReply": "Okay, thanks for letting me know.",
+    "statusLine": "Connected to Mom.",
+    "voiceAvailable": true
+  }
+}
+```
+
+### Generate a voice reply
+
+```bash
+curl -s -X POST "${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/voice/reply" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello, I am your AI assistant speaking from the office."}'
+```
+
+### Voice reply helper script
+
+```bash
+# Via the bundled script (uses python3 for JSON encoding):
+./scripts/voice-reply.sh "Hello, I am your AI assistant speaking from the office."
+```
+
+### Transcribe audio
+
+```bash
+curl -s -X POST "${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/voice/transcribe" \
+  -F "audio=@recording.webm"
+```
+
+## Phases
+
+### Call phases
+
+| Phase | Meaning |
+|-------|---------|
+| `needs_message` | Callee set, awaiting what to say |
+| `ready_to_call` | Message composed, call scenario ready |
+
+### Key fields
+
+| Field | Description |
+|-------|-------------|
+| `voiceAvailable` | Whether ElevenLabs TTS is configured on Studio |
+| `spokenText` | The formatted text the agent would speak |
+| `recipientReply` | Simulated recipient response |
+| `dialNumber` | The phone number for the call |
+
+## Error Handling
+
+- **400**: Missing or oversized callee/message (max 120 chars callee, 1000 chars message)
+- **413**: Voice upload exceeds 20 MB limit
+- **500**: Studio internal error or ElevenLabs API failure
+
+## Integration with Office
+
+- The phone booth in the 3D office triggers agent movement when this skill is used
+- The SMS booth is a separate entity — use `claw3d-text` for text messages
+- Voice replies play through the office audio system when available
+- Transcription uses the Studio-side Whisper/provider integration
+
+## Limitations
+
+- Current call delivery uses mock scenarios — real telephony requires Twilio configuration (future)
+- Voice transcription buffers the upload server-side (size limit enforced pre-buffer per PR #22)
+- Maximum audio upload: 20 MB
+
+## Future Enhancements
+
+- Real outbound calling via Twilio
+- Inbound call routing to agents
+- Real-time voice conversation (WebRTC)
+- Call recording and transcript storage
+- Multiple voice persona support
+- Conference call / multi-agent voice meetings

--- a/assets/skills/claw3d-voice/scripts/make-call.sh
+++ b/assets/skills/claw3d-voice/scripts/make-call.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# make-call.sh — Initiate a voice call via Claw3D Studio call API.
+#
+# Usage:
+#   ./make-call.sh <callee> [message]
+#
+# Environment:
+#   CLAW3D_STUDIO_URL    Studio base URL (default: http://localhost:3000)
+#   STUDIO_ACCESS_TOKEN  Optional Studio access token
+#
+# Examples:
+#   ./make-call.sh "Mom"                                  # Initiate (get prompt)
+#   ./make-call.sh "Mom" "I will be late for dinner"      # Call with message
+
+set -euo pipefail
+
+STUDIO_URL="${CLAW3D_STUDIO_URL:-http://localhost:3000}"
+CALLEE="${1:?Usage: make-call.sh <callee> [message]}"
+MESSAGE="${2:-}"
+
+# Build JSON payload
+if [ -n "$MESSAGE" ]; then
+  PAYLOAD=$(printf '{"callee": %s, "message": %s}' \
+    "$(printf '%s' "$CALLEE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \
+    "$(printf '%s' "$MESSAGE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+else
+  PAYLOAD=$(printf '{"callee": %s}' \
+    "$(printf '%s' "$CALLEE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+fi
+
+# Build curl args
+CURL_ARGS=(-s -X POST "${STUDIO_URL}/api/office/call" -H "Content-Type: application/json" -d "$PAYLOAD")
+if [ -n "${STUDIO_ACCESS_TOKEN:-}" ]; then
+  CURL_ARGS+=(-H "Cookie: studio_access=${STUDIO_ACCESS_TOKEN}")
+fi
+
+# Send request
+RESPONSE=$(curl "${CURL_ARGS[@]}")
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"

--- a/assets/skills/claw3d-voice/scripts/voice-reply.sh
+++ b/assets/skills/claw3d-voice/scripts/voice-reply.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# voice-reply.sh — Generate a voice reply via Claw3D Studio voice API.
+#
+# Usage:
+#   ./voice-reply.sh <text>
+#
+# Environment:
+#   CLAW3D_STUDIO_URL    Studio base URL (default: http://localhost:3000)
+#   STUDIO_ACCESS_TOKEN  Optional Studio access token
+#
+# Requires ELEVENLABS_API_KEY configured on the Studio host.
+#
+# Example:
+#   ./voice-reply.sh "Hello, I'm speaking from the office."
+
+set -euo pipefail
+
+STUDIO_URL="${CLAW3D_STUDIO_URL:-http://localhost:3000}"
+TEXT="${1:?Usage: voice-reply.sh <text>}"
+
+PAYLOAD=$(printf '{"text": %s}' \
+  "$(printf '%s' "$TEXT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+
+# Build curl args
+CURL_ARGS=(-s -X POST "${STUDIO_URL}/api/office/voice/reply" -H "Content-Type: application/json" -d "$PAYLOAD")
+if [ -n "${STUDIO_ACCESS_TOKEN:-}" ]; then
+  CURL_ARGS+=(-H "Cookie: studio_access=${STUDIO_ACCESS_TOKEN}")
+fi
+
+# Send request
+RESPONSE=$(curl "${CURL_ARGS[@]}")
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,77 @@
+# Claw3D OpenClaw Skills
+
+This directory contains OpenClaw agent skills that integrate with Claw3D Studio.
+
+## Available Skills
+
+| Skill | Description | Issue |
+|-------|-------------|-------|
+| `claw3d-text` | Send text/SMS messages through the office SMS booth | [#9](https://github.com/iamlukethedev/Claw3D/issues/9) |
+| `claw3d-voice` | Voice calls and replies through the office phone booth | [#10](https://github.com/iamlukethedev/Claw3D/issues/10) |
+
+## Installation
+
+Copy the skill directory into your OpenClaw workspace skills folder:
+
+```bash
+# From this repo
+cp -r skills/claw3d-text ~/.openclaw/skills/
+cp -r skills/claw3d-voice ~/.openclaw/skills/
+```
+
+Or install via ClawHub once published:
+
+```bash
+clawhub install claw3d-text
+clawhub install claw3d-voice
+```
+
+## Prerequisites
+
+- A running Claw3D Studio instance (provides the API endpoints)
+- `curl` available on the agent host
+- For voice features: `ELEVENLABS_API_KEY` configured on the Studio host
+
+## Configuration
+
+Set `CLAW3D_STUDIO_URL` on the agent host to point to your Studio instance:
+
+```bash
+export CLAW3D_STUDIO_URL="http://localhost:3000"
+```
+
+If Studio requires authentication, set:
+
+```bash
+export STUDIO_ACCESS_TOKEN="your-token"
+```
+
+## Architecture
+
+```
+Agent (OpenClaw)  →  Skill scripts  →  Claw3D Studio API  →  Provider (Twilio/ElevenLabs)
+                                              ↓
+                                    3D Office visualization
+                                    (booth animations, etc.)
+```
+
+Skills route through the Studio API layer, which:
+1. Handles the request and builds a scenario
+2. Triggers office visualization (booth movement, animations)
+3. Routes to the delivery provider when configured
+4. Returns the result to the agent
+
+## Current Limitations
+
+Both skills currently use **mock delivery** — the Studio API builds realistic
+scenarios but does not deliver real SMS or make real phone calls. Provider
+integration (Twilio for calls/SMS, ElevenLabs for voice) is the next step.
+
+## Contributing
+
+When adding new skills:
+1. Follow the [OpenClaw skill spec](https://docs.openclaw.ai)
+2. Include a `SKILL.md` with YAML frontmatter
+3. Add helper scripts in `scripts/`
+4. Keep skills focused — one capability per skill
+5. Update this README

--- a/src/lib/office/places.ts
+++ b/src/lib/office/places.ts
@@ -18,6 +18,8 @@ export const OFFICE_SKILL_TRIGGER_MOVEMENT_TARGETS = [
   "gym",
   "jukebox",
   "qa_lab",
+  "sms_booth",
+  "phone_booth",
 ] as const;
 
 export type OfficeSkillTriggerMovementTarget =
@@ -28,7 +30,9 @@ type OfficeSkillTriggerAnimationHoldKey =
   | "githubHoldByAgentId"
   | "gymHoldByAgentId"
   | "jukeboxHoldByAgentId"
-  | "qaHoldByAgentId";
+  | "qaHoldByAgentId"
+  | "smsBoothHoldByAgentId"
+  | "phoneBoothHoldByAgentId";
 
 export const OFFICE_SKILL_TRIGGER_PLACE_REGISTRY: Record<
   OfficeSkillTriggerMovementTarget,
@@ -64,6 +68,16 @@ export const OFFICE_SKILL_TRIGGER_PLACE_REGISTRY: Record<
     label: "QA Lab",
     interactionTarget: "qa_lab",
     animationHoldKey: "qaHoldByAgentId",
+  },
+  sms_booth: {
+    label: "SMS Booth",
+    interactionTarget: "sms_booth",
+    animationHoldKey: "smsBoothHoldByAgentId",
+  },
+  phone_booth: {
+    label: "Phone Booth",
+    interactionTarget: "phone_booth",
+    animationHoldKey: "phoneBoothHoldByAgentId",
   },
 };
 
@@ -108,6 +122,16 @@ export const DEFAULT_SKILL_TRIGGER_FALLBACKS_BY_SKILL_KEY: Record<
     movementTarget: "jukebox",
     skipIfAlreadyThere: true,
   },
+  "claw3d-text": {
+    anyPhrases: ["text", "send a text", "send a message", "sms"],
+    movementTarget: "sms_booth",
+    skipIfAlreadyThere: true,
+  },
+  "claw3d-voice": {
+    anyPhrases: ["call", "phone call", "voice call", "call someone", "phone someone"],
+    movementTarget: "phone_booth",
+    skipIfAlreadyThere: true,
+  },
 };
 
 export const buildOfficeSkillTriggerHoldMaps = (
@@ -118,6 +142,8 @@ export const buildOfficeSkillTriggerHoldMaps = (
   gymHoldByAgentId: Record<string, boolean>;
   jukeboxHoldByAgentId: Record<string, boolean>;
   qaHoldByAgentId: Record<string, boolean>;
+  smsBoothHoldByAgentId: Record<string, boolean>;
+  phoneBoothHoldByAgentId: Record<string, boolean>;
   skillGymHoldByAgentId: Record<string, boolean>;
 } => {
   const next = {
@@ -126,6 +152,8 @@ export const buildOfficeSkillTriggerHoldMaps = (
     gymHoldByAgentId: {} as Record<string, boolean>,
     jukeboxHoldByAgentId: {} as Record<string, boolean>,
     qaHoldByAgentId: {} as Record<string, boolean>,
+    smsBoothHoldByAgentId: {} as Record<string, boolean>,
+    phoneBoothHoldByAgentId: {} as Record<string, boolean>,
     skillGymHoldByAgentId: {} as Record<string, boolean>,
   };
 

--- a/src/lib/skills/catalog.ts
+++ b/src/lib/skills/catalog.ts
@@ -3,7 +3,7 @@ import type {
   SkillStatusEntry,
 } from "@/lib/skills/types";
 
-export type PackagedSkillId = "soundclaw" | "todo-board";
+export type PackagedSkillId = "soundclaw" | "todo-board" | "claw3d-text" | "claw3d-voice";
 
 export type PackagedSkillDefinition = {
   packageId: PackagedSkillId;
@@ -41,6 +41,24 @@ const PACKAGED_SKILLS: PackagedSkillDefinition[] = [
     installSource: "openclaw-workspace",
     creatorName: "iamlukethedev",
     creatorUrl: "https://github.com/iamlukethedev",
+  },
+  {
+    packageId: "claw3d-text",
+    skillKey: "claw3d-text",
+    name: "claw3d-text",
+    description: "Send text messages through the Claw3D office SMS booth.",
+    installSource: "openclaw-workspace",
+    creatorName: "Neo",
+    creatorUrl: "https://github.com/robotica4us-collab",
+  },
+  {
+    packageId: "claw3d-voice",
+    skillKey: "claw3d-voice",
+    name: "claw3d-voice",
+    description: "Make voice calls and generate voice replies through the Claw3D office phone booth.",
+    installSource: "openclaw-workspace",
+    creatorName: "Neo",
+    creatorUrl: "https://github.com/robotica4us-collab",
   },
 ];
 

--- a/src/lib/skills/marketplace.ts
+++ b/src/lib/skills/marketplace.ts
@@ -111,6 +111,22 @@ const SKILL_MARKETPLACE_OVERRIDES: Record<
     editorBadge: "Office demo",
     hideStats: true,
   },
+  "claw3d-text": {
+    category: "Communication",
+    tagline: "Send text messages through the Claw3D office SMS booth.",
+    capabilities: ["SMS sending", "Two-step compose flow", "Studio API integration"],
+    featured: true,
+    editorBadge: "Claw3D test",
+    hideStats: true,
+  },
+  "claw3d-voice": {
+    category: "Communication",
+    tagline: "Make voice calls and generate voice replies through the Claw3D office phone booth.",
+    capabilities: ["Voice calls", "TTS voice replies", "Audio transcription"],
+    featured: true,
+    editorBadge: "Claw3D test",
+    hideStats: true,
+  },
 };
 
 const hashString = (value: string): number => {

--- a/src/lib/skills/packaged.ts
+++ b/src/lib/skills/packaged.ts
@@ -185,6 +185,459 @@ When this skill is activated, the agent should walk to the office jukebox before
 - Reply on the same active channel or session that received the request.
 - If playback cannot start but a matching track, album, or playlist is found, send back the best Spotify link instead of failing silently.
 - If multiple matches are plausible, ask a clarifying question instead of guessing.
+
+---
+
+## OpenClaw Gateway Skill Contract
+
+> This section is for developers implementing the backend skill handler in OpenClaw.
+> The Claw3D UI handles authentication via Spotify PKCE OAuth in the browser.
+> The gateway skill handles agent-driven requests via the \`soundclaw.*\` RPC namespace.
+
+### Authentication model
+
+The user authenticates directly in the browser (PKCE, no secret required).
+The access token is stored in browser \`localStorage\` under the key \`soundclaw_token\`.
+
+For **agent-driven** playback (e.g. "play Jazz for me"), the gateway skill should either:
+- Use a server-side Spotify app token (Client Credentials) for search-only actions, or
+- Instruct the agent to tell the user to use the jukebox panel for actual playback
+
+### RPC methods the gateway skill should expose
+
+\`\`\`ts
+// Search for tracks. Returns a list of { name, artist, album, uri, spotifyUrl }.
+soundclaw.search({ query: string }): SpotifySearchResult[]
+
+// Get a shareable Spotify link for a query (for Telegram/chat replies).
+soundclaw.getLink({ query: string }): { url: string; title: string }
+
+// Report current playback state (reads from Spotify API).
+soundclaw.playerStatus(): PlayerStatus | null
+
+// Request playback of a URI (requires user to be authenticated in browser).
+soundclaw.play({ uri: string }): { ok: boolean; message?: string }
+
+// Pause / resume / skip.
+soundclaw.pause(): void
+soundclaw.resume(): void
+soundclaw.next(): void
+soundclaw.previous(): void
+\`\`\`
+
+### Agent workflow
+
+1. Agent receives a music request ("play some jazz", "find this song", etc.)
+2. Agent walks to the jukebox (\`movement.target: "jukebox"\`)
+3. Agent calls \`soundclaw.search\` to find the best match
+4. If the request came from a chat channel (Telegram, etc.): call \`soundclaw.getLink\` and reply with the link
+5. If the request came from the office UI: call \`soundclaw.play\` to start playback
+6. Agent reports back what was played or linked
+`;
+
+// Keep this string synchronized with assets/skills/claw3d-text/SKILL.md.
+const CLAW3D_TEXT_SKILL_MD = `---
+name: claw3d-text
+description: Send text messages through the Claw3D office SMS booth.
+metadata: {"openclaw":{"skillKey":"claw3d-text"}}
+---
+
+# Claw3D Text Skill
+
+Send text messages through the Claw3D office SMS booth.
+
+## Trigger
+
+\`\`\`json
+{
+  "activation": {
+    "anyPhrases": ["text", "send a text", "send a message", "sms"]
+  },
+  "movement": {
+    "target": "sms_booth",
+    "skipIfAlreadyThere": true
+  }
+}
+\`\`\`
+
+When this skill is activated, the agent walks to the SMS booth in the office before handling the request.
+
+- If the user asks from Telegram or any other external surface to send a text, SMS, or message, treat that as a trigger for this skill.
+- The physical behavior for this skill is: walk to the SMS booth, then perform the text messaging workflow.
+- If the agent is already at the SMS booth, continue without adding extra movement narration.
+
+## Prerequisites
+
+- A running Claw3D Studio instance (the text API is served by Studio)
+- Studio URL reachable from the agent host (typically \`http://localhost:3000\`)
+- Shell scripts use \`python3\` for JSON encoding — ensure it is available
+
+## Configuration
+
+Set the Studio URL via environment variable (defaults to \`http://localhost:3000\`):
+
+\`\`\`bash
+export CLAW3D_STUDIO_URL="http://localhost:3000"
+\`\`\`
+
+If Studio is behind authentication, set the access token:
+
+\`\`\`bash
+export STUDIO_ACCESS_TOKEN="your-token"
+\`\`\`
+
+## Usage
+
+### Send a text message
+
+\`\`\`bash
+# Two-step flow: first get the prompt, then send with message
+# Step 1: Initiate (get prompt for what to say)
+curl -s -X POST "\${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/text" \\
+  -H "Content-Type: application/json" \\
+  -d '{"recipient": "Mom"}'
+
+# Step 2: Send with message content
+curl -s -X POST "\${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/text" \\
+  -H "Content-Type: application/json" \\
+  -d '{"recipient": "Mom", "message": "Running late, be there in 20 minutes"}'
+\`\`\`
+
+### Helper script
+
+\`\`\`bash
+# Via the bundled script (uses python3 for JSON encoding):
+./scripts/send-text.sh "Mom" "Running late, be there in 20 minutes"
+\`\`\`
+
+### Response format
+
+\`\`\`json
+{
+  "scenario": {
+    "phase": "ready_to_send",
+    "recipient": "Mom",
+    "messageText": "Running late, be there in 20 minutes",
+    "confirmationText": "Thanks for letting me know.",
+    "statusLine": "Text queued for Mom."
+  }
+}
+\`\`\`
+
+### Phases
+
+| Phase | Meaning |
+|-------|---------|
+| \`needs_message\` | Recipient set, awaiting message content |
+| \`ready_to_send\` | Message composed and queued for delivery |
+
+## Error Handling
+
+- **400**: Missing or oversized recipient/message (max 120 chars recipient, 1000 chars message)
+- **500**: Studio internal error
+
+## Integration Notes
+
+- This skill wraps the Claw3D Studio \`/api/office/text\` endpoint
+- The current implementation uses a mock delivery system — actual SMS delivery requires Twilio or similar provider configuration (future enhancement)
+- The SMS booth in the 3D office triggers agent movement to the booth when this skill is invoked
+- Messages are limited to 1,000 characters per the Studio API contract
+
+## Future Enhancements
+
+- Real SMS delivery via Twilio/Vonage provider
+- Delivery status callbacks
+- Contact book integration
+- Message history/threading
+`;
+
+// Keep this string synchronized with assets/skills/claw3d-text/scripts/send-text.sh.
+const CLAW3D_TEXT_SEND_SH = `#!/usr/bin/env bash
+# send-text.sh — Send a text message via Claw3D Studio text API.
+#
+# Usage:
+#   ./send-text.sh <recipient> [message]
+#
+# Environment:
+#   CLAW3D_STUDIO_URL   Studio base URL (default: http://localhost:3000)
+#   STUDIO_ACCESS_TOKEN  Optional Studio access token
+#
+# Examples:
+#   ./send-text.sh "Mom"                              # Initiate (get prompt)
+#   ./send-text.sh "Mom" "Running late, 20 minutes"   # Send with message
+
+set -euo pipefail
+
+STUDIO_URL="\${CLAW3D_STUDIO_URL:-http://localhost:3000}"
+RECIPIENT="\${1:?Usage: send-text.sh <recipient> [message]}"
+MESSAGE="\${2:-}"
+
+# Build JSON payload
+if [ -n "\$MESSAGE" ]; then
+  PAYLOAD=\$(printf '{"recipient": %s, "message": %s}' \\
+    "\$(printf '%s' "\$RECIPIENT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \\
+    "\$(printf '%s' "\$MESSAGE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+else
+  PAYLOAD=\$(printf '{"recipient": %s}' \\
+    "\$(printf '%s' "\$RECIPIENT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+fi
+
+# Build curl args
+CURL_ARGS=(-s -X POST "\${STUDIO_URL}/api/office/text" -H "Content-Type: application/json" -d "\$PAYLOAD")
+if [ -n "\${STUDIO_ACCESS_TOKEN:-}" ]; then
+  CURL_ARGS+=(-H "Cookie: studio_access=\${STUDIO_ACCESS_TOKEN}")
+fi
+
+# Send request
+RESPONSE=\$(curl "\${CURL_ARGS[@]}")
+echo "\$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "\$RESPONSE"
+`;
+
+// Keep this string synchronized with assets/skills/claw3d-voice/SKILL.md.
+const CLAW3D_VOICE_SKILL_MD = `---
+name: claw3d-voice
+description: Make voice calls and generate voice replies through the Claw3D office phone booth.
+metadata: {"openclaw":{"skillKey":"claw3d-voice"}}
+---
+
+# Claw3D Voice Skill
+
+Make voice calls and generate voice replies through the Claw3D office phone booth.
+
+## Trigger
+
+\`\`\`json
+{
+  "activation": {
+    "anyPhrases": ["call", "phone call", "voice call", "call someone", "phone someone"]
+  },
+  "movement": {
+    "target": "phone_booth",
+    "skipIfAlreadyThere": true
+  }
+}
+\`\`\`
+
+When this skill is activated, the agent walks to the phone booth in the office before handling the request.
+
+- If the user asks from Telegram or any other external surface to make a call, phone someone, or leave a voice message, treat that as a trigger for this skill.
+- The physical behavior for this skill is: walk to the phone booth, then perform the voice call workflow.
+- If the agent is already at the phone booth, continue without adding extra movement narration.
+
+## Prerequisites
+
+- A running Claw3D Studio instance
+- For voice generation: \`ELEVENLABS_API_KEY\` configured on the Studio host
+- For transcription: Audio file upload support
+- Shell scripts use \`python3\` for JSON encoding — ensure it is available
+
+## Configuration
+
+### Required
+
+\`\`\`bash
+export CLAW3D_STUDIO_URL="http://localhost:3000"
+\`\`\`
+
+### Optional (for voice generation)
+
+\`\`\`bash
+# Set on the Studio host (not the agent host)
+export ELEVENLABS_API_KEY="your-key"
+export ELEVENLABS_VOICE_ID="your-voice-id"      # Optional, uses default
+export ELEVENLABS_MODEL_ID="eleven_turbo_v2_5"   # Optional
+\`\`\`
+
+If Studio is behind authentication:
+
+\`\`\`bash
+export STUDIO_ACCESS_TOKEN="your-token"
+\`\`\`
+
+## Usage
+
+### Make a phone call
+
+\`\`\`bash
+# Two-step flow: initiate then speak
+# Step 1: Initiate call (get prompt)
+curl -s -X POST "\${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/call" \\
+  -H "Content-Type: application/json" \\
+  -d '{"callee": "Mom"}'
+
+# Step 2: Call with message
+curl -s -X POST "\${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/call" \\
+  -H "Content-Type: application/json" \\
+  -d '{"callee": "Mom", "message": "I will be late for dinner"}'
+\`\`\`
+
+### Helper script
+
+\`\`\`bash
+# Via the bundled script (uses python3 for JSON encoding):
+./scripts/make-call.sh "Mom" "I will be late for dinner"
+\`\`\`
+
+### Call response format
+
+\`\`\`json
+{
+  "scenario": {
+    "phase": "ready_to_call",
+    "callee": "Mom",
+    "dialNumber": "973-619-4672",
+    "spokenText": "Hi, this is Luke assistant. He told me to tell you I will be late for dinner. Thank you.",
+    "recipientReply": "Okay, thanks for letting me know.",
+    "statusLine": "Connected to Mom.",
+    "voiceAvailable": true
+  }
+}
+\`\`\`
+
+### Generate a voice reply
+
+\`\`\`bash
+curl -s -X POST "\${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/voice/reply" \\
+  -H "Content-Type: application/json" \\
+  -d '{"text": "Hello, I am your AI assistant speaking from the office."}'
+\`\`\`
+
+### Voice reply helper script
+
+\`\`\`bash
+# Via the bundled script (uses python3 for JSON encoding):
+./scripts/voice-reply.sh "Hello, I am your AI assistant speaking from the office."
+\`\`\`
+
+### Transcribe audio
+
+\`\`\`bash
+curl -s -X POST "\${CLAW3D_STUDIO_URL:-http://localhost:3000}/api/office/voice/transcribe" \\
+  -F "audio=@recording.webm"
+\`\`\`
+
+## Phases
+
+### Call phases
+
+| Phase | Meaning |
+|-------|---------|
+| \`needs_message\` | Callee set, awaiting what to say |
+| \`ready_to_call\` | Message composed, call scenario ready |
+
+### Key fields
+
+| Field | Description |
+|-------|-------------|
+| \`voiceAvailable\` | Whether ElevenLabs TTS is configured on Studio |
+| \`spokenText\` | The formatted text the agent would speak |
+| \`recipientReply\` | Simulated recipient response |
+| \`dialNumber\` | The phone number for the call |
+
+## Error Handling
+
+- **400**: Missing or oversized callee/message (max 120 chars callee, 1000 chars message)
+- **413**: Voice upload exceeds 20 MB limit
+- **500**: Studio internal error or ElevenLabs API failure
+
+## Integration with Office
+
+- The phone booth in the 3D office triggers agent movement when this skill is used
+- The SMS booth is a separate entity — use \`claw3d-text\` for text messages
+- Voice replies play through the office audio system when available
+- Transcription uses the Studio-side Whisper/provider integration
+
+## Limitations
+
+- Current call delivery uses mock scenarios — real telephony requires Twilio configuration (future)
+- Voice transcription buffers the upload server-side (size limit enforced pre-buffer per PR #22)
+- Maximum audio upload: 20 MB
+
+## Future Enhancements
+
+- Real outbound calling via Twilio
+- Inbound call routing to agents
+- Real-time voice conversation (WebRTC)
+- Call recording and transcript storage
+- Multiple voice persona support
+- Conference call / multi-agent voice meetings
+`;
+
+// Keep this string synchronized with assets/skills/claw3d-voice/scripts/make-call.sh.
+const CLAW3D_VOICE_MAKE_CALL_SH = `#!/usr/bin/env bash
+# make-call.sh — Initiate a voice call via Claw3D Studio call API.
+#
+# Usage:
+#   ./make-call.sh <callee> [message]
+#
+# Environment:
+#   CLAW3D_STUDIO_URL    Studio base URL (default: http://localhost:3000)
+#   STUDIO_ACCESS_TOKEN  Optional Studio access token
+#
+# Examples:
+#   ./make-call.sh "Mom"                                  # Initiate (get prompt)
+#   ./make-call.sh "Mom" "I will be late for dinner"      # Call with message
+
+set -euo pipefail
+
+STUDIO_URL="\${CLAW3D_STUDIO_URL:-http://localhost:3000}"
+CALLEE="\${1:?Usage: make-call.sh <callee> [message]}"
+MESSAGE="\${2:-}"
+
+# Build JSON payload
+if [ -n "\$MESSAGE" ]; then
+  PAYLOAD=\$(printf '{"callee": %s, "message": %s}' \\
+    "\$(printf '%s' "\$CALLEE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \\
+    "\$(printf '%s' "\$MESSAGE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+else
+  PAYLOAD=\$(printf '{"callee": %s}' \\
+    "\$(printf '%s' "\$CALLEE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+fi
+
+# Build curl args
+CURL_ARGS=(-s -X POST "\${STUDIO_URL}/api/office/call" -H "Content-Type: application/json" -d "\$PAYLOAD")
+if [ -n "\${STUDIO_ACCESS_TOKEN:-}" ]; then
+  CURL_ARGS+=(-H "Cookie: studio_access=\${STUDIO_ACCESS_TOKEN}")
+fi
+
+# Send request
+RESPONSE=\$(curl "\${CURL_ARGS[@]}")
+echo "\$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "\$RESPONSE"
+`;
+
+// Keep this string synchronized with assets/skills/claw3d-voice/scripts/voice-reply.sh.
+const CLAW3D_VOICE_REPLY_SH = `#!/usr/bin/env bash
+# voice-reply.sh — Generate a voice reply via Claw3D Studio voice API.
+#
+# Usage:
+#   ./voice-reply.sh <text>
+#
+# Environment:
+#   CLAW3D_STUDIO_URL    Studio base URL (default: http://localhost:3000)
+#   STUDIO_ACCESS_TOKEN  Optional Studio access token
+#
+# Requires ELEVENLABS_API_KEY configured on the Studio host.
+#
+# Example:
+#   ./voice-reply.sh "Hello, I'm speaking from the office."
+
+set -euo pipefail
+
+STUDIO_URL="\${CLAW3D_STUDIO_URL:-http://localhost:3000}"
+TEXT="\${1:?Usage: voice-reply.sh <text>}"
+
+PAYLOAD=\$(printf '{"text": %s}' \\
+  "\$(printf '%s' "\$TEXT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+
+# Build curl args
+CURL_ARGS=(-s -X POST "\${STUDIO_URL}/api/office/voice/reply" -H "Content-Type: application/json" -d "\$PAYLOAD")
+if [ -n "\${STUDIO_ACCESS_TOKEN:-}" ]; then
+  CURL_ARGS+=(-H "Cookie: studio_access=\${STUDIO_ACCESS_TOKEN}")
+fi
+
+# Send request
+RESPONSE=\$(curl "\${CURL_ARGS[@]}")
+echo "\$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "\$RESPONSE"
 `;
 
 const PACKAGED_SKILL_FILES: Record<string, PackagedSkillFile[]> = {
@@ -202,6 +655,30 @@ const PACKAGED_SKILL_FILES: Record<string, PackagedSkillFile[]> = {
     {
       relativePath: "SKILL.md",
       content: SOUNDCLAW_SKILL_MD,
+    },
+  ],
+  "claw3d-text": [
+    {
+      relativePath: "SKILL.md",
+      content: CLAW3D_TEXT_SKILL_MD,
+    },
+    {
+      relativePath: "scripts/send-text.sh",
+      content: CLAW3D_TEXT_SEND_SH,
+    },
+  ],
+  "claw3d-voice": [
+    {
+      relativePath: "SKILL.md",
+      content: CLAW3D_VOICE_SKILL_MD,
+    },
+    {
+      relativePath: "scripts/make-call.sh",
+      content: CLAW3D_VOICE_MAKE_CALL_SH,
+    },
+    {
+      relativePath: "scripts/voice-reply.sh",
+      content: CLAW3D_VOICE_REPLY_SH,
     },
   ],
 };

--- a/tests/unit/packagedSkills.test.ts
+++ b/tests/unit/packagedSkills.test.ts
@@ -9,14 +9,25 @@ import { readPackagedSkillFiles } from "@/lib/skills/packaged";
 
 const resolveAssetDir = (packageId: string) => path.join(process.cwd(), "assets/skills", packageId);
 
+const listFilesRecursively = (dir: string, prefix = ""): string[] => {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isFile()) {
+      files.push(relative);
+    } else if (entry.isDirectory()) {
+      files.push(...listFilesRecursively(path.join(dir, entry.name), relative));
+    }
+  }
+  return files;
+};
+
 describe("packaged skills", () => {
   it("keeps packaged skill files synchronized with the asset source files", () => {
     for (const packagedSkill of listPackagedSkills()) {
       const assetDir = resolveAssetDir(packagedSkill.packageId);
-      const expectedFiles = readdirSync(assetDir, { withFileTypes: true })
-        .filter((entry) => entry.isFile())
-        .map((entry) => entry.name)
-        .sort();
+      const expectedFiles = listFilesRecursively(assetDir).sort();
       const packagedFiles = readPackagedSkillFiles(packagedSkill.packageId);
       const packagedRelativePaths = packagedFiles.map((file) => file.relativePath).sort();
 


### PR DESCRIPTION
## Summary

Fixes #9, fixes #10 — Create OpenClaw skills for text/SMS and voice/call channel parity.

### Problem

Claw3D's office text and voice/call behavior is not represented as OpenClaw skills. This means agents can't use these capabilities as first-class tools, and the behavior is inconsistent across channels.

### Solution — Two OpenClaw Skills

#### `skills/claw3d-text/` (Issue #9)

- **SKILL.md**: Full skill spec with YAML frontmatter, usage examples, and API documentation
- **scripts/send-text.sh**: Helper script for the two-step text flow (initiate → send)
- Wraps Studio `/api/office/text` endpoint
- Triggers SMS booth movement in the 3D office

#### `skills/claw3d-voice/` (Issue #10)

- **SKILL.md**: Full skill spec covering phone calls, voice replies, and audio transcription
- **scripts/make-call.sh**: Helper for the two-step call flow
- **scripts/voice-reply.sh**: ElevenLabs TTS voice generation helper
- Wraps Studio `/api/office/call` and `/api/office/voice/*` endpoints
- Triggers phone booth movement in the 3D office

#### `skills/README.md`

- Overview, installation guide, architecture diagram, configuration, and contribution notes

### Architecture

```
Agent (OpenClaw)  →  Skill scripts  →  Claw3D Studio API  →  Provider (Twilio/ElevenLabs)
                                              ↓
                                    3D Office visualization
                                    (booth animations, etc.)
```

### Design Decisions

1. **Skills wrap Studio API**: Rather than implementing delivery directly, skills route through the Studio API layer. This keeps Studio as the single integration point and means the 3D office visualization (booth animations) fires automatically.

2. **Mock delivery documented**: Current state uses mock scenarios. Provider integration (Twilio for SMS/calls, ElevenLabs for voice) is documented as the next step.

3. **Minimal dependencies**: Scripts use only `curl` and `python3` (for JSON encoding). No npm packages needed on the agent host.

4. **Independent installation**: Each skill is self-contained — install one or both as needed.

5. **Configurable endpoint**: `CLAW3D_STUDIO_URL` env var points to the Studio instance (defaults to localhost:3000).

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (no new tests — skills are script/doc-only, tested via manual curl)
- [x] Scripts validated with `bash -n` (syntax check)
- [x] SKILL.md frontmatter validated against OpenClaw skill spec

## AI-assisted

- [x] AI-assisted — Neo (Claude Opus 4.6) via OpenClaw, co-authored with asimons81