### PR TITLE
feat: easter bunny agent avatars

### DIFF
--- a/src/features/retro-office/objects/agents.tsx
+++ b/src/features/retro-office/objects/agents.tsx
@@ -888,36 +888,36 @@ export const AgentModel = memo(function AgentModel({
         <boxGeometry args={[0.07, 0.05, 0.07]} />
         <meshLambertMaterial color={furColor} />
       </mesh>
-      <mesh position={[0, 0.475, 0]}>
-        <boxGeometry args={[0.16, 0.16, 0.14]} />
+      <mesh position={[0, 0.5, 0]}>
+        <boxGeometry args={[0.2, 0.18, 0.17]} />
         <meshLambertMaterial color={furColor} />
       </mesh>
-      <mesh position={[-0.048, 0.61, 0.01]} rotation={[0.08, 0, 0.06]}>
-        <boxGeometry args={[0.048, 0.17, 0.05]} />
+      <mesh position={[-0.062, 0.725, 0.012]} rotation={[0.05, 0, 0.12]}>
+        <boxGeometry args={[0.062, 0.28, 0.06]} />
         <meshLambertMaterial color={furColor} />
       </mesh>
-      <mesh position={[0.048, 0.61, 0.01]} rotation={[0.08, 0, -0.06]}>
-        <boxGeometry args={[0.048, 0.17, 0.05]} />
+      <mesh position={[0.062, 0.725, 0.012]} rotation={[0.05, 0, -0.12]}>
+        <boxGeometry args={[0.062, 0.28, 0.06]} />
         <meshLambertMaterial color={furColor} />
       </mesh>
-      <mesh position={[-0.048, 0.61, 0.038]} rotation={[0.08, 0, 0.06]}>
-        <boxGeometry args={[0.024, 0.14, 0.02]} />
-        <meshLambertMaterial color={earInnerColor} />
+      <mesh position={[-0.062, 0.725, 0.043]} rotation={[0.05, 0, 0.12]}>
+        <boxGeometry args={[0.028, 0.23, 0.02]} />
+        <meshLambertMaterial color="#f472b6" />
       </mesh>
-      <mesh position={[0.048, 0.61, 0.038]} rotation={[0.08, 0, -0.06]}>
-        <boxGeometry args={[0.024, 0.14, 0.02]} />
-        <meshLambertMaterial color={earInnerColor} />
+      <mesh position={[0.062, 0.725, 0.043]} rotation={[0.05, 0, -0.12]}>
+        <boxGeometry args={[0.028, 0.23, 0.02]} />
+        <meshLambertMaterial color="#f472b6" />
       </mesh>
-      <mesh position={[0, 0.442, 0.08]}>
-        <boxGeometry args={[0.075, 0.055, 0.03]} />
+      <mesh position={[0, 0.468, 0.098]}>
+        <boxGeometry args={[0.094, 0.07, 0.03]} />
         <meshLambertMaterial color="#fff7ed" />
       </mesh>
-      <mesh position={[-0.058, 0.458, 0.079]}>
-        <boxGeometry args={[0.024, 0.024, 0.01]} />
+      <mesh position={[-0.068, 0.485, 0.095]}>
+        <boxGeometry args={[0.03, 0.03, 0.012]} />
         <meshLambertMaterial color={earInnerColor} transparent opacity={0.35} />
       </mesh>
-      <mesh position={[0.058, 0.458, 0.079]}>
-        <boxGeometry args={[0.024, 0.024, 0.01]} />
+      <mesh position={[0.068, 0.485, 0.095]}>
+        <boxGeometry args={[0.03, 0.03, 0.012]} />
         <meshLambertMaterial color={earInnerColor} transparent opacity={0.35} />
       </mesh>
       <mesh ref={leftBrowRef} position={[-0.04, BUNNY_BROW_BASE_Y, BUNNY_BROW_BASE_Z]}>
@@ -944,7 +944,7 @@ export const AgentModel = memo(function AgentModel({
         <boxGeometry args={[0.008, 0.008, 0.01]} />
         <meshBasicMaterial color="#fff" />
       </mesh>
-      <mesh position={[0, 0.476, 0.104]}>
+      <mesh position={[0, 0.49, 0.115]}>
         <boxGeometry args={[0.022, 0.018, 0.012]} />
         <meshBasicMaterial color={noseColor} />
       </mesh>
@@ -968,8 +968,8 @@ export const AgentModel = memo(function AgentModel({
         <boxGeometry args={[0.014, 0.014, 0.01]} />
         <meshBasicMaterial color="#9c4a4a" />
       </mesh>
-      <mesh position={[0, 0.315, -0.065]}>
-        <sphereGeometry args={[0.034, 12, 12]} />
+      <mesh position={[0, 0.315, -0.075]}>
+        <sphereGeometry args={[0.042, 12, 12]} />
         <meshLambertMaterial color={furColor} />
       </mesh>
       <mesh

--- a/src/features/retro-office/objects/agents.tsx
+++ b/src/features/retro-office/objects/agents.tsx
@@ -15,6 +15,13 @@ import type {
 import { AgentModelProps } from "@/features/retro-office/objects/types";
 
 const MAX_NAMEPLATE_TEXT_LENGTH = 10;
+const BUNNY_EYE_BASE_Y = 0.502;
+const BUNNY_EYE_BASE_Z = 0.1;
+const BUNNY_HIGHLIGHT_BASE_Y = 0.51;
+const BUNNY_MOUTH_BASE_Y = 0.462;
+const BUNNY_MOUTH_BASE_Z = 0.101;
+const BUNNY_BROW_BASE_Y = 0.548;
+const BUNNY_BROW_BASE_Z = 0.1;
 
 const formatAgentNameplateText = (value: string): string => {
   const normalized = value.replace(/\s+/g, " ").trim();
@@ -374,33 +381,35 @@ export const AgentModel = memo(function AgentModel({
       if (!eyeRef.current) continue;
       eyeRef.current.scale.x = eyeScaleX;
       eyeRef.current.scale.y = eyeScaleY;
-      eyeRef.current.position.y = 0.475 + eyeOffsetY;
+      eyeRef.current.position.y = BUNNY_EYE_BASE_Y + eyeOffsetY;
+      eyeRef.current.position.z = BUNNY_EYE_BASE_Z;
     }
     for (const highlightRef of [leftEyeHighlightRef, rightEyeHighlightRef]) {
       if (!highlightRef.current) continue;
       highlightRef.current.visible = eyeOpen > 0.45 && !isAway;
-      highlightRef.current.position.y = 0.482 + eyeOffsetY;
+      highlightRef.current.position.y = BUNNY_HIGHLIGHT_BASE_Y + eyeOffsetY;
+      highlightRef.current.position.z = BUNNY_EYE_BASE_Z + 0.002;
     }
 
     if (mouthRef.current) {
       mouthRef.current.rotation.z = 0;
-      mouthRef.current.position.set(0, 0.436, 0.074);
+      mouthRef.current.position.set(0, BUNNY_MOUTH_BASE_Y, BUNNY_MOUTH_BASE_Z);
       if (isAway) {
         mouthRef.current.scale.set(0.5, 0.12, 1);
-        mouthRef.current.position.y = 0.434;
+        mouthRef.current.position.y = BUNNY_MOUTH_BASE_Y - 0.01;
       } else if (isError) {
         mouthRef.current.scale.set(1.28, 0.16, 1);
-        mouthRef.current.position.y = 0.43;
+        mouthRef.current.position.y = BUNNY_MOUTH_BASE_Y - 0.014;
       } else if (working) {
         mouthRef.current.scale.set(0.92, 0.14, 1);
-        mouthRef.current.position.y = 0.437;
+        mouthRef.current.position.y = BUNNY_MOUTH_BASE_Y - 0.008;
       } else if (agent.state === "walking") {
         const talkPulse =
           0.38 + (Math.sin(agent.frame * 0.14 + blinkSeed) + 1) * 0.22;
         mouthRef.current.scale.set(0.95, talkPulse, 1);
       } else {
         mouthRef.current.scale.set(1.35, 0.34, 1);
-        mouthRef.current.position.y = 0.428;
+        mouthRef.current.position.y = BUNNY_MOUTH_BASE_Y - 0.018;
       }
     }
 
@@ -411,42 +420,52 @@ export const AgentModel = memo(function AgentModel({
       leftMouthCornerRef.current.visible = showSmileCorners || showFrownCorners;
       rightMouthCornerRef.current.visible =
         showSmileCorners || showFrownCorners;
-      leftMouthCornerRef.current.position.set(-0.031, 0.434, 0.074);
-      rightMouthCornerRef.current.position.set(0.031, 0.434, 0.074);
+      leftMouthCornerRef.current.position.set(
+        -0.028,
+        BUNNY_MOUTH_BASE_Y - 0.022,
+        BUNNY_MOUTH_BASE_Z,
+      );
+      rightMouthCornerRef.current.position.set(
+        0.028,
+        BUNNY_MOUTH_BASE_Y - 0.022,
+        BUNNY_MOUTH_BASE_Z,
+      );
       if (showFrownCorners) {
         leftMouthCornerRef.current.rotation.z = -0.6;
         rightMouthCornerRef.current.rotation.z = 0.6;
-        leftMouthCornerRef.current.position.y = 0.425;
-        rightMouthCornerRef.current.position.y = 0.425;
+        leftMouthCornerRef.current.position.y = BUNNY_MOUTH_BASE_Y - 0.03;
+        rightMouthCornerRef.current.position.y = BUNNY_MOUTH_BASE_Y - 0.03;
       } else if (showSmileCorners) {
         leftMouthCornerRef.current.rotation.z = 0.62;
         rightMouthCornerRef.current.rotation.z = -0.62;
-        leftMouthCornerRef.current.position.y = 0.438;
-        rightMouthCornerRef.current.position.y = 0.438;
+        leftMouthCornerRef.current.position.y = BUNNY_MOUTH_BASE_Y - 0.016;
+        rightMouthCornerRef.current.position.y = BUNNY_MOUTH_BASE_Y - 0.016;
       }
     }
 
     if (leftBrowRef.current && rightBrowRef.current) {
-      leftBrowRef.current.position.y = 0.52;
-      rightBrowRef.current.position.y = 0.52;
+      leftBrowRef.current.position.y = BUNNY_BROW_BASE_Y;
+      rightBrowRef.current.position.y = BUNNY_BROW_BASE_Y;
+      leftBrowRef.current.position.z = BUNNY_BROW_BASE_Z;
+      rightBrowRef.current.position.z = BUNNY_BROW_BASE_Z;
       if (isAway) {
         leftBrowRef.current.rotation.z = -0.24;
         rightBrowRef.current.rotation.z = 0.24;
-        leftBrowRef.current.position.y = 0.512;
-        rightBrowRef.current.position.y = 0.512;
+        leftBrowRef.current.position.y = BUNNY_BROW_BASE_Y - 0.008;
+        rightBrowRef.current.position.y = BUNNY_BROW_BASE_Y - 0.008;
       } else if (isError) {
         leftBrowRef.current.rotation.z = 0.42;
         rightBrowRef.current.rotation.z = -0.42;
-        leftBrowRef.current.position.y = 0.516;
-        rightBrowRef.current.position.y = 0.516;
+        leftBrowRef.current.position.y = BUNNY_BROW_BASE_Y - 0.004;
+        rightBrowRef.current.position.y = BUNNY_BROW_BASE_Y - 0.004;
       } else if (working) {
         leftBrowRef.current.rotation.z = 0.3;
         rightBrowRef.current.rotation.z = -0.3;
       } else {
         leftBrowRef.current.rotation.z = -0.18;
         rightBrowRef.current.rotation.z = 0.18;
-        leftBrowRef.current.position.y = 0.526;
-        rightBrowRef.current.position.y = 0.526;
+        leftBrowRef.current.position.y = BUNNY_BROW_BASE_Y + 0.006;
+        rightBrowRef.current.position.y = BUNNY_BROW_BASE_Y + 0.006;
       }
     }
 
@@ -546,44 +565,16 @@ export const AgentModel = memo(function AgentModel({
   const topColor = resolvedAppearance.clothing.topColor;
   const trouserColor = resolvedAppearance.clothing.bottomColor;
   const shoeColor = resolvedAppearance.clothing.shoesColor;
-  const hairColor = resolvedAppearance.hair.color;
-  const hairStyle = resolvedAppearance.hair.style;
   const topStyle = resolvedAppearance.clothing.topStyle;
   const bottomStyle = resolvedAppearance.clothing.bottomStyle;
-  const hatStyle = resolvedAppearance.accessories.hatStyle;
-  const showGlasses = resolvedAppearance.accessories.glasses;
-  const showHeadset = resolvedAppearance.accessories.headset;
   const showBackpack = resolvedAppearance.accessories.backpack;
   const accessoryColor = topColor;
+  const furColor = `#${new THREE.Color(skin).lerp(new THREE.Color("#fffaf0"), 0.45).getHexString()}`;
+  const earInnerColor = `#${new THREE.Color(topColor).lerp(new THREE.Color("#f9a8d4"), 0.55).getHexString()}`;
+  const noseColor = `#${new THREE.Color(topColor).lerp(new THREE.Color("#fb7185"), 0.65).getHexString()}`;
   const sleeveColor = topStyle === "jacket" ? "#dbe4ff" : topColor;
   const cuffColor = topStyle === "hoodie" ? "#d1d5db" : sleeveColor;
   const topAccentColor = topStyle === "jacket" ? "#1f2937" : cuffColor;
-
-  const faceTexture = useMemo(() => {
-    const canvas = document.createElement("canvas");
-    canvas.width = 64;
-    canvas.height = 64;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return new THREE.CanvasTexture(canvas);
-
-    ctx.fillStyle = skin;
-    ctx.fillRect(0, 0, 64, 64);
-    ctx.fillStyle = "rgba(255,255,255,0.14)";
-    ctx.fillRect(0, 0, 64, 10);
-    ctx.fillStyle = "rgba(196,122,84,0.18)";
-    ctx.beginPath();
-    ctx.arc(18, 38, 7, 0, Math.PI * 2);
-    ctx.arc(46, 38, 7, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.fillStyle = "#d8a06e";
-    ctx.fillRect(30, 28, 4, 10);
-    ctx.fillRect(29, 37, 6, 2);
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.colorSpace = THREE.SRGBColorSpace;
-    texture.needsUpdate = true;
-    return texture;
-  }, [skin]);
 
   const resolvedSpeechText =
     showSpeech && speechText?.trim()
@@ -895,152 +886,75 @@ export const AgentModel = memo(function AgentModel({
       </group>
       <mesh position={[0, 0.39, 0]}>
         <boxGeometry args={[0.07, 0.05, 0.07]} />
-        <meshLambertMaterial color={skin} />
+        <meshLambertMaterial color={furColor} />
       </mesh>
-      <mesh position={[0, 0.47, 0]}>
+      <mesh position={[0, 0.475, 0]}>
         <boxGeometry args={[0.16, 0.16, 0.14]} />
-        <meshLambertMaterial attach="material-0" color={skin} />
-        <meshLambertMaterial attach="material-1" color={skin} />
-        <meshLambertMaterial attach="material-2" color={skin} />
-        <meshLambertMaterial attach="material-3" color={skin} />
-        <meshLambertMaterial attach="material-4" map={faceTexture} />
-        <meshLambertMaterial attach="material-5" color={skin} />
+        <meshLambertMaterial color={furColor} />
       </mesh>
-      {hairStyle === "short" ? (
-        <mesh position={[0, 0.555, 0]}>
-          <boxGeometry args={[0.17, 0.05, 0.15]} />
-          <meshLambertMaterial color={hairColor} />
-        </mesh>
-      ) : null}
-      {hairStyle === "parted" ? (
-        <>
-          <mesh position={[0, 0.555, 0]}>
-            <boxGeometry args={[0.17, 0.045, 0.15]} />
-            <meshLambertMaterial color={hairColor} />
-          </mesh>
-          <mesh position={[-0.035, 0.59, 0.01]} rotation={[0.1, 0, -0.2]}>
-            <boxGeometry args={[0.12, 0.03, 0.08]} />
-            <meshLambertMaterial color={hairColor} />
-          </mesh>
-        </>
-      ) : null}
-      {hairStyle === "spiky" ? (
-        <>
-          <mesh position={[0, 0.55, 0]}>
-            <boxGeometry args={[0.16, 0.035, 0.14]} />
-            <meshLambertMaterial color={hairColor} />
-          </mesh>
-          <mesh position={[-0.05, 0.59, 0]} rotation={[0, 0, -0.2]}>
-            <boxGeometry args={[0.04, 0.06, 0.04]} />
-            <meshLambertMaterial color={hairColor} />
-          </mesh>
-          <mesh position={[0, 0.605, 0]} rotation={[0, 0, 0]}>
-            <boxGeometry args={[0.04, 0.08, 0.04]} />
-            <meshLambertMaterial color={hairColor} />
-          </mesh>
-          <mesh position={[0.05, 0.59, 0]} rotation={[0, 0, 0.2]}>
-            <boxGeometry args={[0.04, 0.06, 0.04]} />
-            <meshLambertMaterial color={hairColor} />
-          </mesh>
-        </>
-      ) : null}
-      {hairStyle === "bun" ? (
-        <>
-          <mesh position={[0, 0.548, 0]}>
-            <boxGeometry args={[0.17, 0.04, 0.15]} />
-            <meshLambertMaterial color={hairColor} />
-          </mesh>
-          <mesh position={[0, 0.6, -0.035]}>
-            <sphereGeometry args={[0.042, 14, 14]} />
-            <meshLambertMaterial color={hairColor} />
-          </mesh>
-        </>
-      ) : null}
-      {hatStyle === "cap" ? (
-        <>
-          <mesh position={[0, 0.59, 0]}>
-            <boxGeometry args={[0.172, 0.03, 0.152]} />
-            <meshLambertMaterial color={accessoryColor} />
-          </mesh>
-          <mesh position={[0, 0.575, 0.07]}>
-            <boxGeometry args={[0.09, 0.012, 0.05]} />
-            <meshLambertMaterial color={accessoryColor} />
-          </mesh>
-        </>
-      ) : null}
-      {hatStyle === "beanie" ? (
-        <mesh position={[0, 0.59, 0]}>
-          <boxGeometry args={[0.18, 0.06, 0.16]} />
-          <meshLambertMaterial color={accessoryColor} />
-        </mesh>
-      ) : null}
-      {showHeadset ? (
-        <>
-          <mesh position={[0, 0.57, 0]} rotation={[0, 0, Math.PI / 2]}>
-            <torusGeometry args={[0.09, 0.008, 8, 24, Math.PI]} />
-            <meshLambertMaterial color="#94a3b8" />
-          </mesh>
-          <mesh position={[-0.1, 0.48, 0]}>
-            <boxGeometry args={[0.018, 0.05, 0.028]} />
-            <meshLambertMaterial color="#475569" />
-          </mesh>
-          <mesh position={[0.1, 0.48, 0]}>
-            <boxGeometry args={[0.018, 0.05, 0.028]} />
-            <meshLambertMaterial color="#475569" />
-          </mesh>
-          <mesh position={[0.085, 0.43, 0.06]} rotation={[0.25, 0.25, -0.4]}>
-            <boxGeometry args={[0.012, 0.06, 0.012]} />
-            <meshLambertMaterial color="#94a3b8" />
-          </mesh>
-        </>
-      ) : null}
-      <mesh ref={leftBrowRef} position={[-0.04, 0.52, 0.074]}>
+      <mesh position={[-0.048, 0.61, 0.01]} rotation={[0.08, 0, 0.06]}>
+        <boxGeometry args={[0.048, 0.17, 0.05]} />
+        <meshLambertMaterial color={furColor} />
+      </mesh>
+      <mesh position={[0.048, 0.61, 0.01]} rotation={[0.08, 0, -0.06]}>
+        <boxGeometry args={[0.048, 0.17, 0.05]} />
+        <meshLambertMaterial color={furColor} />
+      </mesh>
+      <mesh position={[-0.048, 0.61, 0.038]} rotation={[0.08, 0, 0.06]}>
+        <boxGeometry args={[0.024, 0.14, 0.02]} />
+        <meshLambertMaterial color={earInnerColor} />
+      </mesh>
+      <mesh position={[0.048, 0.61, 0.038]} rotation={[0.08, 0, -0.06]}>
+        <boxGeometry args={[0.024, 0.14, 0.02]} />
+        <meshLambertMaterial color={earInnerColor} />
+      </mesh>
+      <mesh position={[0, 0.442, 0.08]}>
+        <boxGeometry args={[0.075, 0.055, 0.03]} />
+        <meshLambertMaterial color="#fff7ed" />
+      </mesh>
+      <mesh position={[-0.058, 0.458, 0.079]}>
+        <boxGeometry args={[0.024, 0.024, 0.01]} />
+        <meshLambertMaterial color={earInnerColor} transparent opacity={0.35} />
+      </mesh>
+      <mesh position={[0.058, 0.458, 0.079]}>
+        <boxGeometry args={[0.024, 0.024, 0.01]} />
+        <meshLambertMaterial color={earInnerColor} transparent opacity={0.35} />
+      </mesh>
+      <mesh ref={leftBrowRef} position={[-0.04, BUNNY_BROW_BASE_Y, BUNNY_BROW_BASE_Z]}>
         <boxGeometry args={[0.04, 0.01, 0.01]} />
         <meshBasicMaterial color="#342016" />
       </mesh>
-      <mesh ref={rightBrowRef} position={[0.04, 0.52, 0.074]}>
+      <mesh ref={rightBrowRef} position={[0.04, BUNNY_BROW_BASE_Y, BUNNY_BROW_BASE_Z]}>
         <boxGeometry args={[0.04, 0.01, 0.01]} />
         <meshBasicMaterial color="#342016" />
       </mesh>
-      <mesh ref={leftEyeRef} position={[-0.04, 0.475, 0.072]}>
-        <boxGeometry args={[0.03, 0.03, 0.01]} />
+      <mesh ref={leftEyeRef} position={[-0.04, BUNNY_EYE_BASE_Y, BUNNY_EYE_BASE_Z]}>
+        <boxGeometry args={[0.028, 0.032, 0.01]} />
         <meshBasicMaterial color="#1a1a2e" />
       </mesh>
-      <mesh ref={rightEyeRef} position={[0.04, 0.475, 0.072]}>
-        <boxGeometry args={[0.03, 0.03, 0.01]} />
+      <mesh ref={rightEyeRef} position={[0.04, BUNNY_EYE_BASE_Y, BUNNY_EYE_BASE_Z]}>
+        <boxGeometry args={[0.028, 0.032, 0.01]} />
         <meshBasicMaterial color="#1a1a2e" />
       </mesh>
-      <mesh ref={leftEyeHighlightRef} position={[-0.03, 0.482, 0.074]}>
+      <mesh ref={leftEyeHighlightRef} position={[-0.032, BUNNY_HIGHLIGHT_BASE_Y, BUNNY_BROW_BASE_Z]}>
         <boxGeometry args={[0.008, 0.008, 0.01]} />
         <meshBasicMaterial color="#fff" />
       </mesh>
-      <mesh ref={rightEyeHighlightRef} position={[0.05, 0.482, 0.074]}>
+      <mesh ref={rightEyeHighlightRef} position={[0.048, BUNNY_HIGHLIGHT_BASE_Y, BUNNY_BROW_BASE_Z]}>
         <boxGeometry args={[0.008, 0.008, 0.01]} />
         <meshBasicMaterial color="#fff" />
       </mesh>
-      {showGlasses ? (
-        <>
-          <mesh position={[-0.04, 0.475, 0.078]}>
-            <boxGeometry args={[0.05, 0.05, 0.01]} />
-            <meshBasicMaterial color="#111827" wireframe />
-          </mesh>
-          <mesh position={[0.04, 0.475, 0.078]}>
-            <boxGeometry args={[0.05, 0.05, 0.01]} />
-            <meshBasicMaterial color="#111827" wireframe />
-          </mesh>
-          <mesh position={[0, 0.475, 0.078]}>
-            <boxGeometry args={[0.02, 0.008, 0.01]} />
-            <meshBasicMaterial color="#111827" />
-          </mesh>
-        </>
-      ) : null}
-      <mesh ref={mouthRef} position={[0, 0.436, 0.074]}>
-        <boxGeometry args={[0.05, 0.014, 0.01]} />
+      <mesh position={[0, 0.476, 0.104]}>
+        <boxGeometry args={[0.022, 0.018, 0.012]} />
+        <meshBasicMaterial color={noseColor} />
+      </mesh>
+      <mesh ref={mouthRef} position={[0, BUNNY_MOUTH_BASE_Y, BUNNY_MOUTH_BASE_Z]}>
+        <boxGeometry args={[0.05, 0.012, 0.01]} />
         <meshBasicMaterial color="#9c4a4a" />
       </mesh>
       <mesh
         ref={leftMouthCornerRef}
-        position={[-0.031, 0.438, 0.074]}
+        position={[-0.031, BUNNY_MOUTH_BASE_Y + 0.002, BUNNY_MOUTH_BASE_Z]}
         visible={false}
       >
         <boxGeometry args={[0.014, 0.014, 0.01]} />
@@ -1048,11 +962,15 @@ export const AgentModel = memo(function AgentModel({
       </mesh>
       <mesh
         ref={rightMouthCornerRef}
-        position={[0.031, 0.438, 0.074]}
+        position={[0.031, BUNNY_MOUTH_BASE_Y + 0.002, BUNNY_MOUTH_BASE_Z]}
         visible={false}
       >
         <boxGeometry args={[0.014, 0.014, 0.01]} />
         <meshBasicMaterial color="#9c4a4a" />
+      </mesh>
+      <mesh position={[0, 0.315, -0.065]}>
+        <sphereGeometry args={[0.034, 12, 12]} />
+        <meshLambertMaterial color={furColor} />
       </mesh>
       <mesh
         ref={pulseRingRef}

--- a/src/lib/avatars/multiavatar.ts
+++ b/src/lib/avatars/multiavatar.ts
@@ -1,31 +1,31 @@
-const AVATAR_PALETTE = [
-  "#1d4ed8",
-  "#0f766e",
-  "#7c3aed",
-  "#c2410c",
-  "#be123c",
-  "#4f46e5",
-  "#0f172a",
-  "#1f2937",
-] as const;
-
-const AVATAR_ACCENTS = [
-  "#bfdbfe",
-  "#99f6e4",
-  "#ddd6fe",
-  "#fed7aa",
-  "#fecdd3",
-  "#c7d2fe",
-  "#cbd5e1",
+const AVATAR_BACKGROUNDS = [
+  "#67e8f9",
+  "#a7f3d0",
+  "#fbcfe8",
   "#fde68a",
+  "#c4b5fd",
+  "#fdba74",
+  "#93c5fd",
+  "#f9a8d4",
 ] as const;
 
-const AVATAR_FOREGROUNDS = [
-  "#eff6ff",
+const AVATAR_EAR_INNERS = [
+  "#f472b6",
+  "#fb7185",
+  "#f9a8d4",
+  "#fda4af",
+] as const;
+
+const AVATAR_FUR = [
+  "#ffffff",
   "#f8fafc",
-  "#fefce8",
+  "#fef2f2",
   "#fdf4ff",
 ] as const;
+
+const AVATAR_EYE_COLORS = ["#1f2937", "#0f172a", "#3f3f46"] as const;
+
+const AVATAR_NOSE_COLORS = ["#f43f5e", "#ec4899", "#fb7185"] as const;
 
 const hashSeed = (seed: string) => {
   let hash = 2166136261;
@@ -56,24 +56,39 @@ export const buildAvatarSvg = (seed: string): string => {
   }
 
   const hash = hashSeed(trimmed);
-  const background = pick(AVATAR_PALETTE, hash);
-  const accent = pick(AVATAR_ACCENTS, hash >>> 3);
-  const foreground = pick(AVATAR_FOREGROUNDS, hash >>> 5);
+  const background = pick(AVATAR_BACKGROUNDS, hash);
+  const earInner = pick(AVATAR_EAR_INNERS, hash >>> 2);
+  const fur = pick(AVATAR_FUR, hash >>> 4);
+  const eye = pick(AVATAR_EYE_COLORS, hash >>> 7);
+  const nose = pick(AVATAR_NOSE_COLORS, hash >>> 9);
   const label = buildAvatarLabel(trimmed);
-  const offsetA = 16 + (hash % 28);
-  const offsetB = 68 - ((hash >>> 7) % 24);
-  const radius = 12 + ((hash >>> 11) % 10);
-  const tilt = ((hash >>> 13) % 20) - 10;
+  const leftEarTilt = 10 + ((hash >>> 11) % 13);
+  const rightEarTilt = 10 + ((hash >>> 14) % 13);
+  const blinkHeight = 4 + ((hash >>> 17) % 3);
+  const cheekOffset = 13 + ((hash >>> 19) % 4);
+  const whiskerLift = (hash >>> 21) % 3;
 
   return [
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" role="img" aria-label="${label} avatar">`,
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" role="img" aria-label="${label} bunny avatar" data-bunny="true">`,
     `<rect width="80" height="80" rx="18" fill="${background}"/>`,
-    `<circle cx="${offsetA}" cy="18" r="${radius}" fill="${accent}" opacity="0.65"/>`,
-    `<circle cx="${offsetB}" cy="66" r="${radius + 4}" fill="${accent}" opacity="0.42"/>`,
-    `<path d="M10 60 Q40 ${44 + tilt} 70 22 L70 80 L10 80 Z" fill="${foreground}" opacity="0.14"/>`,
-    `<circle cx="40" cy="32" r="16" fill="${foreground}" opacity="0.92"/>`,
-    `<path d="M20 72c4-12 14-18 20-18s16 6 20 18" fill="${foreground}" opacity="0.92"/>`,
-    `<text x="40" y="37" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="${background}">${label}</text>`,
+    `<circle cx="16" cy="14" r="7" fill="#ffffff" opacity="0.22"/>`,
+    `<circle cx="66" cy="64" r="9" fill="#ffffff" opacity="0.18"/>`,
+    `<path d="M28 38 C${26 - leftEarTilt * 0.18} 22, ${26 - leftEarTilt * 0.08} 10, 32 6 C36 10, 35 23, 34 38 Z" fill="${fur}"/>`,
+    `<path d="M28 34 C${27 - leftEarTilt * 0.12} 23, 28 15, 31.5 11 C34 14, 33 23, 32 34 Z" fill="${earInner}" opacity="0.95"/>`,
+    `<path d="M52 38 C${54 + rightEarTilt * 0.18} 22, ${54 + rightEarTilt * 0.08} 10, 48 6 C44 10, 45 23, 46 38 Z" fill="${fur}"/>`,
+    `<path d="M52 34 C${53 + rightEarTilt * 0.12} 23, 52 15, 48.5 11 C46 14, 47 23, 48 34 Z" fill="${earInner}" opacity="0.95"/>`,
+    `<ellipse cx="40" cy="45" rx="21" ry="20" fill="${fur}"/>`,
+    `<ellipse cx="40" cy="57" rx="15" ry="11" fill="#ffffff" opacity="0.56"/>`,
+    `<ellipse cx="33" cy="44" rx="3" ry="${blinkHeight}" fill="${eye}"/>`,
+    `<ellipse cx="47" cy="44" rx="3" ry="${blinkHeight}" fill="${eye}"/>`,
+    `<circle cx="${40 - cheekOffset}" cy="52" r="3.2" fill="${earInner}" opacity="0.4"/>`,
+    `<circle cx="${40 + cheekOffset}" cy="52" r="3.2" fill="${earInner}" opacity="0.4"/>`,
+    `<path d="M40 49 l4 4 l-4 3.2 l-4 -3.2 Z" fill="${nose}"/>`,
+    `<path d="M40 55 v4" stroke="#7f1d1d" stroke-width="1.6" stroke-linecap="round"/>`,
+    `<path d="M40 59 c-3.4 0 -5.6 1.4 -6.7 3.6" stroke="#7f1d1d" stroke-width="1.6" fill="none" stroke-linecap="round"/>`,
+    `<path d="M40 59 c3.4 0 5.6 1.4 6.7 3.6" stroke="#7f1d1d" stroke-width="1.6" fill="none" stroke-linecap="round"/>`,
+    `<path d="M27 ${54 - whiskerLift} H20 M27 ${58 - whiskerLift} H19 M53 ${54 - whiskerLift} H60 M53 ${58 - whiskerLift} H61" stroke="#9f1239" stroke-width="1.2" stroke-linecap="round" opacity="0.8"/>`,
+    `<text x="40" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" font-weight="700" fill="${eye}" opacity="0.9">${label}</text>`,
     `</svg>`,
   ].join("");
 };

--- a/tests/unit/multiavatar.test.ts
+++ b/tests/unit/multiavatar.test.ts
@@ -8,6 +8,8 @@ describe("multiavatar helpers", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
     expect(svg).toContain("AA");
+    expect(svg).toContain("bunny avatar");
+    expect(svg).toContain('data-bunny="true"');
   });
 
   it("buildAvatarDataUrl returns a data url", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace generated agent avatar SVGs with deterministic bunny-themed avatars for Easter.
- Update retro-office animated 3D agent models to bunny characters (prominent ears, bunny face accents, and tail).
- Keep seed-based variation and initials where seed SVG avatars are used.
- Add unit test coverage for bunny avatar markers in SVG output.

## Testing
- ✅ `npm run test -- tests/unit/multiavatar.test.ts`
- ✅ `npm run typecheck`
- ✅ Manual UI validation in Office scene with refreshed code and connected demo gateway.

## Walkthrough
[easter_bunny_office_agents_3d_demo.mp4](https://cursor.com/agents/bc-18666c9d-382c-450a-a124-50ee97446575/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feaster_bunny_office_agents_3d_demo.mp4)
[Bunny agents in 3D office scene](https://cursor.com/agents/bc-18666c9d-382c-450a-a124-50ee97446575/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbunny_office_agents_3d.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18666c9d-382c-450a-a124-50ee97446575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18666c9d-382c-450a-a124-50ee97446575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

