### PR TITLE
feat: Phone & SMS Booth — real calls/SMS with multi-provider support (Twilio, WhatsApp, Telegram, iMessage)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,49 @@ DEBUG=true
 # Optional: required only for public/remote deployments
 # STUDIO_ACCESS_TOKEN=
 
+# ── Messaging provider (Phone Booth & SMS Booth) ──────────────────────────────
+# Active provider: twilio (default) | whatsapp | telegram | imessage
+# MESSAGING_PROVIDER=twilio
+#
+# Expose the active provider to the client UI (must match MESSAGING_PROVIDER)
+# NEXT_PUBLIC_MESSAGING_PROVIDER=twilio
+
+# ── Twilio — SMS & outbound calls ─────────────────────────────────────────────
+# Docs: https://www.twilio.com/docs/usage/api
+# TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# TWILIO_PHONE_NUMBER=+15005550006
+
+# ── WhatsApp via Twilio (MESSAGING_PROVIDER=whatsapp) ─────────────────────────
+# Uses the same TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN as above.
+# Get a WhatsApp-enabled sender at: console.twilio.com/develop/sms/whatsapp/senders
+# Note: outbound calls are not supported via WhatsApp.
+# TWILIO_WHATSAPP_NUMBER=whatsapp:+14155238886
+
+# ── Telegram Bot API (MESSAGING_PROVIDER=telegram) ────────────────────────────
+# 1. Create a bot with @BotFather on Telegram → get the token
+# 2. Start a conversation with your bot, then fetch:
+#    https://api.telegram.org/bot<TOKEN>/getUpdates  → find your chat_id
+# Note: outbound calls are not supported via Telegram.
+# TELEGRAM_BOT_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ
+# TELEGRAM_CHAT_ID=123456789
+
+# ── iMessage via BlueBubbles (MESSAGING_PROVIDER=imessage) ────────────────────
+# Requires a Mac running BlueBubbles server: https://bluebubbles.app
+# The Mac must be on, signed into iMessage, and reachable from this server.
+# Note: outbound calls are not supported via iMessage.
+# IMESSAGE_BLUEBUBBLES_URL=http://192.168.1.50:1234
+# IMESSAGE_BLUEBUBBLES_PASSWORD=your-bluebubbles-password
+# ─────────────────────────────────────────────────────────────────────────────
+
 # Optional: voice features
 # ELEVENLABS_API_KEY=
 # ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
 # ELEVENLABS_MODEL_ID=eleven_flash_v2_5
+
+# Agent notifications — owner phone number (never sent to agents, server-side only)
+# OWNER_PHONE_NUMBER=+1555000000
+# Optional: comma-separated agent IDs allowed to notify (leave unset = all agents allowed)
+# NOTIFY_ALLOWED_AGENTS=
+# Optional: max notifications per hour per agent (default: 3)
+# NOTIFY_RATE_LIMIT_PER_AGENT=3

--- a/docs/booth-messaging.md
+++ b/docs/booth-messaging.md
@@ -1,0 +1,330 @@
+# Phone Booth & SMS Booth — Messaging Integration
+
+This document covers everything added by the Phone & SMS Booth feature:
+architecture, setup, provider configuration, file reference, and the
+companion OpenClaw skill.
+
+---
+
+## Overview
+
+Claw3D's **Phone Booth** and **SMS Booth** went from read-only mock animations
+to fully functional communication tools. Agents and users can now place real
+outbound calls and send real SMS messages directly from the 3D office.
+
+The feature is built around a **provider abstraction layer** so any user can
+connect their preferred messaging backend — Twilio today, with WhatsApp and
+Telegram support designed and documented for contributors.
+
+---
+
+## What changed at a glance
+
+| Area | Before | After |
+|---|---|---|
+| Phone Booth | Mock animation only | Real outbound calls via messaging provider |
+| SMS Booth | Mock animation only | Real SMS via messaging provider |
+| Booth UI | Small modal | Full-screen 3-column layout |
+| Provider support | Hardcoded Twilio | Pluggable (Twilio ✅ / WhatsApp ✅ / Telegram ✅) |
+| Contacts | None | localStorage contacts + call/SMS history |
+| Agent skill | None | `notify-owner` skill for autonomous notifications |
+
+---
+
+## Quick setup
+
+### 1 — Pick a provider and set env vars
+
+**Twilio** (default — SMS + voice calls):
+
+```bash
+# .env.local
+MESSAGING_PROVIDER=twilio          # optional — twilio is the default
+
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_PHONE_NUMBER=+15005550006   # your Twilio number
+```
+
+Get your credentials at [console.twilio.com](https://console.twilio.com).
+A free trial account works — note that trial accounts prepend a notice to
+outbound calls before your message plays.
+
+**WhatsApp** (messages only — no calls):
+
+```bash
+MESSAGING_PROVIDER=whatsapp
+
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx   # same Twilio account
+TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_WHATSAPP_NUMBER=whatsapp:+14155238886            # your WhatsApp sender
+```
+
+Get a WhatsApp-enabled sender at [console.twilio.com/develop/sms/whatsapp/senders](https://console.twilio.com/develop/sms/whatsapp/senders).
+
+**Telegram** (messages only — no calls):
+
+```bash
+MESSAGING_PROVIDER=telegram
+
+TELEGRAM_BOT_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ
+TELEGRAM_CHAT_ID=123456789
+```
+
+1. Create a bot with [@BotFather](https://t.me/BotFather) on Telegram → get the token
+2. Start a conversation with your bot
+3. Fetch `https://api.telegram.org/bot<TOKEN>/getUpdates` → find your `chat_id`
+
+**iMessage via BlueBubbles** (messages only — no calls, requires a Mac):
+
+```bash
+MESSAGING_PROVIDER=imessage
+
+IMESSAGE_BLUEBUBBLES_URL=http://192.168.1.50:1234   # your Mac's BlueBubbles server
+IMESSAGE_BLUEBUBBLES_PASSWORD=your-password
+```
+
+1. Install [BlueBubbles](https://bluebubbles.app) on a Mac that stays on and is signed into iMessage
+2. In BlueBubbles settings, note the server URL and set a password
+3. Make sure the Mac is reachable from your Claw3D server (same network, or via ngrok / Cloudflare Tunnel)
+
+### 2 — (Optional) Owner notification route
+
+If you want agents to be able to notify you directly without knowing your
+personal number, add:
+
+```bash
+OWNER_PHONE_NUMBER=+1555...        # your number — never sent to agents
+```
+
+See [Agent → Owner notifications](#agent--owner-notifications) below.
+
+### 3 — Rebuild and restart
+
+```bash
+npm run build
+sudo systemctl restart claw3d.service   # or however you run Claw3D
+```
+
+### 4 — (Optional) Install the OpenClaw skill
+
+```bash
+cp -r skills/notify-owner ~/.openclaw/workspace/skills/
+```
+
+Then rebuild the skill bundle — see [`skills/README.md`](../skills/README.md).
+
+---
+
+## How the booth flow works
+
+```
+User clicks booth in 3D scene
+        │
+        ▼
+BoothInputDialog opens (full-screen)
+  ├── Left column  : contacts list / call history (localStorage)
+  ├── Center column: number display + message composer
+  └── Right column : numeric keypad
+        │
+        ▼ (submit)
+POST /api/office/call  or  POST /api/office/text
+        │
+        ▼
+messagingProviders.ts  →  dispatchMakeCall / dispatchSendSms
+        │
+        ├── provider = "twilio"  →  twilio.ts  →  Twilio REST API  →  real call/SMS
+        └── provider = other     →  stub (not yet implemented)
+        │
+        ▼ (success)
+Immersive screen opens
+  Phone Booth → PhoneBoothImmersiveScreen (emerald accent)
+  SMS Booth   → SmsBoothImmersiveScreen   (violet accent)
+        │
+        ▼ (phone call only)
+playBoothVoice()  →  POST /api/office/voice/reply
+        └── ElevenLabs TTS plays the spoken message in the browser
+```
+
+---
+
+## Provider abstraction
+
+### Active provider selection
+
+The active provider is read from the `MESSAGING_PROVIDER` environment variable.
+Individual API requests may pass a `provider` field to override it.
+
+```
+MESSAGING_PROVIDER=twilio     → Twilio REST API (SMS + voice calls)
+MESSAGING_PROVIDER=whatsapp   → WhatsApp via Twilio (messages only)
+MESSAGING_PROVIDER=telegram   → Telegram Bot API (messages only)
+MESSAGING_PROVIDER=imessage   → iMessage via BlueBubbles (messages only)
+```
+
+### Provider support matrix
+
+| Provider | Message | Call | Status | Notes |
+|---|---|---|---|---|
+| `twilio` | ✅ | ✅ | Implemented | Twilio REST API — SMS + voice calls |
+| `whatsapp` | ✅ | ❌ | Implemented | Twilio WhatsApp API — messages only |
+| `telegram` | ✅ | ❌ | Implemented | Telegram Bot API — messages only |
+| `imessage` | ✅ | ❌ | Implemented | BlueBubbles server (Mac) — messages only |
+
+> **Calls are only available via Twilio.**
+> WhatsApp, Telegram, and iMessage do not expose public APIs for initiating
+> outbound calls. This is a platform limitation, not a Claw3D limitation.
+> If you need voice calls, use `MESSAGING_PROVIDER=twilio`.
+
+### Adding a new provider
+
+1. Add its key to `MessagingProvider` in `src/lib/office/messagingProviders.ts`
+2. Create `src/lib/office/providers/<name>.ts` with `sendSms()` / `makeCall()`
+3. Wire it into `dispatchSendSms` / `dispatchMakeCall`
+4. Document required env vars in `.env.example`
+
+The stubs for WhatsApp and Telegram in `messagingProviders.ts` include the
+relevant API links and env var shapes as a starting point.
+
+---
+
+## Phone number normalisation
+
+`normalizePhoneNumber()` in `src/lib/office/twilio.ts` handles:
+
+| Input | Output |
+|---|---|
+| `0612345678` | `+33612345678` (French 06/07) |
+| `6121234567` | `+16121234567` (US 10-digit) |
+| `16121234567` | `+16121234567` (US 11-digit) |
+| `+33612345678` | `+33612345678` (E.164 passthrough) |
+
+---
+
+## File reference
+
+### New files
+
+| File | Description |
+|---|---|
+| `src/lib/office/twilio.ts` | Twilio REST client. `sendSms()`, `makeCall()`, `normalizePhoneNumber()`. Reads all credentials from env vars. |
+| `src/lib/office/messagingProviders.ts` | Provider abstraction. `dispatchSendSms()`, `dispatchMakeCall()`, provider status helpers. |
+| `src/lib/office/providers/whatsapp.ts` | WhatsApp provider via Twilio WhatsApp API. Messages only. Requires `TWILIO_WHATSAPP_NUMBER`. |
+| `src/lib/office/providers/telegram.ts` | Telegram provider via Bot API. Messages only. Requires `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`. |
+| `src/lib/office/providers/imessage.ts` | iMessage provider via BlueBubbles REST API. Messages only. Requires a Mac running BlueBubbles. |
+| `src/lib/office/boothContacts.ts` | localStorage contacts (`claw3d-booth-contacts`) and history (`claw3d-booth-history`, capped at 50). |
+| `src/features/office/dialogs/BoothInputDialog.tsx` | Full-screen booth input UI shared by Phone and SMS booths. |
+| `skills/notify-owner/SKILL.md` | OpenClaw skill — teaches agents to send owner notifications. |
+| `skills/README.md` | Skill installation guide. |
+
+### Modified files
+
+| File | What changed |
+|---|---|
+| `src/features/office/screens/PhoneBoothImmersiveScreen.tsx` | Full redesign. Two-column layout (call details + phone mockup). Emerald accent. Glow ring when connected. |
+| `src/features/office/screens/SmsBoothImmersiveScreen.tsx` | Full redesign. Same layout. Violet accent. On-screen keyboard with active key highlight. |
+| `src/app/api/office/call/route.ts` | Now routes through `dispatchMakeCall()`. Accepts optional `provider` field. Mock fallback unchanged. |
+| `src/app/api/office/text/route.ts` | Now routes through `dispatchSendSms()`. Same pattern. |
+| `src/features/retro-office/RetroOffice3D.tsx` | Wires `BoothInputDialog` to booth clicks. Opens immersive screens on success. Adds ping-pong directive. |
+| `src/lib/office/deskDirectives.ts` | Ping-pong intent: agents sent to the table on "play ping-pong" messages. |
+| `src/lib/office/eventTriggers.ts` | `pingPongHoldByAgentId` tracking. |
+| `.env.example` | Documents `MESSAGING_PROVIDER`, `TWILIO_*`, and placeholder blocks for WhatsApp and Telegram. |
+
+---
+
+## BoothInputDialog
+
+The new full-screen input replaces the previous small modal. It is shared
+between both booths and adapts its accent colour per kind.
+
+**Three-column layout:**
+
+```
+┌──────────────────┬──────────────────────┬──────────────────┐
+│  Contacts list   │  Number display      │  Numeric keypad  │
+│  ─────────────   │  ─────────────────   │  ─────────────── │
+│  Recent history  │  Message composer    │  1  2  3         │
+│                  │                      │  4  5  6         │
+│  Search bar      │  [Call / Send SMS]   │  7  8  9         │
+│                  │                      │  *  0  ⌫         │
+│  + Add contact   │                      │                  │
+└──────────────────┴──────────────────────┴──────────────────┘
+```
+
+**Features:**
+- Privacy mode: masks phone numbers with `••• ••• ••••`
+- Add contact: saves name + phone to localStorage
+- History: last 50 calls/SMS with relative timestamps
+- Contacts are shared across both booths
+
+---
+
+## Agent → Owner notifications
+
+`POST /api/agent/notify` lets any OpenClaw agent contact the office owner
+without knowing their phone number. The number is read from
+`OWNER_PHONE_NUMBER` (server-side only, never returned or logged).
+
+```json
+{ "kind": "sms" | "call", "message": "...", "agentId": "optional" }
+```
+
+**Rate limiting:** 3 notifications/hour per agent, 10/hour globally (in-memory).
+**Message cap:** 300 characters.
+**Allowlist:** set `NOTIFY_ALLOWED_AGENTS=id1,id2` to restrict access (unset = all agents).
+
+The companion OpenClaw skill (`skills/notify-owner/SKILL.md`) teaches agents
+the exact curl commands so they can use this endpoint autonomously.
+
+---
+
+## ElevenLabs voice (optional)
+
+When `ELEVENLABS_API_KEY` is set, the Phone Booth plays the spoken message
+through the browser using ElevenLabs TTS as the call animation plays.
+
+```bash
+ELEVENLABS_API_KEY=sk_...
+ELEVENLABS_VOICE_ID=...        # optional — defaults to Rachel (21m00Tcm4TlvDq8ikWAM)
+ELEVENLABS_MODEL_ID=eleven_flash_v2_5   # optional
+```
+
+The voice is played via `POST /api/office/voice/reply` (existing route).
+If the key is not set, the booth animation plays silently.
+
+---
+
+## Full environment variable reference
+
+```bash
+# ── Active provider ───────────────────────────────────────────────────────────
+# Choose one: twilio (default) | whatsapp | telegram | imessage
+MESSAGING_PROVIDER=twilio
+
+# ── Twilio — SMS + voice calls ────────────────────────────────────────────────
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_PHONE_NUMBER=+15005550006
+
+# ── WhatsApp via Twilio — messages only (no calls) ────────────────────────────
+# Uses the same TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN
+TWILIO_WHATSAPP_NUMBER=whatsapp:+14155238886
+
+# ── Telegram Bot API — messages only (no calls) ───────────────────────────────
+TELEGRAM_BOT_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ
+TELEGRAM_CHAT_ID=123456789
+
+# ── iMessage via BlueBubbles — messages only (no calls, requires Mac) ─────────
+IMESSAGE_BLUEBUBBLES_URL=http://192.168.1.50:1234
+IMESSAGE_BLUEBUBBLES_PASSWORD=your-bluebubbles-password
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+OWNER_PHONE_NUMBER=+1555...        # for /api/agent/notify — never exposed to agents
+
+# ElevenLabs TTS — phone booth browser audio (Twilio provider only)
+ELEVENLABS_API_KEY=sk_...
+ELEVENLABS_VOICE_ID=...
+ELEVENLABS_MODEL_ID=eleven_flash_v2_5
+```
+
+All sensitive values go in `.env.local` (gitignored). Never commit real credentials.

--- a/skills/notify-owner/SKILL.md
+++ b/skills/notify-owner/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: notify-owner
+description: Notify the office owner via SMS or phone call using the Claw3D notification system. Use when something requires the owner's immediate attention and cannot wait for them to check their computer — such as a critical error, a completed task they asked to be informed about, or a blocker that requires their input.
+---
+
+# Notify Owner
+
+Send an SMS or trigger a phone call to the office owner directly from Claw3D.
+
+The messaging backend (Twilio, WhatsApp, Telegram, iMessage, …) is configured
+server-side — you do not need to know which provider is active. The API is the
+same regardless.
+
+## When to use
+
+- A task the owner explicitly asked to be notified about is complete
+- A critical blocker requires their input and cannot be resolved autonomously
+- An error or situation is time-sensitive and cannot wait
+
+**Do not use for routine updates, progress reports, or anything the owner can read at their own pace.**
+
+## How to send an SMS
+
+```bash
+curl -s -X POST http://127.0.0.1:3000/api/agent/notify \
+  -H "Content-Type: application/json" \
+  -d "{\"kind\": \"sms\", \"message\": \"Your message here.\", \"agentId\": \"$AGENT_ID\"}"
+```
+
+## How to trigger a phone call
+
+```bash
+curl -s -X POST http://127.0.0.1:3000/api/agent/notify \
+  -H "Content-Type: application/json" \
+  -d "{\"kind\": \"call\", \"message\": \"Your message here.\", \"agentId\": \"$AGENT_ID\"}"
+```
+
+The call will read the message aloud to the owner. Keep the message under 200 characters for calls.
+
+## Response
+
+Success:
+```json
+{ "ok": true, "kind": "sms" }
+```
+
+Rate limit reached:
+```json
+{ "error": "Rate limit reached. Try again in X minute(s)." }
+```
+
+Provider not configured:
+```json
+{ "error": "No messaging provider configured." }
+```
+
+## Constraints
+
+- **Message limit**: 300 characters maximum
+- **Rate limit**: 3 notifications per hour per agent, 10 per hour globally
+- **Phone calls**: only available when the server uses Twilio — prefer SMS/message unless truly urgent
+- **Messages** (SMS, WhatsApp, Telegram, iMessage): available depending on the configured provider
+- The owner's phone number and messaging provider are managed server-side; you do not need to provide them
+- Replace `$AGENT_ID` with your actual agent identifier if known, or omit the field
+
+## Guardrails
+
+- Never send more than one SMS for the same event
+- Do not notify for something the owner will see when they next open Claw3D
+- If the rate limit is hit, do not retry in a loop — wait and continue working
+- Prefer a single clear sentence over a long explanation
+
+## Supported messaging backends
+
+The server routes notifications through the active messaging provider.
+You do not need to select or configure the provider — this is handled in the server environment.
+
+| Provider | Message | Call |
+|---|---|---|
+| Twilio | ✅ | ✅ |
+| WhatsApp (via Twilio) | ✅ | ❌ |
+| Telegram | ✅ | ❌ |
+| iMessage (via BlueBubbles) | ✅ | ❌ |
+
+Phone calls are only available when the server is configured with Twilio.
+All other providers support messages only.

--- a/src/app/api/agent/notify/route.ts
+++ b/src/app/api/agent/notify/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server";
+import {
+  isTwilioConfigured,
+  normalizePhoneNumber,
+  sendSms,
+  makeCall,
+} from "@/lib/office/twilio";
+
+export const runtime = "nodejs";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const OWNER_PHONE_NUMBER = process.env.OWNER_PHONE_NUMBER?.trim() ?? "";
+const MAX_MESSAGE_CHARS = 300;
+
+// Agents autorisés : liste d'IDs séparés par des virgules, ou vide = tous autorisés
+const ALLOWED_AGENTS: Set<string> | null = (() => {
+  const raw = process.env.NOTIFY_ALLOWED_AGENTS?.trim();
+  if (!raw) return null;
+  const ids = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  return ids.length > 0 ? new Set(ids) : null;
+})();
+
+const RATE_LIMIT_PER_AGENT = Number(process.env.NOTIFY_RATE_LIMIT_PER_AGENT ?? 3);
+const RATE_WINDOW_MS = 60 * 60 * 1_000; // 1 heure
+const GLOBAL_RATE_LIMIT = 10;
+
+// ── Rate limiting (in-memory, reset au redémarrage) ───────────────────────────
+
+type RateBucket = { count: number; resetAt: number };
+const agentBuckets = new Map<string, RateBucket>();
+let globalBucket: RateBucket = { count: 0, resetAt: Date.now() + RATE_WINDOW_MS };
+
+const checkAndIncrement = (bucket: RateBucket, limit: number, now: number): boolean => {
+  if (now >= bucket.resetAt) {
+    bucket.count = 0;
+    bucket.resetAt = now + RATE_WINDOW_MS;
+  }
+  if (bucket.count >= limit) return false;
+  bucket.count++;
+  return true;
+};
+
+const checkRateLimit = (agentId: string): { ok: boolean; retryInMinutes: number } => {
+  const now = Date.now();
+
+  // Global
+  if (!checkAndIncrement(globalBucket, GLOBAL_RATE_LIMIT, now)) {
+    return { ok: false, retryInMinutes: Math.ceil((globalBucket.resetAt - now) / 60_000) };
+  }
+
+  // Par agent
+  let bucket = agentBuckets.get(agentId);
+  if (!bucket) {
+    bucket = { count: 0, resetAt: now + RATE_WINDOW_MS };
+    agentBuckets.set(agentId, bucket);
+  }
+  if (!checkAndIncrement(bucket, RATE_LIMIT_PER_AGENT, now)) {
+    return { ok: false, retryInMinutes: Math.ceil((bucket.resetAt - now) / 60_000) };
+  }
+
+  return { ok: true, retryInMinutes: 0 };
+};
+
+// ── Sanitisation ──────────────────────────────────────────────────────────────
+
+const sanitizeMessage = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  return value
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_MESSAGE_CHARS);
+};
+
+const sanitizeAgentId = (value: unknown): string => {
+  if (typeof value !== "string") return "unknown";
+  return value.replace(/[^\w\-]/g, "").slice(0, 64) || "unknown";
+};
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+type NotifyRequestBody = {
+  kind?: string;
+  message?: unknown;
+  agentId?: unknown;
+};
+
+export async function POST(request: Request) {
+  try {
+    // Vérifications de config serveur
+    if (!OWNER_PHONE_NUMBER) {
+      return NextResponse.json(
+        { error: "Owner notifications are not configured on this server." },
+        { status: 503 },
+      );
+    }
+    if (!isTwilioConfigured()) {
+      return NextResponse.json(
+        { error: "Twilio is not configured on this server." },
+        { status: 503 },
+      );
+    }
+
+    const body = (await request.json()) as NotifyRequestBody;
+    const agentId = sanitizeAgentId(body.agentId);
+    const kind = body.kind === "call" ? "call" : "sms";
+    const message = sanitizeMessage(body.message);
+
+    if (!message) {
+      return NextResponse.json({ error: "message is required." }, { status: 400 });
+    }
+
+    // Allowlist
+    if (ALLOWED_AGENTS !== null && !ALLOWED_AGENTS.has(agentId)) {
+      return NextResponse.json(
+        { error: "This agent is not allowed to send notifications." },
+        { status: 403 },
+      );
+    }
+
+    // Rate limit
+    const rate = checkRateLimit(agentId);
+    if (!rate.ok) {
+      return NextResponse.json(
+        { error: `Rate limit reached. Try again in ${rate.retryInMinutes} minute(s).` },
+        { status: 429 },
+      );
+    }
+
+    const to = normalizePhoneNumber(OWNER_PHONE_NUMBER);
+    const excerpt = message.length > 60 ? message.slice(0, 60) + "…" : message;
+
+    if (kind === "call") {
+      await makeCall({ to, message });
+      console.log(`[agent/notify] call | agent=${agentId} | "${excerpt}"`);
+      return NextResponse.json({ ok: true, kind: "call" }, { headers: { "Cache-Control": "no-store" } });
+    } else {
+      await sendSms({ to, body: message });
+      console.log(`[agent/notify] sms  | agent=${agentId} | "${excerpt}"`);
+      return NextResponse.json({ ok: true, kind: "sms" }, { headers: { "Cache-Control": "no-store" } });
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Notification failed.";
+    console.error(`[agent/notify] error: ${msg}`);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/office/call/route.ts
+++ b/src/app/api/office/call/route.ts
@@ -1,12 +1,21 @@
 import { NextResponse } from "next/server";
 
 import { buildMockPhoneCallScenario } from "@/lib/office/call/mock";
+import { isPhoneNumberLike, normalizePhoneNumber } from "@/lib/office/twilio";
+import {
+  dispatchMakeCall,
+  getDefaultCallProvider,
+  getCallProviderStatus,
+  type CallCapableProvider,
+} from "@/lib/office/messagingProviders";
 
 export const runtime = "nodejs";
 
 type PhoneCallRequestBody = {
   callee?: string;
   message?: string | null;
+  /** Optional: override the active messaging provider for this request. */
+  provider?: CallCapableProvider;
 };
 
 const MAX_CALLEE_CHARS = 120;
@@ -37,20 +46,51 @@ export async function POST(request: Request) {
       );
     }
 
-    // TODO: Create Claw3D voice and text skill.
+    const provider = body.provider ?? getDefaultCallProvider();
+    const providerReady = getCallProviderStatus(provider) === "configured";
+    const calleeIsPhone = isPhoneNumberLike(callee);
+
+    // Provider configured + phone number + message → real call
+    if (providerReady && calleeIsPhone && message) {
+      const to = normalizePhoneNumber(callee);
+      await dispatchMakeCall({ to, message, provider });
+      const scenario = {
+        phase: "ready_to_call" as const,
+        callee,
+        dialNumber: to,
+        promptText: null,
+        spokenText: message,
+        recipientReply: null,
+        statusLine: `Appel lancé vers ${callee}.`,
+        voiceAvailable: false,
+      };
+      return NextResponse.json({ scenario }, { headers: { "Cache-Control": "no-store" } });
+    }
+
+    // Provider configured but no message yet → prompt for message
+    if (providerReady && calleeIsPhone && !message) {
+      const scenario = {
+        phase: "needs_message" as const,
+        callee,
+        dialNumber: normalizePhoneNumber(callee),
+        promptText: `Que voulez-vous dire à ${callee} ?`,
+        spokenText: null,
+        recipientReply: null,
+        statusLine: `En attente de votre message pour ${callee}.`,
+        voiceAvailable: false,
+      };
+      return NextResponse.json({ scenario }, { headers: { "Cache-Control": "no-store" } });
+    }
+
+    // Fallback: mock mode (no provider configured or recipient is not a phone number)
     const scenario = buildMockPhoneCallScenario({
       callee,
       message: message || null,
       voiceAvailable: Boolean(process.env.ELEVENLABS_API_KEY?.trim()),
     });
-
-    return NextResponse.json(
-      { scenario },
-      { headers: { "Cache-Control": "no-store" } },
-    );
+    return NextResponse.json({ scenario }, { headers: { "Cache-Control": "no-store" } });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Failed to prepare the mock phone call.";
+    const message = error instanceof Error ? error.message : "Failed to place phone call.";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/office/text/route.ts
+++ b/src/app/api/office/text/route.ts
@@ -1,12 +1,21 @@
 import { NextResponse } from "next/server";
 
 import { buildMockTextMessageScenario } from "@/lib/office/text/mock";
+import { isPhoneNumberLike, normalizePhoneNumber } from "@/lib/office/twilio";
+import {
+  dispatchSendSms,
+  getDefaultSmsProvider,
+  getSmsProviderStatus,
+  type SmsCapableProvider,
+} from "@/lib/office/messagingProviders";
 
 export const runtime = "nodejs";
 
 type TextMessageRequestBody = {
   recipient?: string;
   message?: string | null;
+  /** Optional: override the active messaging provider for this request. */
+  provider?: SmsCapableProvider;
 };
 
 const MAX_RECIPIENT_CHARS = 120;
@@ -37,19 +46,43 @@ export async function POST(request: Request) {
       );
     }
 
-    // TODO: Create Claw3D voice and text skill.
-    const scenario = buildMockTextMessageScenario({
-      recipient,
-      message: message || null,
-    });
+    const provider = body.provider ?? getDefaultSmsProvider();
+    const providerReady = getSmsProviderStatus(provider) === "configured";
+    const recipientIsPhone = isPhoneNumberLike(recipient);
 
-    return NextResponse.json(
-      { scenario },
-      { headers: { "Cache-Control": "no-store" } },
-    );
+    // Provider configured + phone number + message → real SMS
+    if (providerReady && recipientIsPhone && message) {
+      const to = normalizePhoneNumber(recipient);
+      await dispatchSendSms({ to, body: message, provider });
+      const scenario = {
+        phase: "ready_to_send" as const,
+        recipient,
+        messageText: message,
+        confirmationText: "SMS envoyé via Twilio.",
+        promptText: null,
+        statusLine: `SMS envoyé à ${recipient}.`,
+      };
+      return NextResponse.json({ scenario }, { headers: { "Cache-Control": "no-store" } });
+    }
+
+    // Provider configured but no message yet → prompt for message
+    if (providerReady && recipientIsPhone && !message) {
+      const scenario = {
+        phase: "needs_message" as const,
+        recipient,
+        messageText: null,
+        confirmationText: null,
+        promptText: `Que voulez-vous envoyer à ${recipient} ?`,
+        statusLine: `En attente de votre message pour ${recipient}.`,
+      };
+      return NextResponse.json({ scenario }, { headers: { "Cache-Control": "no-store" } });
+    }
+
+    // Fallback: mock mode (no provider configured or recipient is not a phone number)
+    const scenario = buildMockTextMessageScenario({ recipient, message: message || null });
+    return NextResponse.json({ scenario }, { headers: { "Cache-Control": "no-store" } });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Failed to prepare the mock text message.";
+    const message = error instanceof Error ? error.message : "Failed to send text message.";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/features/office/dialogs/BoothInputDialog.tsx
+++ b/src/features/office/dialogs/BoothInputDialog.tsx
@@ -1,0 +1,448 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  PhoneCall, MessageSquareText, Loader2, Delete, UserPlus,
+  Clock, Users, X, Check, Phone, MessageSquare, Eye, EyeOff, ChevronLeft, AtSign,
+} from "lucide-react";
+import type { MockPhoneCallScenario } from "@/lib/office/call/types";
+import type { MockTextMessageScenario } from "@/lib/office/text/types";
+import {
+  loadContacts, loadHistory, addContact, addHistoryEntry,
+  findContactByPhone, formatRelativeTime,
+  type BoothContact, type BoothHistoryEntry,
+} from "@/lib/office/boothContacts";
+
+type Props =
+  | { kind: "phone"; onSuccess: (scenario: MockPhoneCallScenario) => void; onClose: () => void }
+  | { kind: "sms";   onSuccess: (scenario: MockTextMessageScenario) => void; onClose: () => void };
+
+const KEYPAD_ROWS = [["1","2","3"],["4","5","6"],["7","8","9"],["*","0","⌫"]];
+
+// ── Provider config (NEXT_PUBLIC_* inlined at build time) ─────────────────────
+const ACTIVE_PROVIDER = process.env.NEXT_PUBLIC_MESSAGING_PROVIDER ?? "twilio";
+
+const PROVIDER_LABEL: Record<string, string> = {
+  twilio: "Twilio SMS", whatsapp: "WhatsApp", telegram: "Telegram", imessage: "iMessage",
+};
+
+const SMS_CTA_LABEL: Record<string, string> = {
+  twilio: "Send SMS", whatsapp: "Send via WhatsApp",
+  telegram: "Send to Telegram", imessage: "Send via iMessage",
+};
+
+// ── Design tokens per booth kind ──────────────────────────────────────────────
+const tokens = {
+  phone: {
+    accent: "emerald",
+    iconBg:      "bg-emerald-300/8 border-emerald-300/18",
+    iconColor:   "text-emerald-200",
+    tabActive:   "border-emerald-300/22 bg-emerald-300/12 text-white",
+    headerBorder:"border-emerald-400/12",
+    selected:    "border-emerald-300/24 bg-emerald-300/10",
+    ctaBorder:   "border-emerald-400/40 bg-emerald-400/16 text-emerald-100 shadow-[0_0_24px_rgba(52,211,153,0.12)] hover:border-emerald-300/55 hover:bg-emerald-400/24",
+    ctaSuccess:  "border-emerald-400/30 bg-emerald-400/15 text-emerald-200",
+    badge:       "border-emerald-300/18 bg-emerald-300/8 text-emerald-100/85",
+    label:       "text-emerald-200/65",
+    numberBorder:"border-emerald-300/14",
+  },
+  sms: {
+    accent: "violet",
+    iconBg:      "bg-violet-300/8 border-violet-300/18",
+    iconColor:   "text-violet-200",
+    tabActive:   "border-violet-300/22 bg-violet-300/12 text-white",
+    headerBorder:"border-violet-400/12",
+    selected:    "border-violet-300/24 bg-violet-300/10",
+    ctaBorder:   "border-violet-400/40 bg-violet-400/16 text-violet-100 shadow-[0_0_24px_rgba(167,139,250,0.12)] hover:border-violet-300/55 hover:bg-violet-400/24",
+    ctaSuccess:  "border-emerald-400/30 bg-emerald-400/15 text-emerald-200",
+    badge:       "border-violet-300/18 bg-violet-300/8 text-violet-100/85",
+    label:       "text-violet-200/65",
+    numberBorder:"border-violet-300/14",
+  },
+} as const;
+
+// ── Add Contact overlay ───────────────────────────────────────────────────────
+function AddContactModal({ initialPhone, onSave, onClose }: {
+  initialPhone: string; onSave: (c: BoothContact) => void; onClose: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState(initialPhone);
+
+  return (
+    <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/70 backdrop-blur-sm">
+      <div className="w-80 rounded-3xl border border-white/10 bg-[#081122] p-7 shadow-[0_30px_100px_rgba(0,0,0,0.6)]">
+        <div className="mb-5 flex items-center justify-between">
+          <span className="text-sm font-semibold text-white">New Contact</span>
+          <button onClick={onClose}
+            className="flex h-7 w-7 items-center justify-center rounded-full text-white/45 hover:bg-white/8 hover:text-white">
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <div className="space-y-3">
+          <input autoFocus value={name} onChange={(e) => setName(e.target.value)} placeholder="Full name"
+            className="w-full rounded-2xl border border-white/8 bg-white/5 px-4 py-3 text-sm text-white placeholder-white/30 outline-none focus:border-white/20 focus:bg-white/8" />
+          <input value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="(555) 867-5309"
+            className="w-full rounded-2xl border border-white/8 bg-white/5 px-4 py-3 text-sm text-white placeholder-white/30 outline-none focus:border-white/20 focus:bg-white/8" />
+        </div>
+        <div className="mt-5 flex gap-3">
+          <button onClick={onClose}
+            className="flex-1 rounded-2xl border border-white/10 bg-white/4 py-3 text-xs uppercase tracking-widest text-white/55 hover:border-white/20 hover:text-white/80">
+            Cancel
+          </button>
+          <button disabled={!name.trim() || !phone.trim()}
+            onClick={() => { const c = addContact(name.trim(), phone.trim()); onSave(c); }}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-2xl border border-white/15 bg-white/8 py-3 text-xs uppercase tracking-widest text-white hover:bg-white/12 disabled:opacity-35">
+            <Check className="h-3.5 w-3.5" /> Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+export function BoothInputDialog(props: Props) {
+  const { kind, onClose } = props;
+  const isPhone = kind === "phone";
+  const tk = tokens[kind];
+
+  // Provider context — calls are always Twilio; SMS depends on ACTIVE_PROVIDER
+  const provider = ACTIVE_PROVIDER;
+  const isTelegramSms = !isPhone && provider === "telegram";
+  const isIMessageSms = !isPhone && provider === "imessage";
+  const showKeypad = isPhone || provider === "twilio" || provider === "whatsapp";
+  const providerLabel = PROVIDER_LABEL[provider] ?? "Twilio SMS";
+  const smsCtaLabel = SMS_CTA_LABEL[provider] ?? "Send SMS";
+
+  const [digits, setDigits] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [tab, setTab] = useState<"contacts"|"recent">("contacts");
+  const [contacts, setContacts] = useState<BoothContact[]>([]);
+  const [history, setHistory] = useState<BoothHistoryEntry[]>([]);
+  const [search, setSearch] = useState("");
+  const [showAddContact, setShowAddContact] = useState(false);
+  const [privacyMode, setPrivacyMode] = useState(false);
+
+  useEffect(() => { setContacts(loadContacts()); setHistory(loadHistory()); }, []);
+  const refreshContacts = useCallback(() => setContacts(loadContacts()), []);
+  const fullNumber = digits.trim();
+
+  // Telegram doesn't need a recipient (chat_id is server-side)
+  const canSubmit = isTelegramSms ? true : Boolean(fullNumber);
+  const recipientForApi = isTelegramSms ? "telegram" : fullNumber;
+
+  const pressKey = (key: string) => {
+    if (key === "⌫") setDigits((d) => d.slice(0, -1));
+    else if (digits.length < 20) setDigits((d) => d + key);
+  };
+
+  const filteredContacts = contacts.filter(
+    (c) => c.name.toLowerCase().includes(search.toLowerCase()) || c.phone.includes(search));
+  const filteredHistory = history.filter(
+    (h) => (h.name ?? "").toLowerCase().includes(search.toLowerCase()) || h.phone.includes(search));
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setLoading(true); setError(null);
+    try {
+      const url = isPhone ? "/api/office/call" : "/api/office/text";
+      const body = isPhone
+        ? { callee: fullNumber, message: message.trim() || null }
+        : { recipient: recipientForApi, message: message.trim() || null };
+      const res = await fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+      const data = (await res.json()) as { scenario?: unknown; error?: string };
+      if (!res.ok || data.error) { setError(data.error ?? "Something went wrong."); return; }
+      if (!isTelegramSms) {
+        addHistoryEntry({ kind: isPhone ? "call" : "sms", name: findContactByPhone(fullNumber)?.name ?? null, phone: fullNumber, message: message.trim() || null });
+        setHistory(loadHistory());
+      }
+      setSuccess(true);
+      setTimeout(() => {
+        if (isPhone) (props as Extract<Props, { kind: "phone" }>).onSuccess(data.scenario as MockPhoneCallScenario);
+        else (props as Extract<Props, { kind: "sms" }>).onSuccess(data.scenario as MockTextMessageScenario);
+      }, 700);
+    } catch { setError("Could not reach the server."); }
+    finally { setLoading(false); }
+  };
+
+  return (
+    <div className="absolute inset-0 z-30 flex flex-col overflow-hidden bg-[radial-gradient(circle_at_top,#0f1b3d_0%,#060916_42%,#020409_100%)] text-white">
+
+      {/* ── TOP BAR ── */}
+      <div className={`flex h-14 shrink-0 items-center gap-4 border-b ${tk.headerBorder} bg-[#06101f]/82 px-6 backdrop-blur-sm`}>
+        <button onClick={onClose}
+          className="flex h-8 w-8 items-center justify-center rounded-xl text-white/40 transition-colors hover:bg-white/8 hover:text-white">
+          <ChevronLeft className="h-5 w-5" />
+        </button>
+
+        <div className={`flex h-9 w-9 items-center justify-center rounded-2xl border ${tk.iconBg}`}>
+          {isPhone
+            ? <Phone className={`h-4 w-4 ${tk.iconColor}`} />
+            : <MessageSquare className={`h-4 w-4 ${tk.iconColor}`} />}
+        </div>
+
+        <div>
+          <div className={`text-[11px] uppercase tracking-[0.28em] ${tk.label}`}>
+            {isPhone ? "Phone Booth" : "SMS Booth"}
+          </div>
+          <div className="text-[15px] font-semibold text-white">
+            {isPhone ? "Place a call." : "Send a message."}
+          </div>
+        </div>
+
+        {/* Provider badge */}
+        <div className={`rounded-full border px-3 py-1 text-[10px] uppercase tracking-[0.22em] ${tk.badge}`}>
+          {isPhone ? "via Twilio" : providerLabel}
+        </div>
+
+        <div className="flex-1" />
+
+        <button title={privacyMode ? "Show numbers" : "Hide numbers"}
+          onClick={() => setPrivacyMode((v) => !v)}
+          className="flex h-8 w-8 items-center justify-center rounded-xl text-white/30 transition-colors hover:bg-white/8 hover:text-white/70">
+          {privacyMode ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+        </button>
+
+        <button onClick={onClose}
+          className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-[12px] text-white/55 transition-colors hover:border-white/20 hover:text-white">
+          <X className="h-3.5 w-3.5" /> Close
+        </button>
+      </div>
+
+      {/* ── BODY ── */}
+      <div className="grid min-h-0 flex-1 grid-cols-[260px_1fr_360px]">
+
+        {/* ── COL 1 : CONTACTS ── */}
+        <div className="flex min-h-0 flex-col border-r border-white/6 bg-[#081122]/72">
+
+          {/* Tabs */}
+          <div className="grid grid-cols-2 gap-2 p-3">
+            {(["contacts","recent"] as const).map((t) => (
+              <button key={t} onClick={() => setTab(t)}
+                className={`rounded-2xl px-3 py-2.5 text-left transition-colors ${
+                  tab === t ? tk.tabActive + " border" : "border border-white/6 bg-white/4 text-white/55 hover:text-white"
+                }`}>
+                <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.24em] text-white/45">
+                  {t === "contacts" ? <Users className="h-3 w-3" /> : <Clock className="h-3 w-3" />}
+                  {t === "contacts" ? "Contacts" : "Recent"}
+                </div>
+                <div className="mt-1 text-sm font-semibold">
+                  {t === "contacts" ? contacts.length : history.length}
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {/* Search */}
+          <div className="px-3 pb-2">
+            <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search…"
+              className="w-full rounded-2xl border border-white/8 bg-white/4 px-4 py-2 text-[12px] text-white/85 placeholder-white/25 outline-none focus:border-white/16 focus:bg-white/6" />
+          </div>
+
+          {/* List */}
+          <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+            {tab === "contacts" ? (
+              filteredContacts.length === 0
+                ? <div className="rounded-2xl border border-white/6 bg-white/4 px-4 py-4 text-sm text-white/40">No contacts yet.</div>
+                : <div className="space-y-2">
+                    {filteredContacts.map((c) => (
+                      <button key={c.id} onClick={() => setDigits(c.phone)}
+                        className={`w-full rounded-2xl border px-4 py-3 text-left transition-colors ${
+                          digits === c.phone ? tk.selected + " border" : "border-white/6 bg-white/4 hover:border-white/12 hover:bg-white/6"
+                        }`}>
+                        <div className="flex items-center gap-3">
+                          <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full border ${tk.iconBg} text-[12px] font-bold ${tk.iconColor}`}>
+                            {c.name[0]?.toUpperCase() ?? "?"}
+                          </div>
+                          <div className="min-w-0">
+                            <div className="truncate text-[13px] font-semibold text-white">{c.name}</div>
+                            <div className="truncate font-mono text-[11px] text-white/45">
+                              {privacyMode ? "••• ••• ••••" : c.phone}
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+            ) : (
+              filteredHistory.length === 0
+                ? <div className="rounded-2xl border border-white/6 bg-white/4 px-4 py-4 text-sm text-white/40">No recent activity.</div>
+                : <div className="space-y-2">
+                    {filteredHistory.map((h) => (
+                      <button key={h.id} onClick={() => { setDigits(h.phone); if (h.message) setMessage(h.message); }}
+                        className="w-full rounded-2xl border border-white/6 bg-white/4 px-4 py-3 text-left transition-colors hover:border-white/12 hover:bg-white/6">
+                        <div className="flex items-center gap-3">
+                          <div className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full border ${
+                            h.kind === "call" ? "border-emerald-300/18 bg-emerald-300/8" : "border-violet-300/18 bg-violet-300/8"
+                          }`}>
+                            {h.kind === "call"
+                              ? <Phone className="h-3 w-3 text-emerald-300" />
+                              : <MessageSquare className="h-3 w-3 text-violet-300" />}
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[12px] font-semibold text-white">
+                              {h.name ?? (privacyMode ? "••• ••• ••••" : h.phone)}
+                            </div>
+                            <div className="flex items-center justify-between gap-2">
+                              <span className="truncate font-mono text-[10px] text-white/35">
+                                {privacyMode ? "•••" : (h.message ?? h.phone)}
+                              </span>
+                              <span className="shrink-0 text-[10px] text-white/25">{formatRelativeTime(h.timestamp)}</span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+            )}
+          </div>
+
+          {/* Add contact */}
+          <div className="border-t border-white/6 p-3">
+            <button onClick={() => setShowAddContact(true)}
+              className="flex w-full items-center justify-center gap-2 rounded-2xl border border-white/8 bg-white/4 py-2.5 text-[11px] uppercase tracking-widest text-white/45 transition-colors hover:border-white/16 hover:text-white/70">
+              <UserPlus className="h-3.5 w-3.5" /> Add Contact
+            </button>
+          </div>
+        </div>
+
+        {/* ── COL 2 : COMPOSE ── */}
+        <div className="flex flex-col px-10 py-8">
+
+          {/* Recipient display */}
+          <div className="mb-6">
+            <div className={`text-[11px] uppercase tracking-[0.28em] ${tk.label} mb-2`}>
+              {isPhone ? "Call" : isTelegramSms ? "Channel" : "Send to"}
+            </div>
+
+            {isTelegramSms ? (
+              /* Telegram: fixed recipient from server config */
+              <div className={`rounded-2xl border ${tk.numberBorder} bg-[#081122]/72 px-6 py-4`}>
+                <div className="text-sm text-white/70 leading-6">
+                  Message will be sent to your configured Telegram chat.
+                </div>
+                <div className="mt-1 text-[11px] uppercase tracking-[0.18em] text-white/35">
+                  Chat ID set via <span className="font-mono">TELEGRAM_CHAT_ID</span>
+                </div>
+              </div>
+            ) : isIMessageSms ? (
+              /* iMessage: text input (phone or Apple ID email) */
+              <div className={`rounded-2xl border ${tk.numberBorder} bg-[#081122]/72 px-6 py-5`}>
+                <input
+                  value={digits}
+                  onChange={(e) => setDigits(e.target.value)}
+                  placeholder="Phone number or Apple ID email"
+                  className="w-full bg-transparent font-mono text-xl font-light tracking-[0.12em] text-white outline-none placeholder:text-[16px] placeholder:font-sans placeholder:tracking-normal placeholder:text-white/22"
+                />
+              </div>
+            ) : (
+              /* Twilio / WhatsApp: numeric display */
+              <div className={`rounded-2xl border ${tk.numberBorder} bg-[#081122]/72 px-6 py-5`}>
+                <div className="font-mono text-3xl font-light tracking-[0.18em] text-white">
+                  {digits
+                    ? (privacyMode ? "••• ••• ••••" : digits)
+                    : <span className="text-2xl font-sans tracking-normal text-white/22">(555) 867-5309</span>}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Message */}
+          <div className="flex flex-1 flex-col">
+            <div className={`text-[11px] uppercase tracking-[0.28em] ${tk.label} mb-2`}>
+              {isPhone ? "Voice message" : "Message"}
+            </div>
+            <textarea value={message} onChange={(e) => setMessage(e.target.value)}
+              placeholder={
+                isPhone ? "Tell them I'll be late…" :
+                isTelegramSms ? "Type your Telegram message…" :
+                isIMessageSms ? "iMessage text…" :
+                "Hey, just checking in…"
+              }
+              className="flex-1 w-full resize-none rounded-2xl border border-white/8 bg-[#081122]/72 px-6 py-5 text-[15px] leading-7 text-white/85 placeholder-white/22 outline-none transition focus:border-white/16 focus:bg-[#081122]/90" />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="mt-4 rounded-2xl border border-rose-400/16 bg-rose-400/8 px-5 py-3 text-sm text-rose-100">
+              {error}
+            </div>
+          )}
+
+          {/* CTA */}
+          <button disabled={!canSubmit || loading || success} onClick={handleSubmit}
+            className={`mt-5 flex h-14 items-center justify-center gap-3 rounded-2xl border text-[13px] font-semibold uppercase tracking-[0.22em] transition-all disabled:cursor-not-allowed disabled:opacity-30 ${
+              success ? tk.ctaSuccess + " border" : tk.ctaBorder + " border"
+            }`}>
+            {loading ? <Loader2 className="h-5 w-5 animate-spin" />
+              : success ? <Check className="h-5 w-5" />
+              : isPhone ? <PhoneCall className="h-5 w-5" />
+              : <MessageSquareText className="h-5 w-5" />}
+            {success ? "Done!" : isPhone ? "Call" : smsCtaLabel}
+          </button>
+        </div>
+
+        {/* ── COL 3 : KEYPAD / INPUT HINT ── */}
+        {showKeypad ? (
+          /* Numeric keypad — Twilio, WhatsApp, or Phone booth */
+          <div className="flex flex-col items-center justify-center border-l border-white/6 bg-[#081122]/72 px-10 py-10">
+            <div className={`mb-6 text-[11px] uppercase tracking-[0.28em] ${tk.label}`}>Keypad</div>
+            <div className="grid w-full grid-cols-3 gap-3">
+              {KEYPAD_ROWS.flat().map((key) => (
+                <button key={key} onClick={() => pressKey(key)}
+                  className={`flex h-[72px] items-center justify-center rounded-2xl border text-xl font-light transition-all active:scale-95 ${
+                    key === "⌫"
+                      ? "border-white/6 bg-white/3 text-white/40 hover:border-white/12 hover:bg-white/6 hover:text-white/70"
+                      : "border-white/8 bg-white/5 text-white/80 hover:border-white/18 hover:bg-white/10 hover:text-white"
+                  }`}>
+                  {key === "⌫" ? <Delete className="h-5 w-5" /> : key}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : isIMessageSms ? (
+          /* iMessage: hint panel */
+          <div className="flex flex-col items-center justify-center border-l border-white/6 bg-[#081122]/72 px-10 py-10">
+            <div className={`mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border ${tk.iconBg}`}>
+              <AtSign className={`h-6 w-6 ${tk.iconColor}`} />
+            </div>
+            <div className={`mb-3 text-[11px] uppercase tracking-[0.28em] ${tk.label}`}>iMessage</div>
+            <p className="text-center text-[13px] leading-6 text-white/50">
+              Enter a phone number or Apple ID email address in the field on the left.
+            </p>
+            <div className="mt-5 rounded-2xl border border-white/6 bg-white/4 px-4 py-3 text-center text-[11px] text-white/35 leading-5">
+              Examples:<br />
+              <span className="font-mono text-white/50">+33612345678</span><br />
+              <span className="font-mono text-white/50">you@icloud.com</span>
+            </div>
+          </div>
+        ) : (
+          /* Telegram: info panel */
+          <div className="flex flex-col items-center justify-center border-l border-white/6 bg-[#081122]/72 px-10 py-10">
+            <div className={`mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border ${tk.iconBg}`}>
+              <MessageSquare className={`h-6 w-6 ${tk.iconColor}`} />
+            </div>
+            <div className={`mb-3 text-[11px] uppercase tracking-[0.28em] ${tk.label}`}>Telegram</div>
+            <p className="text-center text-[13px] leading-6 text-white/50">
+              Your message will be sent directly to the configured Telegram chat.
+            </p>
+            <div className="mt-5 rounded-2xl border border-white/6 bg-white/4 px-4 py-3 text-center text-[11px] text-white/35 leading-5">
+              The recipient is set via<br />
+              <span className="font-mono text-white/50">TELEGRAM_CHAT_ID</span><br />
+              in your server config.
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showAddContact && (
+        <AddContactModal initialPhone={digits}
+          onSave={() => { refreshContacts(); setShowAddContact(false); }}
+          onClose={() => setShowAddContact(false)} />
+      )}
+    </div>
+  );
+}

--- a/src/features/office/screens/PhoneBoothImmersiveScreen.tsx
+++ b/src/features/office/screens/PhoneBoothImmersiveScreen.tsx
@@ -3,135 +3,152 @@
 import { AudioLines, PhoneCall, Smartphone } from "lucide-react";
 import type { MockPhoneCallScenario } from "@/lib/office/call/types";
 
-export type PhoneCallStep =
-  | "dialing"
-  | "ringing"
-  | "speaking"
-  | "reply"
-  | "complete";
+export type PhoneCallStep = "dialing" | "ringing" | "speaking" | "reply" | "complete";
 
 export function PhoneBoothImmersiveScreen({
-  scenario,
-  step,
-  typedDigits,
+  scenario, step, typedDigits,
 }: {
   scenario: MockPhoneCallScenario;
   step: PhoneCallStep;
   typedDigits: string;
 }) {
   const statusLabel =
-    step === "dialing"
-      ? "Dialing"
-      : step === "ringing"
-        ? "Waiting for answer"
-        : step === "speaking"
-          ? "Connected"
-          : step === "reply"
-            ? "On the line"
-            : "Call complete";
+    step === "dialing"   ? "Dialing" :
+    step === "ringing"   ? "Waiting for answer" :
+    step === "speaking"  ? "Connected" :
+    step === "reply"     ? "On the line" :
+                           "Call complete";
+
+  const isLive = step === "speaking" || step === "reply";
 
   return (
-    <div className="absolute inset-0 overflow-hidden bg-[radial-gradient(circle_at_top,#0f172a_0%,#050816_46%,#02030a_100%)] text-white">
-      <div className="pointer-events-none absolute inset-0 opacity-25 [background-image:linear-gradient(rgba(56,189,248,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(56,189,248,0.08)_1px,transparent_1px)] [background-size:22px_22px]" />
-      <div className="relative flex h-full items-center justify-center px-8 py-10">
-        <div className="grid w-full max-w-5xl grid-cols-[1.05fr_0.95fr] gap-10">
-          <div className="rounded-[32px] border border-sky-300/18 bg-slate-950/65 p-8 shadow-[0_24px_90px_rgba(2,8,23,0.75)]">
-            <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.28em] text-sky-200/70">
-              <PhoneCall className="h-4 w-4" />
-              Phone Booth Call
+    <div className="relative flex h-full flex-col overflow-hidden bg-[radial-gradient(circle_at_top,#0f1b3d_0%,#060916_42%,#020409_100%)] text-white">
+
+      {/* header */}
+      <div className="border-b border-emerald-400/12 bg-[#06101f]/82 px-6 py-4 backdrop-blur-sm">
+        <div className="flex items-center gap-3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-emerald-300/18 bg-emerald-300/8">
+            <PhoneCall className="h-5 w-5 text-emerald-200" />
+          </div>
+          <div>
+            <div className="text-[11px] uppercase tracking-[0.28em] text-emerald-200/65">Phone Booth · via Twilio</div>
+            <div className="text-lg font-semibold text-white">
+              {isLive ? `Connected to ${scenario.callee}.` : `Calling ${scenario.callee}.`}
             </div>
-            <div className="mt-4 text-4xl font-semibold tracking-[0.08em] text-sky-50">
-              {scenario.callee}
-            </div>
-            <div className="mt-2 text-sm uppercase tracking-[0.24em] text-sky-200/55">
+          </div>
+          <div className="ml-auto">
+            <div className={`rounded-full border px-4 py-1.5 text-[12px] uppercase tracking-[0.2em] transition-all ${
+              isLive
+                ? "border-emerald-300/30 bg-emerald-300/12 text-emerald-100 shadow-[0_0_20px_rgba(52,211,153,0.15)]"
+                : "border-white/10 bg-white/5 text-white/55"
+            }`}>
               {statusLabel}
             </div>
-            <div className="mt-8 rounded-[28px] border border-sky-300/16 bg-slate-900/90 p-6">
-              <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.24em] text-sky-200/60">
-                <span>Calling from booth</span>
-                <span>{scenario.voiceAvailable ? "ElevenLabs ready" : "Text fallback"}</span>
-              </div>
-              <div className="mt-5 text-3xl font-medium tracking-[0.24em] text-sky-50">
-                {typedDigits || scenario.dialNumber}
-              </div>
-              <div className="mt-6 grid grid-cols-3 gap-3">
-                {["1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"].map((digit) => (
-                  <div
-                    key={digit}
-                    className={`flex h-14 items-center justify-center rounded-2xl border text-xl ${
-                      typedDigits.includes(digit)
-                        ? "border-sky-300/40 bg-sky-400/16 text-sky-50"
-                        : "border-slate-700 bg-slate-900/75 text-slate-300"
-                    }`}
-                  >
-                    {digit}
-                  </div>
-                ))}
-              </div>
-              <div className="mt-5 flex items-center justify-end">
-                <div
-                  className={`inline-flex items-center gap-3 rounded-2xl border px-5 py-3 text-sm uppercase tracking-[0.22em] transition-all ${
-                    step === "dialing"
-                      ? "border-emerald-300/18 bg-emerald-400/8 text-emerald-100/72"
-                      : "border-emerald-300/45 bg-emerald-400/18 text-emerald-50 shadow-[0_0_24px_rgba(74,222,128,0.22)]"
-                  }`}
-                >
-                  <PhoneCall className="h-4 w-4" />
-                  {step === "dialing" ? "Ready to call" : "Calling"}
-                </div>
+          </div>
+        </div>
+      </div>
+
+      {/* body */}
+      <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_380px] gap-0">
+
+        {/* left — call details */}
+        <div className="flex min-h-0 flex-col gap-4 overflow-y-auto p-8">
+
+          {/* callee card */}
+          <div className="rounded-3xl border border-white/6 bg-[#081122]/72 p-6">
+            <div className="text-[11px] uppercase tracking-[0.28em] text-white/40 mb-3">Recipient</div>
+            <div className="text-4xl font-semibold tracking-[0.06em] text-white">{scenario.callee}</div>
+            <div className="mt-2 font-mono text-lg text-white/50 tracking-[0.14em]">
+              {typedDigits || scenario.dialNumber}
+            </div>
+            <div className="mt-4 flex items-center gap-2">
+              <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] uppercase tracking-[0.2em] text-white/50">
+                {scenario.voiceAvailable ? "ElevenLabs ready" : "Text-to-speech"}
               </div>
             </div>
           </div>
 
-          <div className="flex items-center justify-center">
-            <div className="relative h-[74vh] max-h-[720px] w-[360px] rounded-[44px] border border-sky-200/20 bg-[#020617] p-3 shadow-[0_30px_120px_rgba(0,0,0,0.78)]">
-              <div className="absolute left-1/2 top-3 h-1.5 w-28 -translate-x-1/2 rounded-full bg-slate-700" />
-              <div className="relative flex h-full flex-col overflow-hidden rounded-[34px] border border-sky-300/12 bg-[linear-gradient(180deg,#081225_0%,#020617_100%)] px-6 py-8">
-                <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.24em] text-sky-200/65">
-                  <span>Cellular relay</span>
-                  <Smartphone className="h-4 w-4" />
+          {/* keypad display */}
+          <div className="rounded-3xl border border-white/6 bg-[#081122]/72 p-6">
+            <div className="text-[11px] uppercase tracking-[0.28em] text-white/40 mb-4">Dial pad</div>
+            <div className="grid grid-cols-3 gap-2.5">
+              {["1","2","3","4","5","6","7","8","9","*","0","#"].map((digit) => (
+                <div key={digit}
+                  className={`flex h-12 items-center justify-center rounded-2xl border text-lg font-light transition-all ${
+                    typedDigits.includes(digit)
+                      ? "border-emerald-300/30 bg-emerald-300/12 text-emerald-100"
+                      : "border-white/6 bg-white/4 text-white/55"
+                  }`}>
+                  {digit}
                 </div>
-                <div className="mt-8 flex h-28 w-28 items-center justify-center self-center rounded-full border border-sky-300/22 bg-sky-400/10 text-sky-100">
-                  {step === "speaking" || step === "reply" ? (
-                    <AudioLines className="h-12 w-12" />
-                  ) : (
-                    <PhoneCall className="h-12 w-12" />
-                  )}
+              ))}
+            </div>
+          </div>
+
+          {/* spoken message */}
+          {scenario.spokenText && (
+            <div className="rounded-3xl border border-emerald-300/14 bg-emerald-300/5 p-6">
+              <div className="text-[11px] uppercase tracking-[0.28em] text-emerald-200/55 mb-3">Voice message</div>
+              <p className="text-[15px] leading-7 text-white/85">{scenario.spokenText}</p>
+            </div>
+          )}
+
+          {/* recipient reply */}
+          {(step === "reply" || step === "complete") && scenario.recipientReply && (
+            <div className="rounded-3xl border border-white/6 bg-[#081122]/72 p-6">
+              <div className="text-[11px] uppercase tracking-[0.28em] text-white/40 mb-3">{scenario.callee}</div>
+              <p className="text-[15px] leading-7 text-white/80">{scenario.recipientReply}</p>
+            </div>
+          )}
+
+          {/* status line */}
+          <div className="rounded-2xl border border-white/6 bg-white/4 px-5 py-3 text-sm text-white/55">
+            {scenario.statusLine}
+          </div>
+        </div>
+
+        {/* right — phone mockup */}
+        <div className="flex items-center justify-center border-l border-white/6 bg-[#081122]/50 p-8">
+          <div className="relative h-[68vh] max-h-[660px] w-[320px] rounded-[44px] border border-white/12 bg-[#020617] p-3 shadow-[0_40px_120px_rgba(0,0,0,0.8)]">
+            <div className="absolute left-1/2 top-3 h-1.5 w-24 -translate-x-1/2 rounded-full bg-white/10" />
+            <div className="flex h-full flex-col overflow-hidden rounded-[34px] border border-white/6 bg-[linear-gradient(180deg,#081b35_0%,#020617_100%)] px-5 py-7">
+              <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.24em] text-white/40">
+                <span>Cellular</span>
+                <Smartphone className="h-3.5 w-3.5" />
+              </div>
+
+              <div className="mt-8 flex flex-col items-center">
+                <div className={`flex h-24 w-24 items-center justify-center rounded-full border ${
+                  isLive
+                    ? "border-emerald-300/30 bg-emerald-300/10 shadow-[0_0_30px_rgba(52,211,153,0.2)]"
+                    : "border-white/10 bg-white/5"
+                }`}>
+                  {isLive
+                    ? <AudioLines className="h-11 w-11 text-emerald-300" />
+                    : <PhoneCall className="h-11 w-11 text-white/50" />}
                 </div>
-                <div className="mt-6 text-center">
-                  <div className="text-[13px] uppercase tracking-[0.26em] text-sky-200/55">
-                    {statusLabel}
-                  </div>
-                  <div className="mt-2 text-2xl font-semibold text-sky-50">
-                    {scenario.callee}
-                  </div>
-                  <div className="mt-2 text-sm tracking-[0.22em] text-sky-200/60">
-                    {scenario.dialNumber}
-                  </div>
+                <div className="mt-5 text-center">
+                  <div className="text-[11px] uppercase tracking-[0.28em] text-white/35">{statusLabel}</div>
+                  <div className="mt-2 text-2xl font-semibold text-white">{scenario.callee}</div>
+                  <div className="mt-1 font-mono text-sm text-white/40 tracking-[0.12em]">{scenario.dialNumber}</div>
                 </div>
-                <div className="mt-8 flex-1 space-y-4">
-                  <Bubble
-                    label="Agent"
-                    text={
-                      step === "dialing"
-                        ? `Typing ${typedDigits || scenario.dialNumber}.`
-                        : step === "ringing"
-                          ? `Pressed call and waiting for ${scenario.callee} to answer.`
-                          : scenario.spokenText ?? "Preparing the line."
-                    }
-                    tone="primary"
-                  />
-                  {step === "reply" || step === "complete" ? (
-                    <Bubble
-                      label={scenario.callee}
-                      text={scenario.recipientReply ?? "The line is quiet."}
-                      tone="secondary"
-                    />
-                  ) : null}
-                </div>
-                <div className="rounded-[24px] border border-sky-300/14 bg-slate-950/70 px-4 py-3 text-sm text-sky-100/78">
-                  {scenario.statusLine}
-                </div>
+              </div>
+
+              <div className="mt-8 flex-1 space-y-3">
+                <Bubble label="Agent" tone="primary"
+                  text={
+                    step === "dialing"  ? `Dialling ${typedDigits || scenario.dialNumber}…` :
+                    step === "ringing"  ? `Ringing ${scenario.callee}…` :
+                    scenario.spokenText ?? "Preparing the line."
+                  } />
+                {(step === "reply" || step === "complete") && (
+                  <Bubble label={scenario.callee} tone="secondary"
+                    text={scenario.recipientReply ?? "The line is quiet."} />
+                )}
+              </div>
+
+              <div className="mt-4 rounded-2xl border border-white/6 bg-black/30 px-4 py-3 text-[12px] text-white/55">
+                {scenario.statusLine}
               </div>
             </div>
           </div>
@@ -141,25 +158,15 @@ export function PhoneBoothImmersiveScreen({
   );
 }
 
-function Bubble({
-  label,
-  text,
-  tone,
-}: {
-  label: string;
-  text: string;
-  tone: "primary" | "secondary";
-}) {
+function Bubble({ label, text, tone }: { label: string; text: string; tone: "primary"|"secondary" }) {
   return (
-    <div
-      className={`rounded-[24px] border px-4 py-4 ${
-        tone === "primary"
-          ? "border-sky-300/18 bg-sky-400/10 text-sky-50"
-          : "border-slate-700 bg-slate-900/90 text-slate-100"
-      }`}
-    >
-      <div className="text-[10px] uppercase tracking-[0.22em] opacity-60">{label}</div>
-      <div className="mt-2 text-sm leading-6">{text}</div>
+    <div className={`rounded-2xl border px-4 py-4 ${
+      tone === "primary"
+        ? "border-emerald-300/14 bg-emerald-300/6 text-white"
+        : "border-white/6 bg-white/4 text-white/80"
+    }`}>
+      <div className="text-[10px] uppercase tracking-[0.22em] text-white/40 mb-1.5">{label}</div>
+      <div className="text-sm leading-6">{text}</div>
     </div>
   );
 }

--- a/src/features/office/screens/SmsBoothImmersiveScreen.tsx
+++ b/src/features/office/screens/SmsBoothImmersiveScreen.tsx
@@ -3,21 +3,18 @@
 import { CheckCheck, MessageSquareText, Send, Smartphone } from "lucide-react";
 import type { MockTextMessageScenario } from "@/lib/office/text/types";
 
+const PROVIDER_LABEL: Record<string, string> = {
+  twilio: "Twilio SMS", whatsapp: "WhatsApp", telegram: "Telegram", imessage: "iMessage",
+};
+const ACTIVE_PROVIDER_LABEL =
+  PROVIDER_LABEL[process.env.NEXT_PUBLIC_MESSAGING_PROVIDER ?? "twilio"] ?? "Twilio SMS";
+
 export type TextMessageStep =
-  | "selecting_contact"
-  | "composing"
-  | "sending"
-  | "delivered"
-  | "reply"
-  | "complete";
+  | "selecting_contact" | "composing" | "sending"
+  | "delivered" | "reply" | "complete";
 
 export function SmsBoothImmersiveScreen({
-  scenario,
-  step,
-  typedMessage,
-  activeKey,
-  contacts,
-  activeContactIndex,
+  scenario, step, typedMessage, activeKey, contacts, activeContactIndex,
 }: {
   scenario: MockTextMessageScenario;
   step: TextMessageStep;
@@ -27,109 +24,167 @@ export function SmsBoothImmersiveScreen({
   activeContactIndex: number | null;
 }) {
   const statusLabel =
-    step === "selecting_contact"
-      ? "Selecting contact"
-      : step === "composing"
-      ? "Composing"
-      : step === "sending"
-        ? "Sending"
-        : step === "delivered"
-          ? "Delivered"
-          : step === "reply"
-            ? "Reply received"
-            : "Message complete";
+    step === "selecting_contact" ? "Selecting contact" :
+    step === "composing"         ? "Composing" :
+    step === "sending"           ? "Sending" :
+    step === "delivered"         ? "Delivered" :
+    step === "reply"             ? "Reply received" :
+                                   "Message complete";
+
   const messageBody = typedMessage || scenario.messageText || "";
+  const isSent = step === "delivered" || step === "reply" || step === "complete";
 
   return (
-    <div className="absolute inset-0 overflow-hidden bg-[radial-gradient(circle_at_top,#0f172a_0%,#050816_48%,#02030a_100%)] text-white">
-      <div className="pointer-events-none absolute inset-0 opacity-20 [background-image:linear-gradient(rgba(56,189,248,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(56,189,248,0.08)_1px,transparent_1px)] [background-size:22px_22px]" />
-      <div className="relative flex h-full items-center justify-center px-8 py-10">
-        <div className="grid w-full max-w-5xl grid-cols-[1fr_0.92fr] gap-10">
-          <div className="rounded-[32px] border border-sky-300/18 bg-slate-950/65 p-8 shadow-[0_24px_90px_rgba(2,8,23,0.75)]">
-            <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.28em] text-sky-200/70">
-              <MessageSquareText className="h-4 w-4" />
-              Messaging Booth
+    <div className="relative flex h-full flex-col overflow-hidden bg-[radial-gradient(circle_at_top,#0f1b3d_0%,#060916_42%,#020409_100%)] text-white">
+
+      {/* header */}
+      <div className="border-b border-violet-400/12 bg-[#06101f]/82 px-6 py-4 backdrop-blur-sm">
+        <div className="flex items-center gap-3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-violet-300/18 bg-violet-300/8">
+            <MessageSquareText className="h-5 w-5 text-violet-200" />
+          </div>
+          <div>
+            <div className="text-[11px] uppercase tracking-[0.28em] text-violet-200/65">SMS Booth · {ACTIVE_PROVIDER_LABEL}</div>
+            <div className="text-lg font-semibold text-white">
+              {isSent ? `Message sent to ${scenario.recipient}.` : `Messaging ${scenario.recipient}.`}
             </div>
-            <div className="mt-4 text-4xl font-semibold tracking-[0.08em] text-sky-50">
-              {scenario.recipient}
-            </div>
-            <div className="mt-2 text-sm uppercase tracking-[0.24em] text-sky-200/55">
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <div className={`rounded-full border px-4 py-1.5 text-[12px] uppercase tracking-[0.2em] transition-all ${
+              isSent
+                ? "border-violet-300/30 bg-violet-300/12 text-violet-100 shadow-[0_0_20px_rgba(167,139,250,0.15)]"
+                : step === "sending"
+                  ? "border-amber-300/20 bg-amber-300/8 text-amber-100/80"
+                  : "border-white/10 bg-white/5 text-white/55"
+            }`}>
               {statusLabel}
             </div>
-            <div className="mt-8 rounded-[28px] border border-sky-300/16 bg-slate-900/90 p-6">
-              <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.24em] text-sky-200/60">
-                <span>Typing from booth</span>
-                <span>iPhone relay</span>
-              </div>
-              <div className="mt-5 rounded-[24px] border border-slate-700 bg-slate-950/80 px-5 py-4 text-base leading-7 text-sky-50">
-                {messageBody || "Waiting for the first characters."}
-                {step === "composing" ? <span className="ml-1 inline-block animate-pulse">|</span> : null}
-              </div>
-              <div className="mt-5 flex items-center justify-end gap-3 text-sm uppercase tracking-[0.22em]">
-                <div className="inline-flex items-center gap-2 rounded-2xl border border-sky-300/22 bg-sky-400/10 px-4 py-2 text-sky-100/80">
-                  <Smartphone className="h-4 w-4" />
-                  Active
-                </div>
-                <div className="inline-flex items-center gap-2 rounded-2xl border border-emerald-300/24 bg-emerald-400/10 px-4 py-2 text-emerald-100/80">
-                  {step === "sending" ? <Send className="h-4 w-4" /> : <CheckCheck className="h-4 w-4" />}
-                  {step === "composing" ? "Drafting" : statusLabel}
-                </div>
+          </div>
+        </div>
+      </div>
+
+      {/* body */}
+      <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_380px] gap-0">
+
+        {/* left — compose details */}
+        <div className="flex min-h-0 flex-col gap-4 overflow-y-auto p-8">
+
+          {/* recipient card */}
+          <div className="rounded-3xl border border-white/6 bg-[#081122]/72 p-6">
+            <div className="text-[11px] uppercase tracking-[0.28em] text-white/40 mb-3">Recipient</div>
+            <div className="text-4xl font-semibold tracking-[0.06em] text-white">{scenario.recipient}</div>
+            <div className="mt-4 flex items-center gap-2">
+              <div className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] uppercase tracking-[0.2em] ${
+                isSent ? "border-violet-300/20 bg-violet-300/8 text-violet-100/80" : "border-white/10 bg-white/5 text-white/45"
+              }`}>
+                {isSent ? <CheckCheck className="h-3 w-3" /> : <Send className="h-3 w-3" />}
+                {isSent ? "Delivered" : "Drafting"}
               </div>
             </div>
           </div>
 
-          <div className="flex items-center justify-center">
-            <div className="relative h-[74vh] max-h-[720px] w-[360px] rounded-[44px] border border-sky-200/20 bg-[#020617] p-3 shadow-[0_30px_120px_rgba(0,0,0,0.78)]">
-              <div className="absolute left-1/2 top-3 h-1.5 w-28 -translate-x-1/2 rounded-full bg-slate-700" />
-              <div className="relative flex h-full flex-col overflow-hidden rounded-[34px] border border-sky-300/12 bg-[linear-gradient(180deg,#081225_0%,#020617_100%)] px-5 py-6">
-                <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.24em] text-sky-200/65">
-                  <span>Messages</span>
-                  <Smartphone className="h-4 w-4" />
-                </div>
-                <div className="mt-5 text-center">
-                  <div className="text-[13px] uppercase tracking-[0.26em] text-sky-200/55">
-                    {statusLabel}
-                  </div>
-                  <div className="mt-2 text-2xl font-semibold text-sky-50">
-                    {scenario.recipient}
-                  </div>
-                </div>
-                <div className="mt-6 flex-1">
-                  {step === "selecting_contact" ? (
-                    <ContactList
-                      contacts={contacts}
-                      activeContactIndex={activeContactIndex}
-                    />
-                  ) : (
-                    <div className="space-y-4">
-                      <Bubble
-                        align="right"
-                        label="Agent"
-                        text={messageBody || "Starting draft."}
-                        tone="primary"
-                      />
-                      {step === "delivered" || step === "reply" || step === "complete" ? (
-                        <div className="text-right text-[11px] uppercase tracking-[0.2em] text-sky-200/45">
-                          Delivered
-                        </div>
-                      ) : null}
-                      {step === "reply" || step === "complete" ? (
-                        <Bubble
-                          align="left"
-                          label={scenario.recipient}
-                          text={scenario.confirmationText ?? "Delivered."}
-                          tone="secondary"
-                        />
-                      ) : null}
+          {/* message body */}
+          <div className="rounded-3xl border border-white/6 bg-[#081122]/72 p-6">
+            <div className="text-[11px] uppercase tracking-[0.28em] text-white/40 mb-3">Message</div>
+            <div className="min-h-[80px] rounded-2xl border border-white/6 bg-black/20 px-5 py-4 text-[15px] leading-7 text-white/80">
+              {messageBody || <span className="text-white/25">Waiting for the first characters.</span>}
+              {step === "composing" && <span className="ml-1 inline-block animate-pulse text-white/60">|</span>}
+            </div>
+          </div>
+
+          {/* reply */}
+          {(step === "reply" || step === "complete") && scenario.confirmationText && (
+            <div className="rounded-3xl border border-white/6 bg-[#081122]/72 p-6">
+              <div className="text-[11px] uppercase tracking-[0.28em] text-white/40 mb-3">{scenario.recipient}</div>
+              <p className="text-[15px] leading-7 text-white/80">{scenario.confirmationText}</p>
+            </div>
+          )}
+
+          {/* contact list (selecting phase) */}
+          {step === "selecting_contact" && contacts.length > 0 && (
+            <div className="rounded-3xl border border-white/6 bg-[#081122]/72 p-6">
+              <div className="text-[11px] uppercase tracking-[0.28em] text-white/40 mb-3">Contacts</div>
+              <div className="space-y-2">
+                {contacts.slice(0, 5).map((contact, idx) => {
+                  const active = idx === (activeContactIndex ?? 0);
+                  return (
+                    <div key={`${contact}-${idx}`}
+                      className={`rounded-2xl border px-4 py-3 transition-all ${
+                        active
+                          ? "border-violet-300/24 bg-violet-300/10 text-white"
+                          : "border-white/6 bg-white/4 text-white/65"
+                      }`}>
+                      <div className="text-sm font-medium">{contact}</div>
+                      <div className="mt-0.5 text-[10px] uppercase tracking-[0.18em] text-white/35">
+                        {active ? "Opening conversation" : "Recent thread"}
+                      </div>
                     </div>
-                  )}
-                </div>
-                <div className="mt-4 rounded-[24px] border border-sky-300/14 bg-slate-950/75 p-3">
-                  <PhoneKeyboard activeKey={activeKey} />
-                </div>
-                <div className="rounded-[24px] border border-sky-300/14 bg-slate-950/70 px-4 py-3 text-sm text-sky-100/78">
-                  {scenario.statusLine}
-                </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* status line */}
+          <div className="rounded-2xl border border-white/6 bg-white/4 px-5 py-3 text-sm text-white/55">
+            {scenario.statusLine}
+          </div>
+        </div>
+
+        {/* right — phone mockup */}
+        <div className="flex items-center justify-center border-l border-white/6 bg-[#081122]/50 p-8">
+          <div className="relative h-[68vh] max-h-[660px] w-[320px] rounded-[44px] border border-white/12 bg-[#020617] p-3 shadow-[0_40px_120px_rgba(0,0,0,0.8)]">
+            <div className="absolute left-1/2 top-3 h-1.5 w-24 -translate-x-1/2 rounded-full bg-white/10" />
+            <div className="flex h-full flex-col overflow-hidden rounded-[34px] border border-white/6 bg-[linear-gradient(180deg,#0d1225_0%,#020617_100%)] px-5 py-7">
+              <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.24em] text-white/40">
+                <span>Messages</span>
+                <Smartphone className="h-3.5 w-3.5" />
+              </div>
+
+              <div className="mt-5 text-center">
+                <div className="text-[11px] uppercase tracking-[0.26em] text-white/35">{statusLabel}</div>
+                <div className="mt-2 text-2xl font-semibold text-white">{scenario.recipient}</div>
+              </div>
+
+              <div className="mt-6 flex-1 space-y-3">
+                {step === "selecting_contact" ? (
+                  <ContactList contacts={contacts} activeContactIndex={activeContactIndex} />
+                ) : (
+                  <>
+                    <div className="flex justify-end">
+                      <div className="max-w-[85%] rounded-2xl border border-violet-300/14 bg-violet-300/8 px-4 py-3">
+                        <div className="text-[10px] uppercase tracking-[0.2em] text-white/35 mb-1">Agent</div>
+                        <div className="text-sm leading-6 text-white/85">
+                          {messageBody || "Starting draft."}
+                        </div>
+                      </div>
+                    </div>
+                    {isSent && (
+                      <div className="flex justify-end">
+                        <div className="flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-violet-300/50">
+                          <CheckCheck className="h-3 w-3" /> Delivered
+                        </div>
+                      </div>
+                    )}
+                    {(step === "reply" || step === "complete") && scenario.confirmationText && (
+                      <div className="flex justify-start">
+                        <div className="max-w-[85%] rounded-2xl border border-white/6 bg-white/5 px-4 py-3">
+                          <div className="text-[10px] uppercase tracking-[0.2em] text-white/35 mb-1">{scenario.recipient}</div>
+                          <div className="text-sm leading-6 text-white/75">{scenario.confirmationText}</div>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {/* keyboard */}
+              <div className="mt-3 rounded-2xl border border-white/6 bg-black/25 p-2.5">
+                <PhoneKeyboard activeKey={activeKey} />
+              </div>
+
+              <div className="mt-2 rounded-2xl border border-white/6 bg-black/30 px-4 py-2.5 text-[11px] text-white/45">
+                {scenario.statusLine}
               </div>
             </div>
           </div>
@@ -139,73 +194,51 @@ export function SmsBoothImmersiveScreen({
   );
 }
 
-function ContactList({
-  contacts,
-  activeContactIndex,
-}: {
-  contacts: string[];
-  activeContactIndex: number | null;
-}) {
+function ContactList({ contacts, activeContactIndex }: { contacts: string[]; activeContactIndex: number | null }) {
   const selectedIndex = activeContactIndex ?? 0;
-  const windowStart = Math.max(
-    0,
-    Math.min(selectedIndex - 2, Math.max(contacts.length - 5, 0)),
-  );
-  const visibleContacts = contacts.slice(windowStart, windowStart + 5);
+  const windowStart = Math.max(0, Math.min(selectedIndex - 2, Math.max(contacts.length - 5, 0)));
+  const visible = contacts.slice(windowStart, windowStart + 5);
 
   return (
-    <div className="relative h-full overflow-hidden rounded-[24px] border border-sky-300/14 bg-slate-950/55 px-3 py-3">
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-[linear-gradient(180deg,rgba(2,6,23,0.94),rgba(2,6,23,0))]" />
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-[linear-gradient(0deg,rgba(2,6,23,0.94),rgba(2,6,23,0))]" />
-      <div className="space-y-2 pt-3">
-        {visibleContacts.map((contact, index) => {
-          const absoluteIndex = windowStart + index;
-          const active = absoluteIndex === selectedIndex;
-          return (
-            <div
-              key={`${contact}-${absoluteIndex}`}
-              className={`rounded-[22px] border px-4 py-3 transition-all duration-150 ${
-                active
-                  ? "scale-[0.98] border-sky-200/70 bg-sky-300/20 text-sky-50 shadow-[0_0_20px_rgba(56,189,248,0.2)]"
-                  : "border-slate-700/80 bg-slate-900/80 text-slate-200"
-              }`}
-            >
-              <div className="text-sm font-medium">{contact}</div>
-              <div className="mt-1 text-[11px] uppercase tracking-[0.18em] opacity-60">
-                {active ? "Opening conversation" : "Recent thread"}
-              </div>
+    <div className="space-y-2">
+      {visible.map((contact, index) => {
+        const absoluteIndex = windowStart + index;
+        const active = absoluteIndex === selectedIndex;
+        return (
+          <div key={`${contact}-${absoluteIndex}`}
+            className={`rounded-2xl border px-4 py-3 transition-all duration-150 ${
+              active
+                ? "border-violet-300/28 bg-violet-300/12 text-white shadow-[0_0_16px_rgba(167,139,250,0.15)]"
+                : "border-white/6 bg-white/4 text-white/60"
+            }`}>
+            <div className="text-sm font-medium">{contact}</div>
+            <div className="mt-0.5 text-[10px] uppercase tracking-[0.18em] text-white/30">
+              {active ? "Opening conversation" : "Recent thread"}
             </div>
-          );
-        })}
-      </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 const KEYBOARD_ROWS = [
-  ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
-  ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
-  ["z", "x", "c", "v", "b", "n", "m", ",", ".", "?"],
+  ["q","w","e","r","t","y","u","i","o","p"],
+  ["a","s","d","f","g","h","j","k","l"],
+  ["z","x","c","v","b","n","m",",",".","?"],
 ] as const;
 
 function PhoneKeyboard({ activeKey }: { activeKey: string | null }) {
   return (
-    <div className="space-y-2">
+    <div className="space-y-1.5">
       {KEYBOARD_ROWS.map((row, rowIndex) => (
-        <div
-          key={row.join("")}
-          className={`flex gap-2 ${rowIndex === 1 ? "px-3" : rowIndex === 2 ? "px-6" : ""}`}
-        >
+        <div key={row.join("")} className={`flex gap-1 ${rowIndex === 1 ? "px-3" : rowIndex === 2 ? "px-5" : ""}`}>
           {row.map((keyValue) => (
-            <KeyboardKey
-              key={keyValue}
-              label={keyValue}
-              active={activeKey === keyValue}
-            />
+            <KeyboardKey key={keyValue} label={keyValue} active={activeKey === keyValue} />
           ))}
         </div>
       ))}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1">
         <KeyboardKey label="123" active={false} className="w-[18%]" />
         <KeyboardKey label="space" active={activeKey === "space"} className="flex-1" />
         <KeyboardKey label="return" active={activeKey === "return"} className="w-[22%]" />
@@ -214,51 +247,14 @@ function PhoneKeyboard({ activeKey }: { activeKey: string | null }) {
   );
 }
 
-function KeyboardKey({
-  label,
-  active,
-  className = "",
-}: {
-  label: string;
-  active: boolean;
-  className?: string;
-}) {
+function KeyboardKey({ label, active, className = "" }: { label: string; active: boolean; className?: string }) {
   return (
-    <div
-      className={`flex h-9 min-w-0 flex-1 items-center justify-center rounded-2xl border text-[12px] font-medium uppercase tracking-[0.12em] transition-all duration-100 ${
-        active
-          ? "scale-[0.96] border-sky-200/70 bg-sky-300/30 text-sky-50 shadow-[0_0_20px_rgba(56,189,248,0.25)]"
-          : "border-slate-700/90 bg-slate-800/90 text-slate-200"
-      } ${className}`}
-    >
+    <div className={`flex h-8 min-w-0 flex-1 items-center justify-center rounded-xl border text-[11px] font-medium uppercase tracking-[0.1em] transition-all duration-100 ${
+      active
+        ? "border-violet-300/35 bg-violet-300/18 text-white shadow-[0_0_12px_rgba(167,139,250,0.2)]"
+        : "border-white/8 bg-white/5 text-white/55"
+    } ${className}`}>
       {label}
-    </div>
-  );
-}
-
-function Bubble({
-  align,
-  label,
-  text,
-  tone,
-}: {
-  align: "left" | "right";
-  label: string;
-  text: string;
-  tone: "primary" | "secondary";
-}) {
-  return (
-    <div className={align === "right" ? "ml-10" : "mr-10"}>
-      <div
-        className={`rounded-[24px] border px-4 py-4 ${
-          tone === "primary"
-            ? "border-sky-300/18 bg-sky-400/10 text-sky-50"
-            : "border-slate-700 bg-slate-900/90 text-slate-100"
-        }`}
-      >
-        <div className="text-[10px] uppercase tracking-[0.22em] opacity-60">{label}</div>
-        <div className="mt-2 text-sm leading-6">{text}</div>
-      </div>
     </div>
   );
 }

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -40,6 +40,7 @@ import { buildMockPhoneCallScenario } from "@/lib/office/call/mock";
 import type { MockPhoneCallScenario } from "@/lib/office/call/types";
 import { buildMockTextMessageScenario } from "@/lib/office/text/mock";
 import type { MockTextMessageScenario } from "@/lib/office/text/types";
+import { BoothInputDialog } from "@/features/office/dialogs/BoothInputDialog";
 import type { OfficeDeskMonitor } from "@/lib/office/deskMonitor";
 import type { OfficeAnimationState } from "@/lib/office/eventTriggers";
 import type { StandupMeeting } from "@/lib/office/standup/types";
@@ -459,6 +460,7 @@ function useAgentTick(
   lastSeenByAgentId: Record<string, number> = {},
   deskHoldByAgentId: Record<string, boolean> = {},
   gymHoldByAgentId: Record<string, boolean> = {},
+  pingPongHoldByAgentId: Record<string, boolean> = {},
   smsBoothHoldByAgentId: Record<string, boolean> = {},
   phoneBoothHoldByAgentId: Record<string, boolean> = {},
   qaHoldByAgentId: Record<string, boolean> = {},
@@ -1918,6 +1920,7 @@ export function RetroOffice3D({
     | "githubHoldByAgentId"
     | "gymHoldByAgentId"
     | "phoneBoothHoldByAgentId"
+    | "pingPongHoldByAgentId"
     | "smsBoothHoldByAgentId"
     | "qaHoldByAgentId"
   > | null;
@@ -1982,6 +1985,8 @@ export function RetroOffice3D({
     animationState?.deskHoldByAgentId ?? deskHoldByAgentId;
   const resolvedGymHoldByAgentId =
     animationState?.gymHoldByAgentId ?? gymHoldByAgentId;
+  const resolvedPingPongHoldByAgentId =
+    animationState?.pingPongHoldByAgentId ?? {};
   const resolvedSmsBoothHoldByAgentId =
     animationState?.smsBoothHoldByAgentId ?? {};
   const resolvedPhoneBoothHoldByAgentId =
@@ -2119,6 +2124,7 @@ export function RetroOffice3D({
   const [activeTextContactIndex, setActiveTextContactIndex] = useState<number | null>(
     null,
   );
+  const [boothInputKind, setBoothInputKind] = useState<"phone" | "sms" | null>(null);
   const [manualPhoneBoothOpen, setManualPhoneBoothOpen] = useState(false);
   const [manualPhoneCallScenario, setManualPhoneCallScenario] =
     useState<MockPhoneCallScenario | null>(null);
@@ -2275,6 +2281,7 @@ export function RetroOffice3D({
     lastSeenByAgentId,
     resolvedDeskHoldByAgentId,
     resolvedGymHoldByAgentId,
+    resolvedPingPongHoldByAgentId,
     resolvedSmsBoothHoldByAgentId,
     resolvedPhoneBoothHoldByAgentId,
     resolvedQaHoldByAgentId,
@@ -3050,6 +3057,78 @@ export function RetroOffice3D({
     standupMeeting,
   ]);
 
+  // Ping-pong directive: when an agent receives a "play ping-pong" command,
+  // find a table + idle partner and start the session automatically.
+  useEffect(() => {
+    const requestingIds = Object.keys(resolvedPingPongHoldByAgentId).filter(
+      (id) => resolvedPingPongHoldByAgentId[id],
+    );
+    if (requestingIds.length === 0) return;
+
+    const furniture = furnitureRef.current ?? [];
+    const table = furniture.find((item) => item.type === "pingpong");
+    if (!table) return;
+
+    const allAgents = renderAgentsRef.current;
+    const now = Date.now();
+
+    for (const requestingId of requestingIds) {
+      const requestingAgent = allAgents.find((a) => a.id === requestingId);
+      // Skip if already playing
+      if (!requestingAgent || requestingAgent.pingPongUntil !== undefined) continue;
+
+      // Find an idle partner (not the requesting agent, not already playing)
+      const partner = allAgents.find(
+        (a) =>
+          a.id !== requestingId &&
+          a.pingPongUntil === undefined &&
+          a.status === "idle" &&
+          a.state !== "walking",
+      );
+      if (!partner) continue;
+
+      const targets = resolvePingPongTargets(table);
+      const players = [requestingAgent, partner];
+      players.forEach((agent, index) => {
+        const target = targets[index];
+        if (!target) return;
+        Object.assign(agent, {
+          targetX: target.x,
+          targetY: target.y,
+          path: planPath(agent.x, agent.y, target.x, target.y),
+          facing: target.facing,
+          state: "walking",
+          walkSpeed: Math.max(agent.walkSpeed, PING_PONG_APPROACH_SPEED),
+          pingPongUntil: now + PING_PONG_SESSION_MS,
+          pingPongTargetX: target.x,
+          pingPongTargetY: target.y,
+          pingPongFacing: target.facing,
+          pingPongPartnerId: players[1 - index]?.id,
+          pingPongTableUid: table._uid,
+          pingPongSide: index as 0 | 1,
+          pingPongPreviousWalkSpeed: agent.pingPongPreviousWalkSpeed ?? agent.walkSpeed,
+        } satisfies Partial<RenderAgent>);
+      });
+
+      setMoodByAgentId((prev) => {
+        const next = { ...prev };
+        for (const agent of players) {
+          next[agent.id] = { emoji: "🏓", ts: now };
+        }
+        return next;
+      });
+      window.setTimeout(() => {
+        setMoodByAgentId((prev) => {
+          const next = { ...prev };
+          for (const agent of players) {
+            if (next[agent.id]?.emoji === "🏓") delete next[agent.id];
+          }
+          return next;
+        });
+      }, 2500);
+    }
+  }, [resolvedPingPongHoldByAgentId, furnitureRef]);
+
   useEffect(() => {
     const resetTimer = window.setTimeout(() => {
       setSmsBoothImmersiveReady(false);
@@ -3811,15 +3890,7 @@ export function RetroOffice3D({
         setActiveGithubTerminalUid(null);
         setActiveQaTerminalUid(null);
         onMonitorSelect?.(null);
-        setSmsBoothCommandArrived(true);
-        setSmsBoothDoorOpen(true);
-        setManualTextMessageScenario(
-          buildMockTextMessageScenario({
-            recipient: "Joseph",
-            message: "I will be late for the soccer game.",
-          }),
-        );
-        setManualSmsBoothOpen(true);
+        setBoothInputKind("sms");
         return;
       }
       if (item.type === "phone_booth") {
@@ -3828,19 +3899,7 @@ export function RetroOffice3D({
         setActiveGithubTerminalUid(null);
         setActiveQaTerminalUid(null);
         onMonitorSelect?.(null);
-        setPhoneBoothCommandArrived(true);
-        setPhoneBoothDoorOpen(true);
-        setManualPhoneCallScenario(
-          buildMockPhoneCallScenario({
-            callee: "my contact",
-            message: "This is a demo call from the OpenClaw phone booth.",
-            voiceAvailable:
-              voiceRepliesLoaded &&
-              Boolean(voiceRepliesVoiceId) &&
-              voiceRepliesEnabled,
-          }),
-        );
-        setManualPhoneBoothOpen(true);
+        setBoothInputKind("phone");
         return;
       }
       if (item.type === "server_terminal") {
@@ -5677,6 +5736,32 @@ export function RetroOffice3D({
             </button>
           </div>
         </div>
+      ) : null}
+
+      {boothInputKind === "sms" ? (
+        <BoothInputDialog
+          kind="sms"
+          onClose={() => setBoothInputKind(null)}
+          onSuccess={(scenario) => {
+            setBoothInputKind(null);
+            setSmsBoothCommandArrived(true);
+            setSmsBoothDoorOpen(true);
+            setManualTextMessageScenario(scenario);
+            setManualSmsBoothOpen(true);
+          }}
+        />
+      ) : boothInputKind === "phone" ? (
+        <BoothInputDialog
+          kind="phone"
+          onClose={() => setBoothInputKind(null)}
+          onSuccess={(scenario) => {
+            setBoothInputKind(null);
+            setPhoneBoothCommandArrived(true);
+            setPhoneBoothDoorOpen(true);
+            setManualPhoneCallScenario(scenario);
+            setManualPhoneBoothOpen(true);
+          }}
+        />
       ) : null}
 
       {smsBoothImmersive && effectiveTextMessageScenario && effectiveSmsBoothAgentId ? (

--- a/src/lib/office/boothContacts.ts
+++ b/src/lib/office/boothContacts.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { randomUUID } from "@/lib/uuid";
+
+export type BoothContact = {
+  id: string;
+  name: string;
+  phone: string;
+};
+
+export type BoothHistoryEntry = {
+  id: string;
+  kind: "call" | "sms";
+  name: string | null;
+  phone: string;
+  message: string | null;
+  timestamp: number;
+};
+
+const CONTACTS_KEY = "claw3d-booth-contacts";
+const HISTORY_KEY = "claw3d-booth-history";
+const HISTORY_LIMIT = 50;
+
+const safeParse = <T>(raw: string | null, fallback: T): T => {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+export const loadContacts = (): BoothContact[] => {
+  if (typeof window === "undefined") return [];
+  return safeParse<BoothContact[]>(localStorage.getItem(CONTACTS_KEY), []);
+};
+
+export const saveContacts = (contacts: BoothContact[]): void => {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(CONTACTS_KEY, JSON.stringify(contacts));
+};
+
+export const addContact = (name: string, phone: string): BoothContact => {
+  const contact: BoothContact = { id: randomUUID(), name: name.trim(), phone: phone.trim() };
+  const contacts = loadContacts();
+  saveContacts([contact, ...contacts]);
+  return contact;
+};
+
+export const deleteContact = (id: string): void => {
+  saveContacts(loadContacts().filter((c) => c.id !== id));
+};
+
+export const findContactByPhone = (phone: string): BoothContact | null => {
+  const normalized = phone.replace(/\s/g, "");
+  return loadContacts().find((c) => c.phone.replace(/\s/g, "") === normalized) ?? null;
+};
+
+export const loadHistory = (): BoothHistoryEntry[] => {
+  if (typeof window === "undefined") return [];
+  return safeParse<BoothHistoryEntry[]>(localStorage.getItem(HISTORY_KEY), []);
+};
+
+export const addHistoryEntry = (
+  entry: Omit<BoothHistoryEntry, "id" | "timestamp">,
+): BoothHistoryEntry => {
+  const full: BoothHistoryEntry = { ...entry, id: randomUUID(), timestamp: Date.now() };
+  const history = loadHistory();
+  const next = [full, ...history].slice(0, HISTORY_LIMIT);
+  if (typeof window !== "undefined") {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+  }
+  return full;
+};
+
+export const formatRelativeTime = (timestamp: number): string => {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+};

--- a/src/lib/office/deskDirectives.ts
+++ b/src/lib/office/deskDirectives.ts
@@ -36,6 +36,7 @@ export type OfficeIntentSnapshot = {
   standup: OfficeStandupDirective | null;
   call: OfficeCallDirective | null;
   text: OfficeTextDirective | null;
+  pingpong: boolean;
 };
 type OfficeInteractionDirective =
   | { target: "desk"; action: "hold" | "release" }
@@ -244,6 +245,22 @@ const resolveOfficeQaDirectiveFromNormalized = (
     : null;
 };
 
+const resolveOfficePingPongDirectiveFromNormalized = (normalized: string): boolean => {
+  const pingPongPatterns = [
+    /\bping.?pong\b/,
+    /\btable\s+tennis\b/,
+    /\bjoue[rz]?\s+au\s+ping.?pong\b/,
+    /\bplay\s+(?:some\s+)?ping.?pong\b/,
+    /\bplay\s+(?:some\s+)?table\s+tennis\b/,
+    /\bgo\s+play\s+ping.?pong\b/,
+    /\bgo\s+play\s+table\s+tennis\b/,
+    /\blet['']?s\s+play\s+ping.?pong\b/,
+    /\bpartie\s+de\s+ping.?pong\b/,
+    /\bfaire?\s+(?:une\s+partie\s+de\s+)?ping.?pong\b/,
+  ];
+  return pingPongPatterns.some((pattern) => pattern.test(normalized));
+};
+
 const resolveOfficeStandupDirectiveFromNormalized = (
   normalized: string,
 ): OfficeStandupDirective | null => {
@@ -422,6 +439,7 @@ export const resolveOfficeIntentSnapshot = (
       standup: null,
       call: null,
       text: null,
+      pingpong: false,
     };
   }
 
@@ -439,6 +457,7 @@ export const resolveOfficeIntentSnapshot = (
   const standupDirective = resolveOfficeStandupDirectiveFromNormalized(normalized);
   const callDirective = resolveOfficeCallDirectiveFromNormalized(normalized);
   const textDirective = resolveOfficeTextDirectiveFromNormalized(normalized);
+  const pingpongDirective = resolveOfficePingPongDirectiveFromNormalized(normalized);
   const gymDirective = gymManualDirective
     ? {
         directive: gymManualDirective,
@@ -471,6 +490,7 @@ export const resolveOfficeIntentSnapshot = (
     standup: standupDirective,
     call: callDirective,
     text: textDirective,
+    pingpong: pingpongDirective,
   });
 };
 
@@ -503,6 +523,10 @@ export const resolveOfficeQaDirective = (
 export const resolveOfficeStandupDirective = (
   value: string | null | undefined,
 ): OfficeStandupDirective | null => resolveOfficeIntentSnapshot(value).standup;
+
+export const resolveOfficePingPongDirective = (
+  value: string | null | undefined,
+): boolean => resolveOfficeIntentSnapshot(value).pingpong;
 
 export const resolveOfficeCallDirective = (
   value: string | null | undefined,

--- a/src/lib/office/eventTriggers.ts
+++ b/src/lib/office/eventTriggers.ts
@@ -36,6 +36,7 @@ import {
   resolveOfficeDeskDirective,
   resolveOfficeGithubDirective,
   resolveOfficeGymDirective,
+  resolveOfficePingPongDirective,
   resolveOfficeQaDirective,
   resolveOfficeStandupDirective,
   resolveOfficeTextDirective,
@@ -101,6 +102,8 @@ export type OfficeAnimationTriggerState = {
   pendingStandupRequest: OfficeStandupTriggerRequest | null;
   phoneCallByAgentId: PhoneCallByAgentId;
   phoneCallDirectiveKeyByAgentId: StringByAgentId;
+  pingPongDirectiveKeyByAgentId: StringByAgentId;
+  pingPongHoldByAgentId: BooleanByAgentId;
   qaDirectiveKeyByAgentId: StringByAgentId;
   qaHoldByAgentId: BooleanByAgentId;
   sessionEpochSnapshot: SessionEpochSnapshot;
@@ -127,6 +130,7 @@ export type OfficeAnimationState = {
   pendingStandupRequest: OfficeStandupTriggerRequest | null;
   phoneBoothHoldByAgentId: BooleanByAgentId;
   phoneCallByAgentId: PhoneCallByAgentId;
+  pingPongHoldByAgentId: BooleanByAgentId;
   qaHoldByAgentId: BooleanByAgentId;
   smsBoothHoldByAgentId: BooleanByAgentId;
   skillGymHoldByAgentId: BooleanByAgentId;
@@ -874,6 +878,8 @@ export const createOfficeAnimationTriggerState = (): OfficeAnimationTriggerState
   pendingStandupRequest: null,
   phoneCallByAgentId: emptyObject(),
   phoneCallDirectiveKeyByAgentId: emptyObject(),
+  pingPongDirectiveKeyByAgentId: emptyObject(),
+  pingPongHoldByAgentId: emptyObject(),
   qaDirectiveKeyByAgentId: emptyObject(),
   qaHoldByAgentId: emptyObject(),
   sessionEpochSnapshot: {},
@@ -1053,6 +1059,8 @@ export const reconcileOfficeAnimationTriggerState = (params: {
   const githubDirectiveKeyByAgentId: StringByAgentId = {};
   const phoneCallByAgentId: PhoneCallByAgentId = {};
   const phoneCallDirectiveKeyByAgentId: StringByAgentId = {};
+  const pingPongHoldByAgentId: BooleanByAgentId = {};
+  const pingPongDirectiveKeyByAgentId: StringByAgentId = {};
   const qaHoldByAgentId: BooleanByAgentId = {};
   const qaDirectiveKeyByAgentId: StringByAgentId = {};
   const skillGymHoldByAgentId: BooleanByAgentId = {};
@@ -1124,6 +1132,18 @@ export const reconcileOfficeAnimationTriggerState = (params: {
       }
     } else if (next.qaHoldByAgentId[agentId]) {
       qaHoldByAgentId[agentId] = true;
+    }
+
+    const pingPongDirective = resolveLatestDirective({
+      lastUserMessage: agent.lastUserMessage,
+      transcriptEntries: agent.transcriptEntries,
+      resolver: (value) => resolveOfficePingPongDirective(value) ? "pingpong" as const : null,
+    });
+    if (pingPongDirective) {
+      pingPongDirectiveKeyByAgentId[agentId] = pingPongDirective.key;
+      pingPongHoldByAgentId[agentId] = true;
+    } else if (next.pingPongHoldByAgentId[agentId]) {
+      pingPongHoldByAgentId[agentId] = true;
     }
 
     const skillGymDirective = resolveLatestDirective({
@@ -1215,6 +1235,8 @@ export const reconcileOfficeAnimationTriggerState = (params: {
     pendingStandupRequest,
     phoneCallByAgentId,
     phoneCallDirectiveKeyByAgentId,
+    pingPongDirectiveKeyByAgentId,
+    pingPongHoldByAgentId,
     qaDirectiveKeyByAgentId,
     qaHoldByAgentId,
     sessionEpochSnapshot: buildSessionEpochSnapshot(params.agents),
@@ -1360,6 +1382,7 @@ export const buildOfficeAnimationState = (params: {
     pendingStandupRequest: params.state.pendingStandupRequest,
     phoneBoothHoldByAgentId,
     phoneCallByAgentId,
+    pingPongHoldByAgentId: params.state.pingPongHoldByAgentId,
     qaHoldByAgentId: params.state.qaHoldByAgentId,
     smsBoothHoldByAgentId,
     skillGymHoldByAgentId: params.state.skillGymHoldByAgentId,

--- a/src/lib/office/messagingProviders.ts
+++ b/src/lib/office/messagingProviders.ts
@@ -1,0 +1,176 @@
+/**
+ * Messaging provider abstraction — Phone Booth & SMS Booth.
+ *
+ * Claw3D supports pluggable messaging backends so users can connect whichever
+ * service their OpenClaw workspace uses.
+ *
+ * ┌─────────────────┬────────────┬──────────────────────────────────────────┐
+ * │ Provider        │ MSG  Call  │ Status                                   │
+ * ├─────────────────┼────────────┼──────────────────────────────────────────┤
+ * │ twilio          │  ✅   ✅   │ Implemented — Twilio REST API            │
+ * │ whatsapp        │  ✅   ❌   │ Implemented — Twilio WhatsApp API        │
+ * │ telegram        │  ✅   ❌   │ Implemented — Telegram Bot API           │
+ * │ imessage        │  ✅   ❌   │ Implemented — BlueBubbles server (Mac)   │
+ * └─────────────────┴────────────┴──────────────────────────────────────────┘
+ *
+ * Active provider selection
+ * ─────────────────────────
+ * Set `MESSAGING_PROVIDER` in your `.env.local` (defaults to "twilio").
+ * Individual API calls may also pass an explicit `provider` field to override.
+ *
+ * Adding a new provider
+ * ─────────────────────
+ * 1. Add its key to `MessagingProvider` below.
+ * 2. Create `src/lib/office/providers/<name>.ts` that exports the
+ *    implementation matching the shapes used in this file.
+ * 3. Wire it into `dispatchSendSms` / `dispatchMakeCall`.
+ * 4. Add `getSmsProviderStatus` / `getCallProviderStatus` cases.
+ * 5. Document required env vars in `.env.example`.
+ */
+
+// ── Provider types ────────────────────────────────────────────────────────────
+
+/** All known messaging backends. */
+export type MessagingProvider = "twilio" | "whatsapp" | "telegram" | "imessage";
+
+/** Providers that support sending SMS / chat messages. */
+export type SmsCapableProvider = Extract<MessagingProvider, "twilio" | "whatsapp" | "telegram" | "imessage">;
+
+/** Providers that support voice calls. */
+export type CallCapableProvider = Extract<MessagingProvider, "twilio">;
+
+// ── Active provider resolution ────────────────────────────────────────────────
+
+export const getDefaultSmsProvider = (): SmsCapableProvider => {
+  const raw = (process.env.MESSAGING_PROVIDER ?? "twilio").trim().toLowerCase();
+  if (raw === "whatsapp") return "whatsapp";
+  if (raw === "telegram") return "telegram";
+  if (raw === "imessage") return "imessage";
+  return "twilio";
+};
+
+export const getDefaultCallProvider = (): CallCapableProvider => {
+  // Only Twilio supports outbound calls via a public API.
+  // WhatsApp and Telegram do not expose programmatic outbound calling.
+  return "twilio";
+};
+
+// ── Shared param / result types ───────────────────────────────────────────────
+
+export type SendSmsParams = {
+  to: string;
+  body: string;
+  /** Override the active provider for this request. */
+  provider?: SmsCapableProvider;
+};
+
+export type MakeCallParams = {
+  to: string;
+  message: string;
+  /** Override the active provider for this request. */
+  provider?: CallCapableProvider;
+};
+
+export type MessagingResult = { sid: string };
+
+// ── SMS / message dispatch ────────────────────────────────────────────────────
+
+export async function dispatchSendSms(params: SendSmsParams): Promise<MessagingResult> {
+  const provider = params.provider ?? getDefaultSmsProvider();
+
+  switch (provider) {
+    case "twilio": {
+      const { sendSms } = await import("./twilio");
+      return sendSms({ to: params.to, body: params.body });
+    }
+
+    case "whatsapp": {
+      /**
+       * Sends a WhatsApp message via the Twilio WhatsApp API.
+       * Requires: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_WHATSAPP_NUMBER
+       * Setup:    console.twilio.com/develop/sms/whatsapp/senders
+       */
+      const { sendWhatsAppMessage } = await import("./providers/whatsapp");
+      return sendWhatsAppMessage({ to: params.to, body: params.body });
+    }
+
+    case "telegram": {
+      /**
+       * Sends a message via the Telegram Bot API.
+       * Requires: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
+       * Setup:    message @BotFather on Telegram to create a bot.
+       */
+      const { sendTelegramMessage } = await import("./providers/telegram");
+      return sendTelegramMessage({ text: params.body });
+    }
+
+    case "imessage": {
+      /**
+       * Sends an iMessage via a BlueBubbles server running on a Mac.
+       * Requires: IMESSAGE_BLUEBUBBLES_URL, IMESSAGE_BLUEBUBBLES_PASSWORD
+       * Setup:    https://bluebubbles.app — install on a Mac signed into iMessage.
+       */
+      const { sendIMessage } = await import("./providers/imessage");
+      return sendIMessage({ to: params.to, body: params.body });
+    }
+  }
+}
+
+// ── Call dispatch ─────────────────────────────────────────────────────────────
+
+export async function dispatchMakeCall(params: MakeCallParams): Promise<MessagingResult> {
+  const provider = params.provider ?? getDefaultCallProvider();
+
+  switch (provider) {
+    case "twilio": {
+      const { makeCall } = await import("./twilio");
+      return makeCall({ to: params.to, message: params.message });
+    }
+  }
+}
+
+// ── Configuration helpers ─────────────────────────────────────────────────────
+
+export type ProviderConfigStatus = "configured" | "not_configured" | "not_supported";
+
+export function getSmsProviderStatus(provider: SmsCapableProvider): ProviderConfigStatus {
+  switch (provider) {
+    case "twilio": {
+      const ok =
+        Boolean(process.env.TWILIO_ACCOUNT_SID?.trim()) &&
+        Boolean(process.env.TWILIO_AUTH_TOKEN?.trim()) &&
+        Boolean(process.env.TWILIO_PHONE_NUMBER?.trim());
+      return ok ? "configured" : "not_configured";
+    }
+    case "whatsapp": {
+      const ok =
+        Boolean(process.env.TWILIO_ACCOUNT_SID?.trim()) &&
+        Boolean(process.env.TWILIO_AUTH_TOKEN?.trim()) &&
+        Boolean(process.env.TWILIO_WHATSAPP_NUMBER?.trim());
+      return ok ? "configured" : "not_configured";
+    }
+    case "telegram": {
+      const ok =
+        Boolean(process.env.TELEGRAM_BOT_TOKEN?.trim()) &&
+        Boolean(process.env.TELEGRAM_CHAT_ID?.trim());
+      return ok ? "configured" : "not_configured";
+    }
+    case "imessage": {
+      const ok =
+        Boolean(process.env.IMESSAGE_BLUEBUBBLES_URL?.trim()) &&
+        Boolean(process.env.IMESSAGE_BLUEBUBBLES_PASSWORD?.trim());
+      return ok ? "configured" : "not_configured";
+    }
+  }
+}
+
+export function getCallProviderStatus(provider: CallCapableProvider): ProviderConfigStatus {
+  switch (provider) {
+    case "twilio":
+      return getSmsProviderStatus("twilio");
+  }
+}
+
+/** Returns true when at least one messaging provider is ready. */
+export const isAnyMessagingConfigured = (): boolean =>
+  getSmsProviderStatus(getDefaultSmsProvider()) === "configured";

--- a/src/lib/office/providers/imessage.ts
+++ b/src/lib/office/providers/imessage.ts
@@ -1,0 +1,78 @@
+/**
+ * iMessage provider — sends messages via the BlueBubbles server.
+ *
+ * Apple does not provide a public API for iMessage. This provider uses
+ * BlueBubbles (https://bluebubbles.app), an open-source Mac server that
+ * exposes a REST API to send and receive iMessages from any device.
+ *
+ * ── Setup ────────────────────────────────────────────────────────────────────
+ * 1. Install BlueBubbles on a Mac that stays on and signed into iMessage:
+ *    https://github.com/BlueBubblesApp/bluebubbles-server/releases
+ * 2. In BlueBubbles settings, note the server URL and set a password.
+ * 3. Make sure the Mac is reachable from your Claw3D server
+ *    (same network, or expose via ngrok / Cloudflare Tunnel).
+ * 4. Set env vars:
+ *
+ * Required env vars:
+ *   IMESSAGE_BLUEBUBBLES_URL       — BlueBubbles server base URL
+ *                                    example: http://192.168.1.50:1234
+ *                                    or: https://your-ngrok-url.ngrok.io
+ *   IMESSAGE_BLUEBUBBLES_PASSWORD  — the password set in BlueBubbles settings
+ *
+ * ── Recipient format ─────────────────────────────────────────────────────────
+ * The `to` field accepts a phone number (E.164: +1…, +33…) or an Apple ID
+ * email address. BlueBubbles resolves the correct chat GUID automatically.
+ *
+ * ── Limitations ──────────────────────────────────────────────────────────────
+ * - Requires a Mac running BlueBubbles to be online.
+ * - Outbound calls are not supported.
+ * - Group chats require passing the full chat GUID instead of a phone number.
+ *
+ * Docs: https://documenter.getpostman.com/view/765844/UV5RnfwM
+ */
+
+const BLUEBUBBLES_URL = process.env.IMESSAGE_BLUEBUBBLES_URL?.trim().replace(/\/$/, "") ?? "";
+const BLUEBUBBLES_PASSWORD = process.env.IMESSAGE_BLUEBUBBLES_PASSWORD?.trim() ?? "";
+
+export const isIMessageConfigured = (): boolean =>
+  Boolean(BLUEBUBBLES_URL && BLUEBUBBLES_PASSWORD);
+
+export const sendIMessage = async (params: {
+  to: string;
+  body: string;
+}): Promise<{ sid: string }> => {
+  if (!BLUEBUBBLES_URL) throw new Error("IMESSAGE_BLUEBUBBLES_URL is not set.");
+  if (!BLUEBUBBLES_PASSWORD) throw new Error("IMESSAGE_BLUEBUBBLES_PASSWORD is not set.");
+
+  // BlueBubbles chat GUID format for individual iMessage: "iMessage;-;+1234567890"
+  // If the caller already passed a full GUID, use it as-is.
+  const chatGuid = params.to.startsWith("iMessage;")
+    ? params.to
+    : `iMessage;-;${params.to}`;
+
+  const url = `${BLUEBUBBLES_URL}/api/v1/message/text?password=${encodeURIComponent(BLUEBUBBLES_PASSWORD)}`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chatGuid,
+      message: params.body,
+      method: "apple-script",
+      // tempGuid is optional — BlueBubbles uses it for dedup on its end
+      tempGuid: `claw3d-${Date.now()}`,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json().catch(() => null)) as
+      | { message?: string; error?: string }
+      | null;
+    throw new Error(
+      error?.message ?? error?.error ?? `BlueBubbles error ${response.status}`,
+    );
+  }
+
+  const result = (await response.json()) as { data?: { guid?: string } };
+  return { sid: result.data?.guid ?? "ok" };
+};

--- a/src/lib/office/providers/telegram.ts
+++ b/src/lib/office/providers/telegram.ts
@@ -1,0 +1,56 @@
+/**
+ * Telegram provider — sends messages via the Telegram Bot API.
+ *
+ * Required env vars:
+ *   TELEGRAM_BOT_TOKEN  — your bot token from @BotFather
+ *                         format: 123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ
+ *   TELEGRAM_CHAT_ID    — the chat_id to send messages to
+ *                         Can be a personal chat, group, or channel.
+ *                         To find your chat_id: message your bot and call
+ *                         https://api.telegram.org/bot<TOKEN>/getUpdates
+ *
+ * Important: the bot must have been started by the recipient first
+ * (i.e. they must have sent at least one message to the bot).
+ * For group chats, the bot must be a member of the group.
+ *
+ * Note: outbound calls are not supported via the Telegram Bot API.
+ *
+ * Docs: https://core.telegram.org/bots/api#sendmessage
+ */
+
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN?.trim() ?? "";
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID?.trim() ?? "";
+
+const telegramApiUrl = (method: string) =>
+  `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/${method}`;
+
+export const isTelegramConfigured = (): boolean =>
+  Boolean(TELEGRAM_BOT_TOKEN && TELEGRAM_CHAT_ID);
+
+export const sendTelegramMessage = async (params: {
+  /** Target chat. Defaults to TELEGRAM_CHAT_ID env var. */
+  chatId?: string;
+  text: string;
+}): Promise<{ sid: string }> => {
+  const chatId = params.chatId?.trim() || TELEGRAM_CHAT_ID;
+  if (!chatId) throw new Error("Telegram chat_id is required.");
+
+  const response = await fetch(telegramApiUrl("sendMessage"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text: params.text,
+      parse_mode: "HTML",
+    }),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as { description?: string };
+    throw new Error(error.description ?? `Telegram error ${response.status}`);
+  }
+
+  const result = (await response.json()) as { result?: { message_id?: number } };
+  // Telegram returns a message_id — we normalise it to a sid string for consistency
+  return { sid: String(result.result?.message_id ?? "ok") };
+};

--- a/src/lib/office/providers/whatsapp.ts
+++ b/src/lib/office/providers/whatsapp.ts
@@ -1,0 +1,61 @@
+/**
+ * WhatsApp provider — sends messages via the Twilio WhatsApp API.
+ *
+ * Required env vars:
+ *   TWILIO_ACCOUNT_SID      — same as the voice/SMS Twilio account
+ *   TWILIO_AUTH_TOKEN       — same as the voice/SMS Twilio account
+ *   TWILIO_WHATSAPP_NUMBER  — your WhatsApp-enabled Twilio number
+ *                             format: whatsapp:+14155238886
+ *                             (get one at console.twilio.com/develop/sms/whatsapp/senders)
+ *
+ * The recipient number must be in E.164 format (+1…, +33…, etc.).
+ * Twilio will prefix it with "whatsapp:" automatically.
+ *
+ * Note: outbound WhatsApp calls are not supported via this provider.
+ * WhatsApp calling requires the Meta Cloud API with calling permissions,
+ * which is not yet generally available.
+ *
+ * Docs: https://www.twilio.com/docs/whatsapp/api
+ */
+
+const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID?.trim() ?? "";
+const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN?.trim() ?? "";
+const TWILIO_WHATSAPP_NUMBER = process.env.TWILIO_WHATSAPP_NUMBER?.trim() ?? "";
+
+const twilioApiUrl = (path: string) =>
+  `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}${path}`;
+
+const authHeader = () =>
+  `Basic ${Buffer.from(`${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}`).toString("base64")}`;
+
+export const isWhatsAppTwilioConfigured = (): boolean =>
+  Boolean(TWILIO_ACCOUNT_SID && TWILIO_AUTH_TOKEN && TWILIO_WHATSAPP_NUMBER);
+
+export const sendWhatsAppMessage = async (params: {
+  to: string;
+  body: string;
+}): Promise<{ sid: string }> => {
+  const from = TWILIO_WHATSAPP_NUMBER.startsWith("whatsapp:")
+    ? TWILIO_WHATSAPP_NUMBER
+    : `whatsapp:${TWILIO_WHATSAPP_NUMBER}`;
+  const to = params.to.startsWith("whatsapp:") ? params.to : `whatsapp:${params.to}`;
+
+  const form = new URLSearchParams({ To: to, From: from, Body: params.body });
+
+  const response = await fetch(twilioApiUrl("/Messages.json"), {
+    method: "POST",
+    headers: {
+      Authorization: authHeader(),
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: form.toString(),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as { message?: string };
+    throw new Error(error.message ?? `WhatsApp (Twilio) error ${response.status}`);
+  }
+
+  const result = (await response.json()) as { sid: string };
+  return { sid: result.sid };
+};

--- a/src/lib/office/twilio.ts
+++ b/src/lib/office/twilio.ts
@@ -1,0 +1,80 @@
+const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID?.trim() ?? "";
+const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN?.trim() ?? "";
+const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER?.trim() ?? "";
+
+export const isTwilioConfigured = (): boolean =>
+  Boolean(TWILIO_ACCOUNT_SID && TWILIO_AUTH_TOKEN && TWILIO_PHONE_NUMBER);
+
+const twilioApiUrl = (path: string) =>
+  `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}${path}`;
+
+const twilioHeaders = (): Record<string, string> => ({
+  Authorization: `Basic ${Buffer.from(`${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}`).toString("base64")}`,
+  "Content-Type": "application/x-www-form-urlencoded",
+});
+
+// Normalise un numéro vers le format E.164 (+XXXXXXXXXXX).
+// Accepte : 0612345678, +33612345678, 06 12 34 56 78, (555) 123-4567, etc.
+export const normalizePhoneNumber = (value: string): string => {
+  const digits = value.replace(/[^\d+]/g, "");
+  // Déjà au format international
+  if (digits.startsWith("+")) return digits;
+  // Numéro français commençant par 0 → +33
+  if (digits.startsWith("0") && digits.length === 10) return `+33${digits.slice(1)}`;
+  // Numéro US à 10 chiffres
+  if (digits.length === 10) return `+1${digits}`;
+  // Numéro US à 11 chiffres commençant par 1
+  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
+  // Fallback : ajoute + si absent
+  return `+${digits}`;
+};
+
+export const isPhoneNumberLike = (value: string): boolean => /[\d+]/.test(value);
+
+export const sendSms = async (params: { to: string; body: string }): Promise<{ sid: string }> => {
+  const form = new URLSearchParams({
+    To: params.to,
+    From: TWILIO_PHONE_NUMBER,
+    Body: params.body,
+  });
+
+  const response = await fetch(twilioApiUrl("/Messages.json"), {
+    method: "POST",
+    headers: twilioHeaders(),
+    body: form.toString(),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as { message?: string };
+    throw new Error(error.message ?? `Twilio SMS error ${response.status}`);
+  }
+
+  const result = (await response.json()) as { sid: string };
+  return { sid: result.sid };
+};
+
+export const makeCall = async (params: { to: string; message: string }): Promise<{ sid: string }> => {
+  const escaped = params.message.replace(/[<>&"']/g, (c) =>
+    ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&apos;" }[c] ?? c));
+  const twiml = `<Response><Pause length="1"/><Say voice="alice" language="fr-FR">Message de votre assistant. ${escaped}</Say></Response>`;
+
+  const form = new URLSearchParams({
+    To: params.to,
+    From: TWILIO_PHONE_NUMBER,
+    Twiml: twiml,
+  });
+
+  const response = await fetch(twilioApiUrl("/Calls.json"), {
+    method: "POST",
+    headers: twilioHeaders(),
+    body: form.toString(),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as { message?: string };
+    throw new Error(error.message ?? `Twilio call error ${response.status}`);
+  }
+
+  const result = (await response.json()) as { sid: string };
+  return { sid: result.sid };
+};

--- a/src/lib/openclaw/voiceTranscription.ts
+++ b/src/lib/openclaw/voiceTranscription.ts
@@ -1,19 +1,16 @@
-import fs from "node:fs";
+import { execFile } from "node:child_process";
 import * as fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { createRequire } from "node:module";
-import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 
-const require = createRequire(import.meta.url);
-const CONFIGURED_OPENCLAW_PACKAGE_ROOT = process.env.OPENCLAW_PACKAGE_ROOT?.trim() ?? "";
+const execFileAsync = promisify(execFile);
 
-const OPENCLAW_DIST_INDEX_RELATIVE_PATH = path.join("dist", "index.js");
-const OPENCLAW_DIST_DIRECTORY_RELATIVE_PATH = "dist";
-const AUDIO_KIND = "audio.transcription";
 const DEFAULT_VOICE_MIME = "audio/webm";
 const DEFAULT_VOICE_BASENAME = "voice-note";
+const WHISPER_BIN = process.env.WHISPER_BIN?.trim() || "whisper";
+const WHISPER_MODEL = process.env.WHISPER_MODEL?.trim() || "base";
 
 const MIME_EXTENSION_MAP: Record<string, string> = {
   "audio/mp4": ".m4a",
@@ -25,23 +22,6 @@ const MIME_EXTENSION_MAP: Record<string, string> = {
   "audio/x-wav": ".wav",
 };
 
-type OpenClawConfig = {
-  tools?: {
-    media?: {
-      audio?: {
-        enabled?: boolean;
-      };
-    };
-  };
-};
-
-type MediaUnderstandingOutput = {
-  kind?: string;
-  text?: string;
-  provider?: string;
-  model?: string;
-};
-
 type MediaUnderstandingDecision = {
   outcome?: string;
   attachments?: Array<{
@@ -51,63 +31,12 @@ type MediaUnderstandingDecision = {
   }>;
 };
 
-type RunCapabilityResult = {
-  outputs?: MediaUnderstandingOutput[];
-  decision?: MediaUnderstandingDecision;
-};
-
-type OpenClawConfigModule = {
-  t: () => OpenClawConfig;
-};
-
-type OpenClawRunnerModule = {
-  a: (params: {
-    capability: "audio";
-    cfg: OpenClawConfig;
-    ctx: Record<string, unknown>;
-    attachments: {
-      cleanup: () => Promise<void>;
-    };
-    media: Array<Record<string, unknown>>;
-    providerRegistry: unknown;
-    config: unknown;
-  }) => Promise<RunCapabilityResult>;
-  n: (attachments: Array<Record<string, unknown>>) => {
-    cleanup: () => Promise<void>;
-  };
-  r: (ctx: Record<string, unknown>) => Array<Record<string, unknown>>;
-  t: () => unknown;
-};
-
-type OpenClawTranscriptionSdk = {
-  loadConfig: OpenClawConfigModule["t"];
-  runCapability: OpenClawRunnerModule["a"];
-  createMediaAttachmentCache: OpenClawRunnerModule["n"];
-  normalizeMediaAttachments: OpenClawRunnerModule["r"];
-  buildProviderRegistry: OpenClawRunnerModule["t"];
-};
-
 export type OpenClawVoiceTranscriptionResult = {
   transcript: string | null;
   provider: string | null;
   model: string | null;
   decision: MediaUnderstandingDecision | null;
   ignored: boolean;
-};
-
-let sdkPromise: Promise<OpenClawTranscriptionSdk> | null = null;
-const nativeImport = new Function(
-  "specifier",
-  "return import(specifier);",
-) as (specifier: string) => Promise<unknown>;
-
-const resolveInstalledOpenClawPackageRoot = (): string | null => {
-  try {
-    const resolvedEntry = require.resolve("openclaw");
-    return path.dirname(path.dirname(resolvedEntry));
-  } catch {
-    return null;
-  }
 };
 
 export const normalizeVoiceMimeType = (value: string | null | undefined): string => {
@@ -142,201 +71,40 @@ export const sanitizeVoiceFileName = (
   return normalizedBase.endsWith(extension) ? normalizedBase : `${normalizedBase}${extension}`;
 };
 
-export const buildVoiceTranscriptionErrorMessage = (
-  decision: MediaUnderstandingDecision | null | undefined,
-): string => {
-  if (!decision) return "OpenClaw did not return a transcript.";
-  const outcome = decision.outcome?.trim() || "unknown";
-  const reasons = (decision.attachments ?? [])
-    .flatMap((attachment) => attachment.attempts ?? [])
-    .map((attempt) => attempt.reason?.trim() ?? "")
-    .filter(Boolean);
-  const detail = reasons[0] ? ` ${reasons[0]}` : "";
-  switch (outcome) {
-    case "disabled":
-      return `OpenClaw audio transcription is disabled.${detail}`.trim();
-    case "no-attachment":
-      return "OpenClaw did not receive any audio to transcribe.";
-    case "scope-deny":
-      return `OpenClaw blocked audio transcription for this request.${detail}`.trim();
-    case "skipped":
-      return `OpenClaw skipped audio transcription.${detail}`.trim();
-    default:
-      return `OpenClaw did not return a transcript.${detail}`.trim();
-  }
-};
-
-export const shouldIgnoreVoiceTranscription = (params: {
-  transcript: string | null | undefined;
-  decision: MediaUnderstandingDecision | null | undefined;
-}): boolean => {
-  const transcript = params.transcript?.trim() ?? "";
-  if (transcript) return false;
-  const reasons = (params.decision?.attachments ?? [])
-    .flatMap((attachment) => attachment.attempts ?? [])
-    .map((attempt) => attempt.reason?.trim().toLowerCase() ?? "")
-    .filter(Boolean);
-  return reasons.some((reason) =>
-    [
-      "missing text",
-      "empty transcript",
-      "no speech",
-      "no audio detected",
-      "no transcript text",
-    ].some((snippet) => reason.includes(snippet)),
-  );
-};
-
-const resolveOpenClawPackageRoot = (): string => {
-  const configuredCandidate = CONFIGURED_OPENCLAW_PACKAGE_ROOT;
-  if (configuredCandidate) {
-    const indexPath = path.join(configuredCandidate, OPENCLAW_DIST_INDEX_RELATIVE_PATH);
-    if (fs.existsSync(indexPath)) return configuredCandidate;
-    throw new Error("OPENCLAW_PACKAGE_ROOT does not point to a valid OpenClaw installation.");
-  }
-
-  const installedCandidate = resolveInstalledOpenClawPackageRoot();
-  if (installedCandidate) {
-    const indexPath = path.join(installedCandidate, OPENCLAW_DIST_INDEX_RELATIVE_PATH);
-    if (fs.existsSync(indexPath)) return installedCandidate;
-  }
-
-  throw new Error(
-    "OpenClaw could not be resolved from the current Node runtime. Install the `openclaw` package or set OPENCLAW_PACKAGE_ROOT.",
-  );
-};
-
-const loadOpenClawSdk = async (): Promise<OpenClawTranscriptionSdk> => {
-  if (sdkPromise) return sdkPromise;
-  sdkPromise = (async () => {
-    const packageRoot = resolveOpenClawPackageRoot();
-    const distDirectory = path.join(packageRoot, OPENCLAW_DIST_DIRECTORY_RELATIVE_PATH);
-    const distEntries = (await fsp.readdir(distDirectory)).sort();
-    const configCandidates = distEntries.filter((entry) => /^config-.*\.js$/.test(entry));
-    let loadConfig: OpenClawTranscriptionSdk["loadConfig"] | null = null;
-
-    for (const candidate of configCandidates) {
-      const configModule = (await nativeImport(
-        pathToFileURL(path.join(distDirectory, candidate)).href,
-      )) as Partial<OpenClawConfigModule>;
-      if (typeof configModule.t === "function") {
-        loadConfig = configModule.t;
-        break;
-      }
-    }
-
-    if (!loadConfig) {
-      throw new Error("The installed OpenClaw runtime does not expose a loadConfig() module.");
-    }
-
-    const runnerCandidates = distEntries.filter((entry) => /^runner-.*\.js$/.test(entry));
-
-    for (const candidate of runnerCandidates) {
-      const runnerModule = (await nativeImport(
-        pathToFileURL(path.join(distDirectory, candidate)).href,
-      )) as Partial<
-        OpenClawRunnerModule
-      >;
-      if (
-        typeof runnerModule.a === "function" &&
-        typeof runnerModule.n === "function" &&
-        typeof runnerModule.r === "function" &&
-        typeof runnerModule.t === "function"
-      ) {
-        return {
-          loadConfig,
-          runCapability: runnerModule.a,
-          createMediaAttachmentCache: runnerModule.n,
-          normalizeMediaAttachments: runnerModule.r,
-          buildProviderRegistry: runnerModule.t,
-        };
-      }
-    }
-
-    throw new Error("The installed OpenClaw runtime does not expose the audio transcription runner.");
-  })().catch((error) => {
-    sdkPromise = null;
-    throw error;
-  });
-  return sdkPromise;
-};
-
 export const transcribeVoiceWithOpenClaw = async (params: {
   buffer: Buffer;
   fileName?: string | null;
   mimeType?: string | null;
 }): Promise<OpenClawVoiceTranscriptionResult> => {
-  const sdk = await loadOpenClawSdk();
-  const cfg = sdk.loadConfig();
-  if (cfg.tools?.media?.audio?.enabled === false) {
-    throw new Error("OpenClaw audio transcription is disabled.");
-  }
-
   const mimeType = normalizeVoiceMimeType(params.mimeType);
   const fileName = sanitizeVoiceFileName(params.fileName, mimeType);
   const tempDirectory = await fsp.mkdtemp(path.join(os.tmpdir(), "claw3d-voice-"));
-  const tempPath = path.join(tempDirectory, `${randomUUID()}-${fileName}`);
+  const inputName = `${randomUUID()}-${fileName}`;
+  const tempPath = path.join(tempDirectory, inputName);
 
   await fsp.writeFile(tempPath, params.buffer);
 
-  const ctx: Record<string, unknown> = {
-    Body: "",
-    BodyForAgent: "",
-    BodyForCommands: "",
-    RawBody: "",
-    CommandBody: "",
-    ChatType: "direct",
-    MediaPath: tempPath,
-    MediaType: mimeType,
-    MediaPaths: [tempPath],
-    MediaTypes: [mimeType],
-  };
-
-  const media = sdk.normalizeMediaAttachments(ctx);
-  const cache = sdk.createMediaAttachmentCache(media);
-
   try {
-    const result = await sdk.runCapability({
-      capability: "audio",
-      cfg,
-      ctx,
-      attachments: cache,
-      media,
-      providerRegistry: sdk.buildProviderRegistry(),
-      config: cfg.tools?.media?.audio,
-    });
+    await execFileAsync(WHISPER_BIN, [
+      tempPath,
+      "--model", WHISPER_MODEL,
+      "--output_format", "txt",
+      "--output_dir", tempDirectory,
+      "--fp16", "False",
+    ]);
 
-    const audioOutputs = (result.outputs ?? []).filter((output) => output.kind === AUDIO_KIND);
-    const transcript = audioOutputs
-      .map((output) => output.text?.trim() ?? "")
-      .filter(Boolean)
-      .join("\n\n")
-      .trim();
+    const baseName = path.basename(tempPath, path.extname(tempPath));
+    const txtPath = path.join(tempDirectory, `${baseName}.txt`);
+    const transcript = (await fsp.readFile(txtPath, "utf8")).trim();
 
-    if (!transcript) {
-      if (shouldIgnoreVoiceTranscription({ transcript, decision: result.decision ?? null })) {
-        return {
-          transcript: null,
-          provider: null,
-          model: null,
-          decision: result.decision ?? null,
-          ignored: true,
-        };
-      }
-      throw new Error(buildVoiceTranscriptionErrorMessage(result.decision ?? null));
-    }
-
-    const firstOutput = audioOutputs[0] ?? null;
     return {
-      transcript,
-      provider: firstOutput?.provider ?? null,
-      model: firstOutput?.model ?? null,
-      decision: result.decision ?? null,
-      ignored: false,
+      transcript: transcript || null,
+      provider: "whisper",
+      model: WHISPER_MODEL,
+      decision: null,
+      ignored: !transcript,
     };
   } finally {
-    await cache.cleanup().catch(() => undefined);
-    await fsp.rm(tempPath, { force: true }).catch(() => undefined);
-    await fsp.rmdir(tempDirectory).catch(() => undefined);
+    await fsp.rm(tempDirectory, { recursive: true, force: true }).catch(() => undefined);
   }
 };


### PR DESCRIPTION
## What this PR does

Turns the Phone Booth and SMS Booth from read-only mock animations into **fully functional communication tools**. Agents and users can now place real outbound calls and send real messages directly from the 3D office.

Built around a **provider abstraction layer** so users can connect whichever messaging backend they use.

---

## Provider support

| Provider | Message | Call | Notes |
|---|---|---|---|
| `twilio` | ✅ | ✅ | SMS + voice calls via Twilio REST API |
| `whatsapp` | ✅ | ❌ | WhatsApp via Twilio WhatsApp API |
| `telegram` | ✅ | ❌ | Telegram Bot API |
| `imessage` | ✅ | ❌ | iMessage via [BlueBubbles](https://bluebubbles.app) server (Mac) |

> Calls are Twilio-only — WhatsApp, Telegram, and iMessage have no public outbound call API.

---

## New files

| File | Description |
|---|---|
| `src/lib/office/twilio.ts` | Twilio REST client — `sendSms()`, `makeCall()`, `normalizePhoneNumber()` |
| `src/lib/office/messagingProviders.ts` | Provider abstraction — `dispatchSendSms()`, `dispatchMakeCall()` |
| `src/lib/office/providers/whatsapp.ts` | WhatsApp via Twilio WhatsApp API |
| `src/lib/office/providers/telegram.ts` | Telegram Bot API |
| `src/lib/office/providers/imessage.ts` | iMessage via BlueBubbles REST API |
| `src/lib/office/boothContacts.ts` | localStorage contacts + call/SMS history (capped at 50) |
| `src/features/office/dialogs/BoothInputDialog.tsx` | Full-screen 3-column booth input UI |
| `src/app/api/agent/notify/route.ts` | Agent → owner notification endpoint |
| `docs/booth-messaging.md` | Full setup and architecture documentation |
| `skills/notify-owner/SKILL.md` | OpenClaw skill — agents learn to notify the owner |

---

## Quick setup

Add to `.env.local`:

**Twilio** (SMS + calls):
```bash
TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
TWILIO_PHONE_NUMBER=+15005550006
```

**WhatsApp** (messages only):
```bash
MESSAGING_PROVIDER=whatsapp
TWILIO_ACCOUNT_SID=...
TWILIO_AUTH_TOKEN=...
TWILIO_WHATSAPP_NUMBER=whatsapp:+14155238886
```

**Telegram** (messages only):
```bash
MESSAGING_PROVIDER=telegram
TELEGRAM_BOT_TOKEN=123456789:ABCdef...
TELEGRAM_CHAT_ID=123456789
```

**iMessage** (messages only, requires Mac running BlueBubbles):
```bash
MESSAGING_PROVIDER=imessage
IMESSAGE_BLUEBUBBLES_URL=http://192.168.1.50:1234
IMESSAGE_BLUEBUBBLES_PASSWORD=your-password
```

Optional:
```bash
OWNER_PHONE_NUMBER=+1555...             # for agent notifications — never exposed to agents
NEXT_PUBLIC_MESSAGING_PROVIDER=twilio   # shows active provider badge in booth UI
```

Full setup guide: [`docs/booth-messaging.md`](docs/booth-messaging.md)

---

## Booth UI

```
┌──────────────────┬──────────────────────┬──────────────────┐
│  Contacts list   │  Number / recipient  │  Numeric keypad  │
│  Recent history  │  Message composer    │  (or hint panel  │
│  Search + Add    │  [Call / Send ...]   │   per provider)  │
└──────────────────┴──────────────────────┴──────────────────┘
```

- Provider badge in header (e.g. "WhatsApp", "iMessage", "via Twilio")
- Privacy mode: masks phone numbers
- iMessage: accepts phone number or Apple ID email
- Telegram: no recipient input needed (chat_id is server-side)
- CTA label adapts per provider

---

## Agent → Owner notifications

`POST /api/agent/notify` — agents contact the owner via SMS or call without knowing their number. Owner's number stays server-side only.

- Rate-limited: 3/hour per agent, 10/hour global
- Optional allowlist: `NOTIFY_ALLOWED_AGENTS=id1,id2`
- Companion skill in `skills/notify-owner/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)