### PR TITLE
Add outdoor soccer stadium beside the office

### DIFF
--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -5160,35 +5160,41 @@ export function RetroOffice3D({
 
   // Camera constants.
   const LOCAL_CAMERA_TARGET = useMemo(
-    () =>
-      toWorld(LOCAL_OFFICE_CANVAS_WIDTH / 2, LOCAL_OFFICE_CANVAS_HEIGHT / 2),
+    () => toWorld(LOCAL_OFFICE_CANVAS_WIDTH / 2, LOCAL_OFFICE_CANVAS_HEIGHT / 2 + 150),
     [],
   );
   const CAM_POS = useMemo<[number, number, number]>(() => {
     if (remoteOfficeEnabled) return DISTRICT_CAMERA_POSITION;
     return [
-      LOCAL_CAMERA_TARGET[0] + (DISTRICT_CAMERA_POSITION[0] - DISTRICT_CAMERA_TARGET[0]),
-      LOCAL_CAMERA_TARGET[1] + (DISTRICT_CAMERA_POSITION[1] - DISTRICT_CAMERA_TARGET[1]),
-      LOCAL_CAMERA_TARGET[2] + (DISTRICT_CAMERA_POSITION[2] - DISTRICT_CAMERA_TARGET[2]),
+      LOCAL_CAMERA_TARGET[0] + 14,
+      LOCAL_CAMERA_TARGET[1] + 16,
+      LOCAL_CAMERA_TARGET[2] + 17,
     ];
   }, [remoteOfficeEnabled, LOCAL_CAMERA_TARGET]);
   const cameraTarget = remoteOfficeEnabled
     ? DISTRICT_CAMERA_TARGET
     : LOCAL_CAMERA_TARGET;
-  const cameraZoom = remoteOfficeEnabled ? DISTRICT_CAMERA_ZOOM : 56;
-  const overviewPresetRef = useRef({ pos: CAM_POS, target: cameraTarget, zoom: cameraZoom });
-  overviewPresetRef.current = { pos: CAM_POS, target: cameraTarget, zoom: cameraZoom };
+  const cameraZoom = remoteOfficeEnabled ? DISTRICT_CAMERA_ZOOM : 39;
+  const overviewPreset = useMemo(
+    () => ({ pos: CAM_POS, target: cameraTarget, zoom: cameraZoom }),
+    [CAM_POS, cameraTarget, cameraZoom],
+  );
+  const overviewPresetRef = useRef(overviewPreset);
   const lastOfficeCenterSignalRef = useRef(officeCenterSignal);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/immutability -- overview camera preset is intentionally kept in sync here.
+    overviewPresetRef.current = overviewPreset;
     cameraPresetRef.current = overviewPresetRef.current;
-  }, [CAM_POS, cameraTarget, cameraZoom]);
+  }, [overviewPreset]);
 
   useEffect(() => {
     if (officeCenterSignal === lastOfficeCenterSignalRef.current) return;
     lastOfficeCenterSignalRef.current = officeCenterSignal;
+    // eslint-disable-next-line react-hooks/immutability -- overview camera preset is intentionally kept in sync here.
+    overviewPresetRef.current = overviewPreset;
     cameraPresetRef.current = overviewPresetRef.current;
-  }, [officeCenterSignal, CAM_POS, cameraTarget, cameraZoom]);
+  }, [officeCenterSignal, overviewPreset]);
 
   return (
     <div className="relative w-full h-full bg-[#1a1008] font-mono text-white overflow-hidden">

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -167,24 +167,24 @@ function OfficeFlagPole({
   );
 }
 
-const SOCCER_FIELD_WIDTH = 20.8;
-const SOCCER_FIELD_DEPTH = 7.4;
-const SOCCER_STADIUM_BASE_WIDTH = SOCCER_FIELD_WIDTH + 2.6;
-const SOCCER_STADIUM_BASE_DEPTH = SOCCER_FIELD_DEPTH + 2.1;
+const SOCCER_FIELD_WIDTH = 24.8;
+const SOCCER_FIELD_DEPTH = 9.6;
+const SOCCER_STADIUM_BASE_WIDTH = SOCCER_FIELD_WIDTH + 3.2;
+const SOCCER_STADIUM_BASE_DEPTH = SOCCER_FIELD_DEPTH + 2.8;
 const SOCCER_ENTRY_PATH_WIDTH = 2.1;
 const SOCCER_ENTRY_OPENING_WIDTH = 3.8;
 const SOCCER_TEAM_SHAPE = [
-  { x: 0, z: -2.72, goalkeeper: true },
-  { x: -6.9, z: -1.86, goalkeeper: false },
-  { x: -2.35, z: -2.02, goalkeeper: false },
-  { x: 2.35, z: -2.02, goalkeeper: false },
-  { x: 6.9, z: -1.86, goalkeeper: false },
-  { x: -7.7, z: -0.24, goalkeeper: false },
-  { x: -2.8, z: -0.3, goalkeeper: false },
-  { x: 2.8, z: -0.3, goalkeeper: false },
-  { x: 7.7, z: -0.24, goalkeeper: false },
-  { x: -3.05, z: 1.84, goalkeeper: false },
-  { x: 3.05, z: 1.98, goalkeeper: false },
+  { x: 0, z: -3.42, goalkeeper: true },
+  { x: -8.2, z: -2.38, goalkeeper: false },
+  { x: -2.85, z: -2.52, goalkeeper: false },
+  { x: 2.85, z: -2.52, goalkeeper: false },
+  { x: 8.2, z: -2.38, goalkeeper: false },
+  { x: -9.2, z: -0.32, goalkeeper: false },
+  { x: -3.45, z: -0.44, goalkeeper: false },
+  { x: 3.45, z: -0.44, goalkeeper: false },
+  { x: 9.2, z: -0.32, goalkeeper: false },
+  { x: -3.7, z: 2.34, goalkeeper: false },
+  { x: 3.7, z: 2.5, goalkeeper: false },
 ] as const;
 
 function SoccerPlayer({
@@ -203,48 +203,73 @@ function SoccerPlayer({
   const sockColor = goalkeeper ? "#111827" : teamColor;
   return (
     <group position={position} rotation={[0, facing, 0]} scale={1.75}>
-      <mesh position={[0, 0.1, 0.028]} castShadow>
-        <sphereGeometry args={[0.078, 16, 16]} />
+      <mesh position={[0, 0.001, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[0.12, 12]} />
+        <meshBasicMaterial color="#000" transparent opacity={0.18} />
+      </mesh>
+      <group position={[-0.045, 0.1, 0]}>
+        <mesh>
+          <boxGeometry args={[0.07, 0.14, 0.08]} />
+          <meshLambertMaterial color={sockColor} />
+        </mesh>
+        <mesh position={[0, -0.09, 0]}>
+          <boxGeometry args={[0.07, 0.05, 0.12]} />
+          <meshLambertMaterial color="#111827" />
+        </mesh>
+      </group>
+      <group position={[0.045, 0.1, 0]}>
+        <mesh>
+          <boxGeometry args={[0.07, 0.14, 0.08]} />
+          <meshLambertMaterial color={sockColor} />
+        </mesh>
+        <mesh position={[0, -0.09, 0]}>
+          <boxGeometry args={[0.07, 0.05, 0.12]} />
+          <meshLambertMaterial color="#111827" />
+        </mesh>
+      </group>
+      <mesh position={[0, 0.28, 0]}>
+        <boxGeometry args={[0.18, 0.2, 0.1]} />
+        <meshLambertMaterial color={jerseyColor} />
+      </mesh>
+      <mesh position={[0, 0.36, 0]}>
+        <boxGeometry args={[0.1, 0.05, 0.08]} />
+        <meshLambertMaterial color={goalkeeper ? teamColor : "#0f172a"} />
+      </mesh>
+      <group position={[-0.12, 0.28, 0]} rotation={[0, 0, 0.32]}>
+        <mesh position={[0, -0.08, 0]}>
+          <boxGeometry args={[0.06, 0.16, 0.06]} />
+          <meshLambertMaterial color={jerseyColor} />
+        </mesh>
+        <mesh position={[0, -0.17, 0]}>
+          <boxGeometry args={[0.05, 0.05, 0.05]} />
+          <meshLambertMaterial color="#f1c7a6" />
+        </mesh>
+      </group>
+      <group position={[0.12, 0.28, 0]} rotation={[0, 0, -0.32]}>
+        <mesh position={[0, -0.08, 0]}>
+          <boxGeometry args={[0.06, 0.16, 0.06]} />
+          <meshLambertMaterial color={jerseyColor} />
+        </mesh>
+        <mesh position={[0, -0.17, 0]}>
+          <boxGeometry args={[0.05, 0.05, 0.05]} />
+          <meshLambertMaterial color="#f1c7a6" />
+        </mesh>
+      </group>
+      <mesh position={[0, 0.52, 0.016]} castShadow>
+        <sphereGeometry args={[0.082, 16, 16]} />
         <meshStandardMaterial color="#f1c7a6" roughness={0.9} metalness={0.02} />
       </mesh>
-      <mesh position={[0, -0.035, 0]} castShadow receiveShadow>
-        <capsuleGeometry args={[0.085, 0.24, 4, 10]} />
-        <meshStandardMaterial color={jerseyColor} roughness={0.68} metalness={0.08} />
+      <mesh position={[0, 0.61, 0.05]}>
+        <planeGeometry args={[0.09, 0.07]} />
+        <meshBasicMaterial color={goalkeeper ? teamColor : "#f8fafc"} />
       </mesh>
-      <mesh position={[0, -0.19, 0.01]} castShadow receiveShadow>
-        <boxGeometry args={[0.21, 0.11, 0.1]} />
-        <meshStandardMaterial color={shortColor} roughness={0.84} metalness={0.02} />
+      <mesh position={[0, 0.19, 0.055]}>
+        <boxGeometry args={[0.21, 0.11, 0.05]} />
+        <meshLambertMaterial color={shortColor} />
       </mesh>
-      <mesh position={[0, -0.04, 0.085]} castShadow>
-        <boxGeometry args={[0.18, 0.05, 0.04]} />
-        <meshStandardMaterial color="#0f172a" roughness={0.78} metalness={0.08} />
-      </mesh>
-      {([-0.055, 0.055] as const).map((x) => (
-        <mesh key={`leg-${x}`} position={[x, -0.315, 0.008]} castShadow>
-          <cylinderGeometry args={[0.026, 0.028, 0.2, 10]} />
-          <meshStandardMaterial color={sockColor} roughness={0.94} metalness={0.02} />
-        </mesh>
-      ))}
-      {([-0.082, 0.082] as const).map((x) => (
-        <mesh key={`foot-${x}`} position={[x, -0.43, 0.055]} castShadow receiveShadow>
-          <boxGeometry args={[0.075, 0.034, 0.12]} />
-          <meshStandardMaterial color="#101214" roughness={0.9} metalness={0.02} />
-        </mesh>
-      ))}
-      {([-0.13, 0.13] as const).map((x) => (
-        <mesh
-          key={`arm-${x}`}
-          position={[x, -0.03, 0]}
-          rotation={[0, 0, x < 0 ? 0.7 : -0.7]}
-          castShadow
-        >
-          <capsuleGeometry args={[0.018, 0.16, 4, 8]} />
-          <meshStandardMaterial color="#f1c7a6" roughness={0.9} metalness={0.02} />
-        </mesh>
-      ))}
       {goalkeeper ? (
-        <mesh position={[0, -0.01, -0.09]} castShadow>
-          <boxGeometry args={[0.32, 0.045, 0.08]} />
+        <mesh position={[0, 0.26, -0.09]} castShadow>
+          <boxGeometry args={[0.32, 0.045, 0.09]} />
           <meshStandardMaterial color={teamColor} roughness={0.72} metalness={0.04} />
         </mesh>
       ) : null}
@@ -261,28 +286,28 @@ function GoalFrame({
 }) {
   return (
     <group position={position} rotation={[0, rotY, 0]}>
-      <mesh position={[-1.08, 0.62, 0]} castShadow>
+      <mesh position={[-1.3, 0.72, 0]} castShadow>
         <boxGeometry args={[0.08, 1.24, 0.08]} />
         <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
       </mesh>
-      <mesh position={[1.08, 0.62, 0]} castShadow>
+      <mesh position={[1.3, 0.72, 0]} castShadow>
         <boxGeometry args={[0.08, 1.24, 0.08]} />
         <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
       </mesh>
-      <mesh position={[0, 1.2, 0]} castShadow>
-        <boxGeometry args={[2.22, 0.08, 0.08]} />
+      <mesh position={[0, 1.4, 0]} castShadow>
+        <boxGeometry args={[2.68, 0.08, 0.08]} />
         <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
       </mesh>
-      <mesh position={[0, 0.54, -0.74]} receiveShadow>
-        <boxGeometry args={[2.1, 1.08, 0.03]} />
+      <mesh position={[0, 0.64, -0.92]} receiveShadow>
+        <boxGeometry args={[2.52, 1.28, 0.03]} />
         <meshStandardMaterial color="#dbeafe" transparent opacity={0.24} roughness={0.95} />
       </mesh>
-      <mesh position={[-1.02, 0.54, -0.37]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
-        <boxGeometry args={[0.76, 1.08, 0.03]} />
+      <mesh position={[-1.24, 0.64, -0.46]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
+        <boxGeometry args={[0.94, 1.28, 0.03]} />
         <meshStandardMaterial color="#dbeafe" transparent opacity={0.18} roughness={0.95} />
       </mesh>
-      <mesh position={[1.02, 0.54, -0.37]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
-        <boxGeometry args={[0.76, 1.08, 0.03]} />
+      <mesh position={[1.24, 0.64, -0.46]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
+        <boxGeometry args={[0.94, 1.28, 0.03]} />
         <meshStandardMaterial color="#dbeafe" transparent opacity={0.18} roughness={0.95} />
       </mesh>
     </group>

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -198,43 +198,54 @@ function SoccerPlayer({
   facing?: number;
   goalkeeper?: boolean;
 }) {
-  const jerseyColor = goalkeeper ? teamColor : teamColor;
+  const jerseyColor = goalkeeper ? "#f8fafc" : teamColor;
+  const shortColor = goalkeeper ? teamColor : "#f8fafc";
+  const sockColor = goalkeeper ? "#111827" : teamColor;
   return (
-    <group position={position} rotation={[0, facing, 0]} scale={0.52}>
-      <mesh position={[0, 0.06, 0.018]} castShadow>
-        <sphereGeometry args={[0.052, 14, 14]} />
+    <group position={position} rotation={[0, facing, 0]} scale={0.9}>
+      <mesh position={[0, 0.1, 0.028]} castShadow>
+        <sphereGeometry args={[0.078, 14, 14]} />
         <meshStandardMaterial color="#f1c7a6" roughness={0.9} metalness={0.02} />
       </mesh>
-      <mesh position={[0, -0.05, 0]} castShadow receiveShadow>
-        <capsuleGeometry args={[0.052, 0.18, 4, 10]} />
-        <meshStandardMaterial color={jerseyColor} roughness={0.72} metalness={0.08} />
+      <mesh position={[0, -0.035, 0]} castShadow receiveShadow>
+        <capsuleGeometry args={[0.085, 0.24, 4, 10]} />
+        <meshStandardMaterial color={jerseyColor} roughness={0.68} metalness={0.08} />
       </mesh>
-      <mesh position={[0, -0.17, 0.01]} castShadow receiveShadow>
-        <boxGeometry args={[0.14, 0.08, 0.08]} />
-        <meshStandardMaterial color="#f5f7fa" roughness={0.88} metalness={0.02} />
+      <mesh position={[0, -0.19, 0.01]} castShadow receiveShadow>
+        <boxGeometry args={[0.21, 0.11, 0.1]} />
+        <meshStandardMaterial color={shortColor} roughness={0.84} metalness={0.02} />
       </mesh>
-      {([-0.038, 0.038] as const).map((x) => (
-        <mesh key={`leg-${x}`} position={[x, -0.26, 0.008]} castShadow>
-          <cylinderGeometry args={[0.016, 0.018, 0.12, 10]} />
-          <meshStandardMaterial color="#111827" roughness={0.94} metalness={0.02} />
+      <mesh position={[0, -0.04, 0.085]} castShadow>
+        <boxGeometry args={[0.18, 0.05, 0.04]} />
+        <meshStandardMaterial color="#0f172a" roughness={0.78} metalness={0.08} />
+      </mesh>
+      {([-0.055, 0.055] as const).map((x) => (
+        <mesh key={`leg-${x}`} position={[x, -0.315, 0.008]} castShadow>
+          <cylinderGeometry args={[0.026, 0.028, 0.2, 10]} />
+          <meshStandardMaterial color={sockColor} roughness={0.94} metalness={0.02} />
         </mesh>
       ))}
-      {([-0.058, 0.058] as const).map((x) => (
-        <mesh key={`foot-${x}`} position={[x, -0.325, 0.03]} castShadow receiveShadow>
-          <boxGeometry args={[0.05, 0.025, 0.085]} />
+      {([-0.082, 0.082] as const).map((x) => (
+        <mesh key={`foot-${x}`} position={[x, -0.43, 0.055]} castShadow receiveShadow>
+          <boxGeometry args={[0.075, 0.034, 0.12]} />
           <meshStandardMaterial color="#101214" roughness={0.9} metalness={0.02} />
         </mesh>
       ))}
-      {([-0.088, 0.088] as const).map((x) => (
-        <mesh key={`arm-${x}`} position={[x, -0.055, 0]} rotation={[0, 0, x < 0 ? 0.45 : -0.45]} castShadow>
-          <capsuleGeometry args={[0.013, 0.11, 4, 8]} />
+      {([-0.13, 0.13] as const).map((x) => (
+        <mesh
+          key={`arm-${x}`}
+          position={[x, -0.03, 0]}
+          rotation={[0, 0, x < 0 ? 0.7 : -0.7]}
+          castShadow
+        >
+          <capsuleGeometry args={[0.018, 0.16, 4, 8]} />
           <meshStandardMaterial color="#f1c7a6" roughness={0.9} metalness={0.02} />
         </mesh>
       ))}
       {goalkeeper ? (
-        <mesh position={[0, -0.02, -0.05]} castShadow>
-          <boxGeometry args={[0.22, 0.03, 0.06]} />
-          <meshStandardMaterial color="#f8fafc" roughness={0.72} metalness={0.04} />
+        <mesh position={[0, -0.01, -0.09]} castShadow>
+          <boxGeometry args={[0.32, 0.045, 0.08]} />
+          <meshStandardMaterial color={teamColor} roughness={0.72} metalness={0.04} />
         </mesh>
       ) : null}
     </group>

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -167,6 +167,117 @@ function OfficeFlagPole({
   );
 }
 
+const SOCCER_FIELD_WIDTH = 13.2;
+const SOCCER_FIELD_DEPTH = 3.1;
+const SOCCER_STADIUM_BASE_WIDTH = SOCCER_FIELD_WIDTH + 1.6;
+const SOCCER_STADIUM_BASE_DEPTH = SOCCER_FIELD_DEPTH + 1.3;
+const SOCCER_ENTRY_PATH_WIDTH = 1.24;
+const SOCCER_ENTRY_OPENING_WIDTH = 2.2;
+const SOCCER_TEAM_SHAPE = [
+  { x: 0, z: -1.12, goalkeeper: true },
+  { x: -4.4, z: -0.76, goalkeeper: false },
+  { x: -1.55, z: -0.86, goalkeeper: false },
+  { x: 1.55, z: -0.86, goalkeeper: false },
+  { x: 4.4, z: -0.76, goalkeeper: false },
+  { x: -4.85, z: -0.12, goalkeeper: false },
+  { x: -1.75, z: -0.18, goalkeeper: false },
+  { x: 1.75, z: -0.18, goalkeeper: false },
+  { x: 4.85, z: -0.12, goalkeeper: false },
+  { x: -1.95, z: 0.64, goalkeeper: false },
+  { x: 1.95, z: 0.72, goalkeeper: false },
+] as const;
+
+function SoccerPlayer({
+  position,
+  teamColor,
+  facing = 0,
+  goalkeeper = false,
+}: {
+  position: [number, number, number];
+  teamColor: string;
+  facing?: number;
+  goalkeeper?: boolean;
+}) {
+  const jerseyColor = goalkeeper ? teamColor : teamColor;
+  return (
+    <group position={position} rotation={[0, facing, 0]} scale={0.52}>
+      <mesh position={[0, 0.06, 0.018]} castShadow>
+        <sphereGeometry args={[0.052, 14, 14]} />
+        <meshStandardMaterial color="#f1c7a6" roughness={0.9} metalness={0.02} />
+      </mesh>
+      <mesh position={[0, -0.05, 0]} castShadow receiveShadow>
+        <capsuleGeometry args={[0.052, 0.18, 4, 10]} />
+        <meshStandardMaterial color={jerseyColor} roughness={0.72} metalness={0.08} />
+      </mesh>
+      <mesh position={[0, -0.17, 0.01]} castShadow receiveShadow>
+        <boxGeometry args={[0.14, 0.08, 0.08]} />
+        <meshStandardMaterial color="#f5f7fa" roughness={0.88} metalness={0.02} />
+      </mesh>
+      {([-0.038, 0.038] as const).map((x) => (
+        <mesh key={`leg-${x}`} position={[x, -0.26, 0.008]} castShadow>
+          <cylinderGeometry args={[0.016, 0.018, 0.12, 10]} />
+          <meshStandardMaterial color="#111827" roughness={0.94} metalness={0.02} />
+        </mesh>
+      ))}
+      {([-0.058, 0.058] as const).map((x) => (
+        <mesh key={`foot-${x}`} position={[x, -0.325, 0.03]} castShadow receiveShadow>
+          <boxGeometry args={[0.05, 0.025, 0.085]} />
+          <meshStandardMaterial color="#101214" roughness={0.9} metalness={0.02} />
+        </mesh>
+      ))}
+      {([-0.088, 0.088] as const).map((x) => (
+        <mesh key={`arm-${x}`} position={[x, -0.055, 0]} rotation={[0, 0, x < 0 ? 0.45 : -0.45]} castShadow>
+          <capsuleGeometry args={[0.013, 0.11, 4, 8]} />
+          <meshStandardMaterial color="#f1c7a6" roughness={0.9} metalness={0.02} />
+        </mesh>
+      ))}
+      {goalkeeper ? (
+        <mesh position={[0, -0.02, -0.05]} castShadow>
+          <boxGeometry args={[0.22, 0.03, 0.06]} />
+          <meshStandardMaterial color="#f8fafc" roughness={0.72} metalness={0.04} />
+        </mesh>
+      ) : null}
+    </group>
+  );
+}
+
+function GoalFrame({
+  position,
+  rotY = 0,
+}: {
+  position: [number, number, number];
+  rotY?: number;
+}) {
+  return (
+    <group position={position} rotation={[0, rotY, 0]}>
+      <mesh position={[-0.52, 0.34, 0]} castShadow>
+        <boxGeometry args={[0.05, 0.68, 0.05]} />
+        <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
+      </mesh>
+      <mesh position={[0.52, 0.34, 0]} castShadow>
+        <boxGeometry args={[0.05, 0.68, 0.05]} />
+        <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
+      </mesh>
+      <mesh position={[0, 0.66, 0]} castShadow>
+        <boxGeometry args={[1.09, 0.05, 0.05]} />
+        <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
+      </mesh>
+      <mesh position={[0, 0.3, -0.36]} receiveShadow>
+        <boxGeometry args={[1.02, 0.6, 0.02]} />
+        <meshStandardMaterial color="#dbeafe" transparent opacity={0.24} roughness={0.95} />
+      </mesh>
+      <mesh position={[-0.49, 0.3, -0.18]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
+        <boxGeometry args={[0.38, 0.6, 0.02]} />
+        <meshStandardMaterial color="#dbeafe" transparent opacity={0.18} roughness={0.95} />
+      </mesh>
+      <mesh position={[0.49, 0.3, -0.18]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
+        <boxGeometry args={[0.38, 0.6, 0.02]} />
+        <meshStandardMaterial color="#dbeafe" transparent opacity={0.18} roughness={0.95} />
+      </mesh>
+    </group>
+  );
+}
+
 export const FloorAndWalls = memo(function FloorAndWalls({
   showRemoteOffice = true,
 }: {
@@ -211,10 +322,24 @@ export const FloorAndWalls = memo(function FloorAndWalls({
   const localSouthWallZ = localOfficeCenterZ + localOfficeHeight / 2;
   const localWestWallX = localOfficeCenterX - localOfficeWidth / 2;
   const localEastWallX = localOfficeCenterX + localOfficeWidth / 2;
+  const stadiumCenterX = localOfficeCenterX;
+  const stadiumCenterZ = pathCenterZ;
+  const stadiumNorthEdgeZ = stadiumCenterZ - SOCCER_FIELD_DEPTH / 2;
+  const outdoorSouthEdgeZ = stadiumCenterZ + SOCCER_STADIUM_BASE_DEPTH / 2 + 0.92;
+  const localGroundCenterZ = (localNorthWallZ + outdoorSouthEdgeZ) / 2;
+  const localGroundHeight = outdoorSouthEdgeZ - localNorthWallZ;
+  const southWallWingWidth = Math.max(
+    0.8,
+    (localOfficeWidth - SOCCER_ENTRY_OPENING_WIDTH) / 2,
+  );
+  const southWallWingOffsetX = SOCCER_ENTRY_OPENING_WIDTH / 2 + southWallWingWidth / 2;
+  const pathEntryStartZ = localSouthWallZ + 0.14;
+  const entryPathLength = Math.max(0.42, stadiumNorthEdgeZ - pathEntryStartZ);
+  const entryPathCenterZ = pathEntryStartZ + entryPathLength / 2;
   const groundCenterX = showRemoteOffice ? districtCenterX : localOfficeCenterX;
-  const groundCenterZ = showRemoteOffice ? districtCenterZ : localOfficeCenterZ;
+  const groundCenterZ = showRemoteOffice ? districtCenterZ : localGroundCenterZ;
   const groundWidth = showRemoteOffice ? districtWidth : localOfficeWidth;
-  const groundHeight = showRemoteOffice ? districtHeight : localOfficeHeight;
+  const groundHeight = showRemoteOffice ? districtHeight : localGroundHeight;
 
   return (
     <group>
@@ -245,6 +370,254 @@ export const FloorAndWalls = memo(function FloorAndWalls({
         <meshLambertMaterial color="#c8a97e" />
       </mesh>
 
+      <mesh
+        position={[pathCenterX, 0.002, pathCenterZ]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
+        <planeGeometry
+          args={[
+            (CITY_PATH_ZONE.maxX - CITY_PATH_ZONE.minX) * SCALE,
+            (CITY_PATH_ZONE.maxY - CITY_PATH_ZONE.minY) * SCALE,
+          ]}
+        />
+        <meshStandardMaterial color="#6d8b5a" roughness={0.96} metalness={0.02} />
+      </mesh>
+
+      <mesh
+        position={[pathCenterX, 0.004, pathCenterZ]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
+        <planeGeometry
+          args={[
+            (CITY_PATH_ZONE.maxX - CITY_PATH_ZONE.minX) * SCALE * 0.72,
+            (CITY_PATH_ZONE.maxY - CITY_PATH_ZONE.minY) * SCALE * 0.26,
+          ]}
+        />
+        <meshStandardMaterial color="#c9ae8d" roughness={0.94} metalness={0.02} />
+      </mesh>
+
+      <mesh
+        position={[localOfficeCenterX, 0.008, entryPathCenterZ]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
+        <planeGeometry args={[SOCCER_ENTRY_PATH_WIDTH, entryPathLength]} />
+        <meshStandardMaterial color="#d8c09f" roughness={0.93} metalness={0.03} />
+      </mesh>
+
+      <mesh
+        position={[stadiumCenterX, 0.012, stadiumCenterZ]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
+        <planeGeometry args={[SOCCER_STADIUM_BASE_WIDTH, SOCCER_STADIUM_BASE_DEPTH]} />
+        <meshStandardMaterial color="#4b5563" roughness={0.84} metalness={0.1} />
+      </mesh>
+
+      <mesh
+        position={[stadiumCenterX, 0.016, stadiumCenterZ]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
+        <planeGeometry args={[SOCCER_FIELD_WIDTH, SOCCER_FIELD_DEPTH]} />
+        <meshStandardMaterial color="#2f8f46" roughness={0.94} metalness={0.02} />
+      </mesh>
+
+      {Array.from({ length: 7 }).map((_, index) => {
+        const stripeX =
+          stadiumCenterX - SOCCER_FIELD_WIDTH / 2 + (index + 0.5) * (SOCCER_FIELD_WIDTH / 7);
+        return (
+          <mesh
+            key={`soccer-stripe-${index}`}
+            position={[stripeX, 0.017, stadiumCenterZ]}
+            rotation={[-Math.PI / 2, 0, 0]}
+          >
+            <planeGeometry args={[SOCCER_FIELD_WIDTH / 7, SOCCER_FIELD_DEPTH]} />
+            <meshBasicMaterial color={index % 2 === 0 ? "#3c9b50" : "#2d8442"} />
+          </mesh>
+        );
+      })}
+
+      <mesh
+        position={[stadiumCenterX, 0.018, stadiumCenterZ]}
+        rotation={[-Math.PI / 2, 0, 0]}
+      >
+        <planeGeometry args={[SOCCER_FIELD_WIDTH, 0.06]} />
+        <meshBasicMaterial color="#f8fafc" />
+      </mesh>
+      <mesh
+        position={[stadiumCenterX, 0.018, stadiumCenterZ - SOCCER_FIELD_DEPTH / 2]}
+        rotation={[-Math.PI / 2, 0, 0]}
+      >
+        <planeGeometry args={[SOCCER_FIELD_WIDTH, 0.06]} />
+        <meshBasicMaterial color="#f8fafc" />
+      </mesh>
+      <mesh
+        position={[stadiumCenterX, 0.018, stadiumCenterZ + SOCCER_FIELD_DEPTH / 2]}
+        rotation={[-Math.PI / 2, 0, 0]}
+      >
+        <planeGeometry args={[SOCCER_FIELD_WIDTH, 0.06]} />
+        <meshBasicMaterial color="#f8fafc" />
+      </mesh>
+      <mesh
+        position={[stadiumCenterX - SOCCER_FIELD_WIDTH / 2, 0.018, stadiumCenterZ]}
+        rotation={[-Math.PI / 2, 0, Math.PI / 2]}
+      >
+        <planeGeometry args={[SOCCER_FIELD_DEPTH, 0.06]} />
+        <meshBasicMaterial color="#f8fafc" />
+      </mesh>
+      <mesh
+        position={[stadiumCenterX + SOCCER_FIELD_WIDTH / 2, 0.018, stadiumCenterZ]}
+        rotation={[-Math.PI / 2, 0, Math.PI / 2]}
+      >
+        <planeGeometry args={[SOCCER_FIELD_DEPTH, 0.06]} />
+        <meshBasicMaterial color="#f8fafc" />
+      </mesh>
+      <mesh position={[stadiumCenterX, 0.019, stadiumCenterZ]} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[0.54, 0.61, 32]} />
+        <meshBasicMaterial color="#f8fafc" side={2} />
+      </mesh>
+      <mesh position={[stadiumCenterX, 0.019, stadiumCenterZ]}>
+        <circleGeometry args={[0.06, 14]} />
+        <meshBasicMaterial color="#f8fafc" />
+      </mesh>
+      {[-1, 1].map((direction) => {
+        const boxZ = stadiumCenterZ + direction * (SOCCER_FIELD_DEPTH / 2 - 0.42);
+        const smallBoxZ = stadiumCenterZ + direction * (SOCCER_FIELD_DEPTH / 2 - 0.2);
+        return (
+          <group key={`soccer-boxes-${direction}`}>
+            <mesh position={[stadiumCenterX, 0.019, boxZ]} rotation={[-Math.PI / 2, 0, 0]}>
+              <ringGeometry args={[0.74, 0.8, 4, 1, -Math.PI / 4, Math.PI / 2]} />
+              <meshBasicMaterial color="#f8fafc" side={2} />
+            </mesh>
+            <mesh position={[stadiumCenterX, 0.018, boxZ]}>
+              <planeGeometry args={[4.2, 0.06]} />
+              <meshBasicMaterial color="#f8fafc" />
+            </mesh>
+            <mesh position={[stadiumCenterX - 2.1, 0.018, boxZ - direction * 0.37]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+              <planeGeometry args={[0.78, 0.06]} />
+              <meshBasicMaterial color="#f8fafc" />
+            </mesh>
+            <mesh position={[stadiumCenterX + 2.1, 0.018, boxZ - direction * 0.37]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+              <planeGeometry args={[0.78, 0.06]} />
+              <meshBasicMaterial color="#f8fafc" />
+            </mesh>
+            <mesh position={[stadiumCenterX, 0.018, smallBoxZ]}>
+              <planeGeometry args={[1.9, 0.06]} />
+              <meshBasicMaterial color="#f8fafc" />
+            </mesh>
+            <mesh position={[stadiumCenterX - 0.95, 0.018, smallBoxZ - direction * 0.18]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+              <planeGeometry args={[0.42, 0.06]} />
+              <meshBasicMaterial color="#f8fafc" />
+            </mesh>
+            <mesh position={[stadiumCenterX + 0.95, 0.018, smallBoxZ - direction * 0.18]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+              <planeGeometry args={[0.42, 0.06]} />
+              <meshBasicMaterial color="#f8fafc" />
+            </mesh>
+          </group>
+        );
+      })}
+
+      <GoalFrame position={[stadiumCenterX, 0.02, stadiumCenterZ - SOCCER_FIELD_DEPTH / 2 + 0.12]} />
+      <GoalFrame
+        position={[stadiumCenterX, 0.02, stadiumCenterZ + SOCCER_FIELD_DEPTH / 2 - 0.12]}
+        rotY={Math.PI}
+      />
+
+      {SOCCER_TEAM_SHAPE.map((player, index) => (
+        <SoccerPlayer
+          key={`blue-player-${index}`}
+          position={[stadiumCenterX + player.x, 0.24, stadiumCenterZ + player.z]}
+          teamColor="#2563eb"
+          facing={0}
+          goalkeeper={player.goalkeeper}
+        />
+      ))}
+      {SOCCER_TEAM_SHAPE.map((player, index) => (
+        <SoccerPlayer
+          key={`red-player-${index}`}
+          position={[stadiumCenterX + player.x, 0.24, stadiumCenterZ - player.z]}
+          teamColor="#dc2626"
+          facing={Math.PI}
+          goalkeeper={player.goalkeeper}
+        />
+      ))}
+
+      <mesh position={[stadiumCenterX + 0.28, 0.08, stadiumCenterZ + 0.04]} castShadow receiveShadow>
+        <sphereGeometry args={[0.07, 16, 16]} />
+        <meshStandardMaterial color="#ffffff" roughness={0.46} metalness={0.05} />
+      </mesh>
+      <mesh position={[stadiumCenterX + 0.28, 0.08, stadiumCenterZ + 0.04]}>
+        <torusGeometry args={[0.052, 0.008, 8, 10]} />
+        <meshStandardMaterial color="#111827" roughness={0.65} metalness={0.04} />
+      </mesh>
+
+      {[-1, 1].map((direction) => (
+        <group key={`stadium-stands-${direction}`}>
+          {[0, 1, 2].map((tier) => (
+            <mesh
+              key={`stand-${direction}-${tier}`}
+              position={[
+                stadiumCenterX,
+                0.17 + tier * 0.09,
+                stadiumCenterZ + direction * (SOCCER_FIELD_DEPTH / 2 + 0.42 + tier * 0.16),
+              ]}
+              castShadow
+              receiveShadow
+            >
+              <boxGeometry args={[SOCCER_FIELD_WIDTH - tier * 1.15, 0.08, 0.28]} />
+              <meshStandardMaterial color="#94a3b8" roughness={0.82} metalness={0.12} />
+            </mesh>
+          ))}
+        </group>
+      ))}
+
+      {[-1, 1].flatMap((zDirection) =>
+        [-1, 1].map((xDirection) => {
+          const lightX = stadiumCenterX + xDirection * (SOCCER_FIELD_WIDTH / 2 + 0.92);
+          const lightZ = stadiumCenterZ + zDirection * (SOCCER_FIELD_DEPTH / 2 + 0.64);
+          return (
+            <group key={`soccer-light-${zDirection}-${xDirection}`} position={[lightX, 0, lightZ]}>
+              <mesh position={[0, 0.92, 0]} castShadow>
+                <cylinderGeometry args={[0.05, 0.06, 1.84, 12]} />
+                <meshStandardMaterial color="#d1d5db" roughness={0.54} metalness={0.52} />
+              </mesh>
+              <mesh position={[0, 1.92, zDirection * -0.05]} castShadow>
+                <boxGeometry args={[0.42, 0.16, 0.12]} />
+                <meshStandardMaterial
+                  color="#fef3c7"
+                  emissive="#fde68a"
+                  emissiveIntensity={0.58}
+                  roughness={0.36}
+                  metalness={0.22}
+                />
+              </mesh>
+            </group>
+          );
+        }),
+      )}
+
+      <group position={[stadiumCenterX + SOCCER_FIELD_WIDTH / 2 + 1.28, 0, stadiumCenterZ]}>
+        <mesh position={[0, 1.02, 0]} castShadow>
+          <boxGeometry args={[0.22, 2.04, 0.22]} />
+          <meshStandardMaterial color="#475569" roughness={0.74} metalness={0.18} />
+        </mesh>
+        <mesh position={[0, 2.24, 0]} castShadow receiveShadow>
+          <boxGeometry args={[1.42, 0.82, 0.18]} />
+          <meshStandardMaterial color="#111827" roughness={0.58} metalness={0.22} />
+        </mesh>
+        <mesh position={[0, 2.4, 0.1]}>
+          <planeGeometry args={[1.1, 0.42]} />
+          <meshBasicMaterial color="#93c5fd" />
+        </mesh>
+        <mesh position={[0, 2.12, 0.1]}>
+          <planeGeometry args={[1.1, 0.18]} />
+          <meshBasicMaterial color="#ffffff" />
+        </mesh>
+      </group>
+
       {showRemoteOffice ? (
         <>
           <mesh
@@ -254,34 +627,6 @@ export const FloorAndWalls = memo(function FloorAndWalls({
           >
             <planeGeometry args={[localOfficeWidth, localOfficeHeight, 22, 14]} />
             <meshLambertMaterial color="#c8a97e" />
-          </mesh>
-
-          <mesh
-            position={[pathCenterX, 0.002, pathCenterZ]}
-            rotation={[-Math.PI / 2, 0, 0]}
-            receiveShadow
-          >
-            <planeGeometry
-              args={[
-                (CITY_PATH_ZONE.maxX - CITY_PATH_ZONE.minX) * SCALE,
-                (CITY_PATH_ZONE.maxY - CITY_PATH_ZONE.minY) * SCALE,
-              ]}
-            />
-            <meshStandardMaterial color="#6d8b5a" roughness={0.96} metalness={0.02} />
-          </mesh>
-
-          <mesh
-            position={[pathCenterX, 0.004, pathCenterZ]}
-            rotation={[-Math.PI / 2, 0, 0]}
-            receiveShadow
-          >
-            <planeGeometry
-              args={[
-                (CITY_PATH_ZONE.maxX - CITY_PATH_ZONE.minX) * SCALE * 0.72,
-                (CITY_PATH_ZONE.maxY - CITY_PATH_ZONE.minY) * SCALE * 0.26,
-              ]}
-            />
-            <meshStandardMaterial color="#c9ae8d" roughness={0.94} metalness={0.02} />
           </mesh>
 
           {Array.from({ length: 8 }).map((_, index) => {
@@ -561,15 +906,25 @@ export const FloorAndWalls = memo(function FloorAndWalls({
                 />
               </mesh>
             ) : null}
-            <mesh position={[localOfficeCenterX, 0.5, localSouthWallZ]} receiveShadow>
-              <boxGeometry args={[localOfficeWidth, 1, 0.12]} />
-              <meshStandardMaterial
-                color={wallColor}
-                emissive={wallEmissive}
-                emissiveIntensity={0.4}
-                roughness={0.9}
-              />
-            </mesh>
+            {([-1, 1] as const).map((direction) => (
+              <mesh
+                key={`local-south-wall-${direction}`}
+                position={[
+                  localOfficeCenterX + direction * southWallWingOffsetX,
+                  0.5,
+                  localSouthWallZ,
+                ]}
+                receiveShadow
+              >
+                <boxGeometry args={[southWallWingWidth, 1, 0.12]} />
+                <meshStandardMaterial
+                  color={wallColor}
+                  emissive={wallEmissive}
+                  emissiveIntensity={0.4}
+                  roughness={0.9}
+                />
+              </mesh>
+            ))}
             {showRemoteOffice ? (
               <mesh
                 position={[localOfficeCenterX, 0.5, localSouthWallZ + remoteOfficeOffsetZ]}
@@ -644,10 +999,19 @@ export const FloorAndWalls = memo(function FloorAndWalls({
           <meshLambertMaterial color="#0c0c10" />
         </mesh>
       ) : null}
-      <mesh position={[localOfficeCenterX, 0.03, localSouthWallZ - 0.04]}>
-        <boxGeometry args={[localOfficeWidth, 0.06, 0.04]} />
-        <meshLambertMaterial color="#0c0c10" />
-      </mesh>
+      {([-1, 1] as const).map((direction) => (
+        <mesh
+          key={`local-south-trim-${direction}`}
+          position={[
+            localOfficeCenterX + direction * southWallWingOffsetX,
+            0.03,
+            localSouthWallZ - 0.04,
+          ]}
+        >
+          <boxGeometry args={[southWallWingWidth, 0.06, 0.04]} />
+          <meshLambertMaterial color="#0c0c10" />
+        </mesh>
+      ))}
       {showRemoteOffice ? (
         <mesh position={[localOfficeCenterX, 0.03, localSouthWallZ - 0.04 + remoteOfficeOffsetZ]}>
           <boxGeometry args={[localOfficeWidth, 0.06, 0.04]} />

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -167,24 +167,24 @@ function OfficeFlagPole({
   );
 }
 
-const SOCCER_FIELD_WIDTH = 13.2;
-const SOCCER_FIELD_DEPTH = 3.1;
-const SOCCER_STADIUM_BASE_WIDTH = SOCCER_FIELD_WIDTH + 1.6;
-const SOCCER_STADIUM_BASE_DEPTH = SOCCER_FIELD_DEPTH + 1.3;
-const SOCCER_ENTRY_PATH_WIDTH = 1.24;
-const SOCCER_ENTRY_OPENING_WIDTH = 2.2;
+const SOCCER_FIELD_WIDTH = 20.8;
+const SOCCER_FIELD_DEPTH = 7.4;
+const SOCCER_STADIUM_BASE_WIDTH = SOCCER_FIELD_WIDTH + 2.6;
+const SOCCER_STADIUM_BASE_DEPTH = SOCCER_FIELD_DEPTH + 2.1;
+const SOCCER_ENTRY_PATH_WIDTH = 2.1;
+const SOCCER_ENTRY_OPENING_WIDTH = 3.8;
 const SOCCER_TEAM_SHAPE = [
-  { x: 0, z: -1.12, goalkeeper: true },
-  { x: -4.4, z: -0.76, goalkeeper: false },
-  { x: -1.55, z: -0.86, goalkeeper: false },
-  { x: 1.55, z: -0.86, goalkeeper: false },
-  { x: 4.4, z: -0.76, goalkeeper: false },
-  { x: -4.85, z: -0.12, goalkeeper: false },
-  { x: -1.75, z: -0.18, goalkeeper: false },
-  { x: 1.75, z: -0.18, goalkeeper: false },
-  { x: 4.85, z: -0.12, goalkeeper: false },
-  { x: -1.95, z: 0.64, goalkeeper: false },
-  { x: 1.95, z: 0.72, goalkeeper: false },
+  { x: 0, z: -2.72, goalkeeper: true },
+  { x: -6.9, z: -1.86, goalkeeper: false },
+  { x: -2.35, z: -2.02, goalkeeper: false },
+  { x: 2.35, z: -2.02, goalkeeper: false },
+  { x: 6.9, z: -1.86, goalkeeper: false },
+  { x: -7.7, z: -0.24, goalkeeper: false },
+  { x: -2.8, z: -0.3, goalkeeper: false },
+  { x: 2.8, z: -0.3, goalkeeper: false },
+  { x: 7.7, z: -0.24, goalkeeper: false },
+  { x: -3.05, z: 1.84, goalkeeper: false },
+  { x: 3.05, z: 1.98, goalkeeper: false },
 ] as const;
 
 function SoccerPlayer({
@@ -202,9 +202,9 @@ function SoccerPlayer({
   const shortColor = goalkeeper ? teamColor : "#f8fafc";
   const sockColor = goalkeeper ? "#111827" : teamColor;
   return (
-    <group position={position} rotation={[0, facing, 0]} scale={0.9}>
+    <group position={position} rotation={[0, facing, 0]} scale={1.75}>
       <mesh position={[0, 0.1, 0.028]} castShadow>
-        <sphereGeometry args={[0.078, 14, 14]} />
+        <sphereGeometry args={[0.078, 16, 16]} />
         <meshStandardMaterial color="#f1c7a6" roughness={0.9} metalness={0.02} />
       </mesh>
       <mesh position={[0, -0.035, 0]} castShadow receiveShadow>
@@ -261,28 +261,28 @@ function GoalFrame({
 }) {
   return (
     <group position={position} rotation={[0, rotY, 0]}>
-      <mesh position={[-0.52, 0.34, 0]} castShadow>
-        <boxGeometry args={[0.05, 0.68, 0.05]} />
+      <mesh position={[-1.08, 0.62, 0]} castShadow>
+        <boxGeometry args={[0.08, 1.24, 0.08]} />
         <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
       </mesh>
-      <mesh position={[0.52, 0.34, 0]} castShadow>
-        <boxGeometry args={[0.05, 0.68, 0.05]} />
+      <mesh position={[1.08, 0.62, 0]} castShadow>
+        <boxGeometry args={[0.08, 1.24, 0.08]} />
         <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
       </mesh>
-      <mesh position={[0, 0.66, 0]} castShadow>
-        <boxGeometry args={[1.09, 0.05, 0.05]} />
+      <mesh position={[0, 1.2, 0]} castShadow>
+        <boxGeometry args={[2.22, 0.08, 0.08]} />
         <meshStandardMaterial color="#f8fafc" roughness={0.7} metalness={0.14} />
       </mesh>
-      <mesh position={[0, 0.3, -0.36]} receiveShadow>
-        <boxGeometry args={[1.02, 0.6, 0.02]} />
+      <mesh position={[0, 0.54, -0.74]} receiveShadow>
+        <boxGeometry args={[2.1, 1.08, 0.03]} />
         <meshStandardMaterial color="#dbeafe" transparent opacity={0.24} roughness={0.95} />
       </mesh>
-      <mesh position={[-0.49, 0.3, -0.18]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
-        <boxGeometry args={[0.38, 0.6, 0.02]} />
+      <mesh position={[-1.02, 0.54, -0.37]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
+        <boxGeometry args={[0.76, 1.08, 0.03]} />
         <meshStandardMaterial color="#dbeafe" transparent opacity={0.18} roughness={0.95} />
       </mesh>
-      <mesh position={[0.49, 0.3, -0.18]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
-        <boxGeometry args={[0.38, 0.6, 0.02]} />
+      <mesh position={[1.02, 0.54, -0.37]} rotation={[0, Math.PI / 2, 0]} receiveShadow>
+        <boxGeometry args={[0.76, 1.08, 0.03]} />
         <meshStandardMaterial color="#dbeafe" transparent opacity={0.18} roughness={0.95} />
       </mesh>
     </group>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an outdoor soccer stadium directly south of the office scene
- connect the office to the stadium with a visible path and office-side exit opening
- populate the field with two full teams of 11 players, colored blue and red, with goalkeepers on each side
- scale the stadium up substantially so it reads as a full outdoor facility instead of a miniature pitch
- resize and reshape soccer players so they read in the same scale family as the office avatars
- improve player contrast and silhouettes so the teams are clearly visible in the 3D scene
- widen the default local office overview so the office and stadium are visible together

## Testing
- `npx eslint src/features/retro-office/scene/environment.tsx src/features/retro-office/RetroOffice3D.tsx`
- `npm run typecheck` *(currently fails due to pre-existing test prop type errors unrelated to this change)*
- manual visual verification of the current rendered scene in-browser

## Walkthrough artifacts
- Original wide office/stadium walkthrough: [soccer_stadium_office_walkthrough.mp4](https://cursor.com/agents/bc-c711e8b2-2d0c-50f1-b4bf-57f88811b8f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoccer_stadium_office_walkthrough.mp4)
- Close-up team screenshot: [Soccer stadium close-up with blue and red teams](https://cursor.com/agents/bc-c711e8b2-2d0c-50f1-b4bf-57f88811b8f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoccer_stadium_closeup.webp)
- Final scale verification screenshot: [Enlarged soccer stadium with avatar-sized players](https://cursor.com/agents/bc-c711e8b2-2d0c-50f1-b4bf-57f88811b8f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoccer_stadium_scale_fix.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://smartwayslogistics.slack.com/archives/D096DULCA7K/p1775006973111989?thread_ts=1775006973.111989&cid=D096DULCA7K)

<div><a href="https://cursor.com/agents/bc-c711e8b2-2d0c-50f1-b4bf-57f88811b8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c711e8b2-2d0c-50f1-b4bf-57f88811b8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

