### PR TITLE
fix: replace fake random agent states with real gateway session data

### DIFF
--- a/src/app/api/office/presence/route.ts
+++ b/src/app/api/office/presence/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
     const workspaceId = url.searchParams.get("workspaceId")?.trim() || "default";
-    const snapshot = loadOfficePresenceSnapshot(workspaceId);
+    const snapshot = await loadOfficePresenceSnapshot(workspaceId);
     return NextResponse.json(snapshot);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to load office presence.";

--- a/src/lib/office/presence.ts
+++ b/src/lib/office/presence.ts
@@ -20,25 +20,97 @@ export type OfficePresenceSnapshot = {
 
 const OPENCLAW_CONFIG_FILENAME = "openclaw.json";
 
-const stableHash = (input: string): number => {
-  let hash = 0;
-  for (let index = 0; index < input.length; index += 1) {
-    hash = (hash * 31 + input.charCodeAt(index)) >>> 0;
+type GatewaySession = {
+  key: string;
+  agentId?: string | null;
+  status: string;
+  kind?: string;
+  [key: string]: unknown;
+};
+
+type GatewaySessionsResponse = {
+  count: number;
+  sessions: GatewaySession[];
+};
+
+/**
+ * Extract agent ID from session key
+ * Session keys follow pattern: "agent:{agentId}:{sessionType}"
+ */
+const extractAgentIdFromSessionKey = (sessionKey: string): string | null => {
+  const match = sessionKey.match(/^agent:([^:]+):/);
+  return match ? match[1] : null;
+};
+
+/**
+ * Map gateway session status to office agent state
+ */
+const mapSessionStatusToAgentState = (status: string): OfficeAgentState => {
+  switch (status) {
+    case "running":
+      return "working";
+    case "error":
+    case "failed":
+      return "error";
+    case "done":
+    case "idle":
+      return "idle";
+    default:
+      // For unknown status, check if session exists (implies some activity)
+      return "idle";
   }
-  return hash;
 };
 
-const resolveStateFromSeed = (seed: number): OfficeAgentState => {
-  const mod = seed % 20;
-  if (mod <= 9) return "working";
-  if (mod <= 14) return "idle";
-  if (mod <= 17) return "meeting";
-  return "error";
+/**
+ * Get active sessions from the OpenClaw gateway
+ */
+const getActiveSessionsFromGateway = async (gatewayUrl: string, token: string): Promise<GatewaySession[]> => {
+  try {
+    const response = await fetch(`${gatewayUrl}/tools/invoke`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        tool: 'sessions_list',
+        args: { activeMinutes: 120, messageLimit: 0 }
+      }),
+    });
+
+    if (!response.ok) {
+      console.warn(`Gateway sessions API returned ${response.status}: ${response.statusText}`);
+      return [];
+    }
+
+    const envelope = await response.json() as { ok: boolean; result?: { content?: Array<{ text?: string }> } };
+    
+    if (!envelope.ok || !envelope.result?.content?.[0]?.text) {
+      console.warn('Gateway sessions API returned unexpected format or failed');
+      return [];
+    }
+
+    // The gateway returns session data as a JSON string inside result.content[0].text
+    const parsed = JSON.parse(envelope.result.content[0].text) as GatewaySessionsResponse;
+    
+    if (!parsed.sessions) {
+      return [];
+    }
+
+    return parsed.sessions.map(session => ({
+      ...session,
+      agentId: session.agentId ?? extractAgentIdFromSessionKey(session.key),
+    }));
+  } catch (error) {
+    console.warn('Failed to fetch sessions from gateway:', error instanceof Error ? error.message : 'Unknown error');
+    return [];
+  }
 };
 
-export const loadOfficePresenceSnapshot = (workspaceId: string): OfficePresenceSnapshot => {
+export const loadOfficePresenceSnapshot = async (workspaceId: string): Promise<OfficePresenceSnapshot> => {
   const configPath = path.join(resolveStateDir(), OPENCLAW_CONFIG_FILENAME);
   const timestamp = new Date().toISOString();
+  
   if (!fs.existsSync(configPath)) {
     return {
       workspaceId,
@@ -46,28 +118,91 @@ export const loadOfficePresenceSnapshot = (workspaceId: string): OfficePresenceS
       agents: [],
     };
   }
-  const raw = fs.readFileSync(configPath, "utf8");
-  const parsed = JSON.parse(raw) as unknown;
-  const config =
-    parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  const agentList = readConfigAgentList(config);
-  const bucket = Math.floor(Date.now() / 2000);
-  const agents: OfficeAgentPresence[] = agentList.map((entry) => {
-    const id = entry.id.trim();
-    const nameRaw = typeof entry.name === "string" ? entry.name : id;
-    const seed = stableHash(`${id}:${bucket}`);
+
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    const config =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : undefined;
+
+    const agentList = readConfigAgentList(config);
+    
+    // Get gateway configuration for API access
+    const gateway = config?.gateway as Record<string, unknown> | undefined;
+    const gatewayPort = (gateway?.port as number) || 18789;
+    const gatewayAuth = gateway?.auth as Record<string, unknown> | undefined;
+    const gatewayToken = gatewayAuth?.token as string | undefined;
+    
+    const gatewayUrl = `http://127.0.0.1:${gatewayPort}`;
+
+    // Create a map of agent states - default to idle
+    const agentStatesMap = new Map<string, OfficeAgentState>();
+    agentList.forEach(agent => {
+      agentStatesMap.set(agent.id, "idle");
+    });
+
+    // If we have gateway token, fetch real session data
+    if (gatewayToken) {
+      try {
+        const sessions = await getActiveSessionsFromGateway(gatewayUrl, gatewayToken);
+        
+        // Count child sessions per agent (subagent activity implies "meeting"/collaboration)
+        const childCountByAgent = new Map<string, number>();
+        sessions.forEach(session => {
+          if (session.agentId && session.kind === "subagent") {
+            const parent = extractAgentIdFromSessionKey(session.key);
+            if (parent) {
+              childCountByAgent.set(parent, (childCountByAgent.get(parent) ?? 0) + 1);
+            }
+          }
+        });
+
+        // Update agent states based on active sessions
+        sessions.forEach(session => {
+          if (session.agentId && agentStatesMap.has(session.agentId)) {
+            const state = mapSessionStatusToAgentState(session.status);
+            // Agents with active child sessions are "meeting" (collaborating)
+            if (state === "working" && (childCountByAgent.get(session.agentId) ?? 0) > 0) {
+              agentStatesMap.set(session.agentId, "meeting");
+            } else {
+              agentStatesMap.set(session.agentId, state);
+            }
+          }
+        });
+      } catch (error) {
+        console.warn('Failed to fetch gateway sessions, falling back to idle state:', error);
+      }
+    } else {
+      console.warn('No gateway token configured, all agents will show as idle');
+    }
+
+    // Build the presence array
+    const agents: OfficeAgentPresence[] = agentList.map((entry) => {
+      const id = entry.id.trim();
+      const nameRaw = typeof entry.name === "string" ? entry.name : id;
+      const state = agentStatesMap.get(id) || "idle";
+      
+      return {
+        agentId: id,
+        name: nameRaw,
+        state,
+        preferredDeskId: `desk-${id}`,
+      };
+    });
+
     return {
-      agentId: id,
-      name: nameRaw,
-      state: resolveStateFromSeed(seed),
-      preferredDeskId: `desk-${id}`,
+      workspaceId,
+      timestamp,
+      agents,
     };
-  });
-  return {
-    workspaceId,
-    timestamp,
-    agents,
-  };
+  } catch (error) {
+    console.error('Error loading office presence snapshot:', error);
+    return {
+      workspaceId,
+      timestamp,
+      agents: [],
+    };
+  }
 };


### PR DESCRIPTION
## Problem

The office presence system in `src/lib/office/presence.ts` generates **fake agent states** using a seeded random hash that changes every 2 seconds. Agents randomly flip between "working", "idle", "meeting", and "error" with no connection to actual gateway runtime state. This makes the 3D office visualization misleading — agents appear busy or errored when they're actually idle, and idle when they're actually working.

## Solution

Rewrites `loadOfficePresenceSnapshot()` to query the **real OpenClaw gateway** for active session data via the `/tools/invoke` endpoint (`sessions_list` tool).

### Changes
- **`src/lib/office/presence.ts`**: Replaced random state generation with actual gateway session queries
  - Reads gateway auth token dynamically from `openclaw.json` (no hardcoded credentials)
  - Maps gateway session status to office agent states: `running` → `working`, `error/failed` → `error`, else → `idle`
  - Agents with active child sessions (subagents) are mapped to `meeting` state (collaboration)
  - Graceful fallback: if gateway is unreachable or token is missing, all agents default to `idle`
  - Function is now `async` to support HTTP calls
- **`src/app/api/office/presence/route.ts`**: Added `await` for the now-async function

### Architecture note
The existing codebase queries sessions via the WebSocket RPC client (`client.call("sessions.list", ...)`). This change uses the HTTP `/tools/invoke` endpoint instead, since the presence snapshot is loaded server-side in a Next.js API route without an active WebSocket connection. Both surfaces return the same data.

### Testing
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` — 893 passed, 2 failed (pre-existing on main, not introduced by this PR)
- Manual verification against a live gateway with 10 agents confirmed correct state mapping

### Security
- No hardcoded credentials or tokens
- Gateway URL is localhost-only (`127.0.0.1`)
- Token read dynamically from config at runtime
- Reviewed for sensitive data leaks — clean