### PR TITLE
fix(security): resolve symlinks in path-suggestions home directory check (fixes #52)

### DIFF
--- a/src/app/api/path-suggestions/route.ts
+++ b/src/app/api/path-suggestions/route.ts
@@ -42,8 +42,18 @@ const normalizeQuery = (query: string): string => {
   return `~/${withoutLeading}`;
 };
 
+const resolveRealPath = (value: string): string => {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
+};
+
 const isWithinHome = (target: string, home: string): boolean => {
-  const relative = path.relative(home, target);
+  const resolvedTarget = resolveRealPath(target);
+  const resolvedHome = resolveRealPath(home);
+  const relative = path.relative(resolvedHome, resolvedTarget);
   if (!relative) return true;
   return !relative.startsWith("..") && !path.isAbsolute(relative);
 };


### PR DESCRIPTION
The `isWithinHome()` check in `/api/path-suggestions` used `path.relative()` which is purely string-based and does not follow symlinks. A symlink inside the home directory pointing to an external path would bypass the containment check, allowing directory listing of arbitrary filesystem locations.

This fix uses `fs.realpathSync()` to resolve symlinks before the containment comparison, ensuring the real filesystem path is validated.

Fixes #52.