### PR TITLE
fix(security): validate trashDir to prevent SSH command injection (fixes #35)

### DIFF
--- a/src/app/api/gateway/agent-state/route.ts
+++ b/src/app/api/gateway/agent-state/route.ts
@@ -87,6 +87,10 @@ export async function PUT(request: Request) {
     if (!trimmedTrash) {
       return NextResponse.json({ error: "trashDir is required." }, { status: 400 });
     }
+    const SAFE_TRASH_DIR_RE = /^[a-zA-Z0-9_.~\/-]+$/;
+    if (!SAFE_TRASH_DIR_RE.test(trimmedTrash)) {
+      return NextResponse.json({ error: "trashDir contains invalid characters." }, { status: 400 });
+    }
     if (!isSafeAgentId(trimmedAgent)) {
       return NextResponse.json({ error: `Invalid agentId: ${trimmedAgent}` }, { status: 400 });
     }


### PR DESCRIPTION
Adds regex validation for the `trashDir` parameter in the PUT handler of `/api/gateway/agent-state/route.ts`. The value is now checked against `^[a-zA-Z0-9_.~\/-]+$` before being passed to SSH commands, preventing shell metacharacter injection.

Fixes #35.