### PR TITLE
fix(security): enforce access gate on all routes (fixes #38)

### DIFF
--- a/server/access-gate.js
+++ b/server/access-gate.js
@@ -28,8 +28,8 @@ function createAccessGate(options) {
 
   const handleHttp = (req, res) => {
     if (!enabled) return false;
-    if (String(req.url || "/").startsWith("/api/")) {
-      if (!isAuthorized(req)) {
+    if (!isAuthorized(req)) {
+      if (String(req.url || "/").startsWith("/api/")) {
         res.statusCode = 401;
         res.setHeader("Content-Type", "application/json");
         res.end(
@@ -37,10 +37,13 @@ function createAccessGate(options) {
             error: "Studio access token required. Send the configured Studio access cookie and retry.",
           })
         );
-        return true;
+      } else {
+        res.statusCode = 401;
+        res.setHeader("Content-Type", "text/plain");
+        res.end("Studio access token required. Set the studio_access cookie to access this page.");
       }
+      return true;
     }
-
     return false;
   };
 


### PR DESCRIPTION
The access gate previously only checked authorization for `/api/` routes, leaving the Studio UI and all non-API paths accessible without a token. This change applies the auth check to ALL incoming HTTP requests. API routes return JSON 401, non-API routes return plain text 401.

Fixes #38.