### PR TITLE
[FEAT] Claw3Doctor v1.0 diagnostics and align the runtime roadmap

### DIFF
--- a/docs/integrations/claw3doctor-spec.md
+++ b/docs/integrations/claw3doctor-spec.md
@@ -1,0 +1,245 @@
+# Claw3Doctor Spec
+
+> First-pass diagnostics plan for Claw3D deployments so users stop chasing the same setup failures manually.
+
+## Goal
+
+Provide a single diagnostics surface for the common "Claw3D cannot connect"
+or "runtime support looks broken" cases.
+
+The intent is similar to:
+
+- `openclaw doctor`
+- `hermes doctor`
+
+but focused on Claw3D's integration points across providers.
+
+## Primary Outcomes
+
+`claw3doctor` should:
+
+- identify the selected runtime profile/provider
+- verify the gateway is reachable
+- identify common auth/config mistakes
+- surface provider-specific hints without making the whole app provider-specific
+- reduce issue-thread back-and-forth
+
+## First-Pass Scope
+
+### Claw3D Settings / Environment
+
+Checks:
+
+- current runtime profile selection
+- gateway URL presence
+- token presence when required
+- adapter/provider selection
+- obvious `.env` misconfiguration
+
+Outputs:
+
+- selected provider/profile
+- missing env or token warnings
+- suspicious profile precedence warnings
+
+### Gateway Reachability
+
+Checks:
+
+- can the configured gateway URL be reached?
+- can Studio proxy the selected gateway?
+- does the endpoint respond like a Claw3D-compatible gateway?
+
+Outputs:
+
+- reachable / unreachable
+- timeout / refused / bad handshake
+- wrong backend contract warning
+
+### OpenClaw Checks
+
+Checks:
+
+- OpenClaw version
+- pairing/device-approval state hints
+- common remote secure-context failures
+- common `1008`, `1011`, `1012` patterns
+
+Outputs:
+
+- version found / not found
+- device approval guidance
+- remote/Tailscale/public tunnel guidance
+
+### Hermes Checks
+
+Checks:
+
+- Hermes adapter running
+- Hermes API reachable
+- Hermes model present
+- auth key configured if required
+- adapter env loaded correctly
+
+Outputs:
+
+- adapter found / missing
+- API reachable / unreachable
+- `401` / bad model / bad URL hints
+
+### Auth / Token Checks
+
+Checks:
+
+- missing Studio access token
+- gateway token missing
+- invalid API key patterns
+- profile says tokened backend but token is absent
+
+Outputs:
+
+- precise missing-token messages
+- auth mismatch guidance
+
+### WebSocket / Origin / Secure-Context Checks
+
+Checks:
+
+- localhost vs remote
+- secure-context expectations
+- browser/origin hints for public/tunneled deployments
+- Cloudflare/ngrok/reverse-proxy warning patterns
+
+Outputs:
+
+- websocket handshake guidance
+- origin/secure-context notes
+- public tunnel caution notes
+
+## Recommended Output Shape
+
+`claw3doctor` should produce:
+
+- short headline result
+- categorized checks
+- pass / warn / fail per item
+- copy-pasteable next actions
+
+Example:
+
+```text
+Claw3Doctor: WARN
+
+[pass] Runtime profile: OpenClaw Default
+[pass] Gateway URL reachable: ws://localhost:18789
+[warn] OpenClaw version: 2026.4.2
+[fail] Device approval required for remote browser
+[warn] Secure-context mismatch for public remote setup
+
+Suggested next actions:
+1. openclaw devices approve --latest
+2. retry from an approved browser/device
+3. if using a public tunnel, test local/LAN direct first
+```
+
+## Runtime-Profile Awareness
+
+`claw3doctor` should be designed against the runtime-profile model:
+
+- provider
+- runtime profile
+- floor binding
+
+That means the doctor should never assume:
+
+- one backend
+- one port
+- one global runtime mode
+
+Instead it should inspect the currently selected profile and run the
+appropriate checks for that provider.
+
+## Provider-Specific Guidance Rules
+
+### OpenClaw
+
+Focus on:
+
+- pairing
+- device identity
+- remote websocket setup
+- public/tunnel secure-context issues
+
+### Hermes
+
+Focus on:
+
+- adapter process
+- Hermes API reachability
+- model/config correctness
+- auth key presence
+
+### Custom Runtime
+
+Focus on:
+
+- gateway contract compatibility
+- reachability
+- auth
+- profile configuration
+
+## Suggested Implementation Order
+
+### PR 1: CLI / Script Scaffold
+
+Add:
+
+- doctor command entrypoint or script
+- report formatter
+- shared result types
+
+### PR 2: Runtime Profile Checks
+
+Add:
+
+- selected profile inspection
+- settings/env parsing
+- gateway URL/token checks
+
+### PR 3: Provider Checks
+
+Add:
+
+- OpenClaw checks
+- Hermes checks
+- custom runtime checks
+
+### PR 4: Common Failure Classifiers
+
+Add:
+
+- websocket close-code guidance
+- secure-context/origin hints
+- reverse-proxy/tunnel notes
+
+## Relationship To Office Systems
+
+`claw3doctor` should land before more runtime complexity because it will
+make debugging:
+
+- multi-runtime support
+- floor-to-profile binding
+- public remote deployment
+
+much less painful.
+
+This is why it is sequenced ahead of deeper Office Systems feature work.
+
+## Follow-Up Docs
+
+After this spec, the next planning doc should be:
+
+- floor schema and builder plan
+
+That doc should define the metadata model before any admin-side floor
+builder is implemented.

--- a/docs/integrations/claw3doctor-spec.md
+++ b/docs/integrations/claw3doctor-spec.md
@@ -235,6 +235,54 @@ much less painful.
 
 This is why it is sequenced ahead of deeper Office Systems feature work.
 
+## V1 Delivery Boundary
+
+`claw3doctor` v1 should be considered complete when it provides:
+
+- selected-profile diagnostics with optional per-profile probing
+- grouped terminal output with clear pass / warn / fail results
+- JSON output for automation and issue reporting
+- provider-aware checks for OpenClaw, Hermes, demo, and custom runtimes
+- common failure classification for transport and auth problems
+- concrete remediation for local, remote, tunneled, and adapter-backed setups
+
+This keeps v1 reviewable as deployment diagnostics rather than letting it
+turn into a full runtime orchestration project.
+
+## V2 Expansion Backlog
+
+After v1 lands, the next doctor-specific expansion should focus on better
+diagnosis depth and better operator ergonomics rather than broader scope.
+
+### Higher-Signal Runtime Heuristics
+
+- deeper OpenClaw pairing and device-approval detection
+- stronger close-code interpretation from real-world failures
+- provider-specific contract validation for demo and custom runtimes
+- better wrong-model / wrong-adapter mismatch detection
+
+### Tunnel / Proxy Guidance
+
+- Cloudflare-specific websocket and origin remediation
+- Tailscale-specific remote deployment guidance
+- reverse-proxy fingerprinting and likely-misconfiguration hints
+- public-host checks when auth or secure-context expectations are missing
+
+### Output / Workflow Improvements
+
+- richer terminal presentation
+- issue-template or bundle-friendly export
+- in-app diagnostics panel later, reusing the same JSON report
+- optional doctor autofix for safe configuration repairs
+
+### Runtime-Profile Follow-Through
+
+`claw3doctor` v2 should also benefit from the separate runtime-profile work:
+
+- simultaneous runtime profile visibility
+- per-profile health history
+- floor-to-profile diagnosis once Office Systems binding is live
+
 ## Follow-Up Docs
 
 After this spec, the next planning doc should be:

--- a/docs/integrations/runtime-profile-architecture.md
+++ b/docs/integrations/runtime-profile-architecture.md
@@ -186,7 +186,7 @@ Custom runtimes should fit the same profile model:
 - one or more named profiles
 - floor binding selects which profile powers which floor
 
-This avoids making the “Custom Floor” logic one-off and lets Claw3D grow
+This avoids making the "Custom Floor" logic one-off and lets Claw3D grow
 to multiple custom environments without another architecture pass.
 
 ## One Gateway Contract, Different Backends

--- a/docs/integrations/runtime-profile-architecture.md
+++ b/docs/integrations/runtime-profile-architecture.md
@@ -1,0 +1,320 @@
+# Runtime Profile Architecture
+
+> Forward-looking runtime model for Claw3D after the OpenClaw + Hermes adapter work landed on `main`.
+
+## Goal
+
+Claw3D should treat runtime connection targets as profiles, not as ad hoc
+gateway URLs tied to one backend assumption.
+
+That means the app should model:
+
+- provider
+- runtime profile
+- floor binding
+
+instead of making the user think in terms of:
+
+- one hard-coded backend
+- one port
+- one global gateway selection
+
+## Recommendation
+
+Use one gateway contract in the UI, with different backend providers
+behind it.
+
+Default path:
+
+- `OpenClaw` is the default runtime profile
+
+Optional paths:
+
+- `Hermes Adapter`
+- `Custom Runtime(s)`
+
+The important rule is:
+
+- the UI keeps speaking one Claw3D gateway contract
+- the backend behind that contract may be native OpenClaw, Hermes through
+  the adapter, or a custom runtime/provider
+
+## Core Terms
+
+### Provider
+
+A provider identifies the backend family behind a runtime profile.
+
+Initial provider set:
+
+- `openclaw`
+- `hermes`
+- `custom`
+- `demo`
+
+Provider answers questions like:
+
+- what backend is this?
+- what capabilities should the UI expect?
+- which default labels or help copy apply?
+
+### Runtime Profile
+
+A runtime profile is a named connection target.
+
+Examples:
+
+- `OpenClaw Default`
+- `Hermes Adapter`
+- `Custom Staging Runtime`
+- `Custom Prod Runtime`
+
+Suggested shape:
+
+```ts
+export type RuntimeProfileId = string;
+
+export type RuntimeProfile = {
+  id: RuntimeProfileId;
+  label: string;
+  provider: "openclaw" | "hermes" | "custom" | "demo";
+  gatewayUrl: string;
+  token?: string | null;
+  adapterType?: "openclaw" | "hermes" | "custom" | "demo" | null;
+  enabled: boolean;
+  defaultProfile: boolean;
+  notes?: string | null;
+};
+```
+
+Runtime profile answers:
+
+- where does Claw3D connect?
+- what provider is behind this connection?
+- which auth/token should be used?
+- which profile should be the default?
+
+### Floor Binding
+
+A floor binding maps an office floor to a runtime profile.
+
+Examples:
+
+- `OpenClaw Floor -> openclaw-default`
+- `Hermes Floor -> hermes-default`
+- `Custom Floor -> custom-default`
+- `Lobby -> null`
+- `Campus -> null`
+
+Suggested shape:
+
+```ts
+export type FloorRuntimeBinding = {
+  floorId: FloorId;
+  runtimeProfileId: RuntimeProfileId | null;
+};
+```
+
+Floor binding answers:
+
+- which runtime powers this floor?
+- is this floor provider-backed, function-backed, or a destination?
+
+## Runtime Model
+
+The recommended mental model is:
+
+```text
+Provider -> Runtime Profile -> Floor Binding
+```
+
+Examples:
+
+- provider: `openclaw`
+  - profile: `openclaw-default`
+  - bound floor: `openclaw-ground`
+
+- provider: `hermes`
+  - profile: `hermes-default`
+  - bound floor: `hermes-first`
+
+- provider: `custom`
+  - profiles:
+    - `custom-default`
+    - `custom-staging`
+    - `custom-prod`
+  - one or more custom floors may bind to them later
+
+## Default Behavior
+
+Initial default behavior should be:
+
+- if nothing else is configured, Claw3D prefers `OpenClaw`
+- Hermes remains optional and adapter-backed
+- custom runtimes remain optional and profile-driven
+
+That means:
+
+- OpenClaw is the safe baseline
+- Hermes should not destabilize the default path
+- custom runtimes should not require special-case UI logic
+
+## Hermes Adapter Position
+
+Right now Hermes works through the adapter path, and that is acceptable as
+the near-term production path.
+
+Architecture implication:
+
+- Hermes should be represented as a provider/profile combination
+- not as a special global mode
+
+So the app should think:
+
+- provider: `hermes`
+- profile: `hermes-default`
+- gateway URL: adapter endpoint
+
+This keeps the runtime selection model uniform even though Hermes is still
+adapter-backed today.
+
+## Custom Runtime Position
+
+Custom runtimes should fit the same profile model:
+
+- provider: `custom`
+- one or more named profiles
+- floor binding selects which profile powers which floor
+
+This avoids making the “Custom Floor” logic one-off and lets Claw3D grow
+to multiple custom environments without another architecture pass.
+
+## One Gateway Contract, Different Backends
+
+The UI should not branch everywhere on backend family.
+
+Instead:
+
+- the browser talks one Claw3D gateway contract
+- Studio/settings select the runtime profile
+- profile/provider metadata informs capability checks and defaults
+
+This keeps the frontend stable while backends differ behind the scenes.
+
+## Office Systems Implications
+
+This model supports the current Office Systems direction cleanly.
+
+### Floor Zones
+
+- `Building`
+- `Outside`
+
+### Floor Types
+
+- provider-backed
+- function-backed
+- destination/outside
+
+### Examples
+
+- `Lobby`
+  - function-backed
+  - no runtime binding required
+
+- `OpenClaw Floor`
+  - provider-backed
+  - bound to `openclaw-default`
+
+- `Hermes Floor`
+  - provider-backed
+  - bound to `hermes-default`
+
+- `Custom Floor`
+  - provider-backed
+  - bound to `custom-default`
+
+- `Training Floor`
+  - function-backed
+  - may later bind to a chosen provider profile
+
+- `Trader's Floor`
+  - function-backed
+  - may later bind to a chosen provider profile
+
+- `Campus` / `Stadium`
+  - outside destinations
+  - not required to behave like numbered floors
+
+## Branch Sequence
+
+Recommended next branches:
+
+- `docs/runtime-profiles`
+- `feat/claw3doctor`
+- `refactor/office-shell`
+- later:
+  - `docs/floor-builder-schema`
+  - `feat/floor-builder`
+
+## Next Sequence
+
+### 1. `docs: runtime profile architecture`
+
+Define:
+
+- provider vs profile vs floor binding
+- `OpenClaw` default
+- `Hermes Adapter` optional
+- `Custom Runtime(s)` optional
+- one gateway contract, different backends
+
+### 2. `feat: claw3doctor`
+
+First pass should check:
+
+- Claw3D settings/env
+- gateway reachability
+- OpenClaw version
+- Hermes adapter/API availability
+- auth/token issues
+- common websocket/origin/secure-context failures
+
+### 3. `refactor: office shell modularization`
+
+Next extractions:
+
+- `OfficeShell`
+- `OfficeFloorController`
+- `OfficePanelsController`
+
+### 4. `docs: floor schema and builder plan`
+
+Define the schema before building the editor.
+
+### 5. `feat: admin floor builder`
+
+Only after floor metadata/schema stabilizes.
+
+## Why This Comes First
+
+The runtime-profile document should land before more implementation work
+because it informs both:
+
+- multi-runtime support
+- `claw3doctor`
+
+Without this, diagnostics and floor binding will keep being designed
+against moving assumptions.
+
+## Summary
+
+Claw3D should move to a runtime profile model where:
+
+- providers describe the backend family
+- profiles describe named connection targets
+- floors bind to profiles
+
+OpenClaw remains the default.
+Hermes adapter remains optional.
+Custom runtimes become first-class without special-case UI debt.

--- a/docs/office_sys/office-systems-roadmap.md
+++ b/docs/office_sys/office-systems-roadmap.md
@@ -43,6 +43,102 @@ The office should feel like a real place where work happens, not only a dashboar
 - Build useful features first, then layer on simulation and style.
 - Preserve backend neutrality so these systems work across OpenClaw, Hermes, Vera, and future providers.
 
+## External Validation
+
+Recent production-user feedback strongly reinforces the current direction.
+
+What that feedback confirms:
+
+- multi-agent visibility is the core differentiator
+- agent state to animation mapping should become config/schema driven
+- mobile-first support matters for real demos and daily use
+- subtle sound design and event cues add operational value, not just polish
+- enterprise auth and reverse-proxy compatibility matter for adoption
+- external event webhooks fit naturally into the office as world reactions
+
+This means the roadmap should not treat those as side quests. They are
+adoption-critical support for the office-as-operations-center model.
+
+## Current Post-Merge Sequence
+
+After the recent hardening and runtime work, the next sequence should be:
+
+1. runtime profile architecture
+2. `claw3doctor`
+3. `OfficeScreen` modularization
+4. floor schema and builder plan
+5. admin floor builder
+
+That sequence keeps the base stable before adding more office complexity.
+
+## Supporting Product Lanes
+
+### Mobile-First Office
+
+The office should work well on phones and tablets, not just scale down.
+
+Implications:
+
+- floor navigation and shell chrome must collapse cleanly
+- touch navigation should be intentional
+- control surfaces should avoid desktop-only assumptions
+
+### State-To-Animation Mapping
+
+Agent operational state should not be locked in source code.
+
+Target direction:
+
+- state -> animation mapping should be data driven
+- operator-facing config should define mappings like:
+  - idle
+  - writing
+  - executing
+  - syncing
+  - error
+
+This will matter for adoption across teams with different runtime semantics.
+
+### Sound And Event Cues
+
+Office audio should be treated as operational feedback, not decoration.
+
+Good first examples:
+
+- subtle office ambience
+- start/finish cues
+- warning/alarm cues for failures
+- event-based celebratory cues
+
+### Auth And Enterprise Adoption
+
+Enterprise deployments will often sit behind:
+
+- `oauth2-proxy`
+- Entra / OIDC
+- reverse proxies
+- HTTPS termination
+
+That means Claw3D should continue improving:
+
+- documented auth integration patterns
+- public-host hardening
+- secure-context guidance
+- proxy compatibility
+
+### Event Ingress / Webhooks
+
+External systems should be able to push state into the office.
+
+Examples:
+
+- CI failure -> alarm in the server room
+- new customer onboarded -> front-desk cue
+- CRM event -> bulletin board or celebration event
+
+This fits naturally with the office model and should become a first-class
+integration surface later.
+
 ## V1: Useful Office Systems
 
 These should be the first systems because they add product value immediately and fit the existing office concept naturally.
@@ -312,6 +408,18 @@ Recommended sequence:
 8. Culture / sim systems
 9. Theme skins
 
+## Platform Prerequisites
+
+These platform lanes should keep moving in parallel with the office feature
+roadmap because they directly affect adoption and maintainability:
+
+1. runtime profile architecture
+2. `claw3doctor`
+3. `OfficeScreen` modularization
+4. mobile shell work
+5. auth/proxy deployment guidance
+6. event ingress/webhook planning
+
 ## Theme / Skin Strategy
 
 Skins should come after the office has enough systems worth skinning.
@@ -335,12 +443,17 @@ Examples:
 
 If this roadmap is used for implementation planning, the best next concrete docs/tasks are:
 
-1. Bulletin board system spec
-2. Whiteboard interaction spec
-3. Meeting room workflow spec
-4. QA department workflow spec
+1. Runtime profile architecture doc
+2. `claw3doctor` implementation
+3. `OfficeScreen` modularization plan and extraction work
+4. Floor schema and builder plan
+5. Bulletin board system spec
+6. Whiteboard interaction spec
+7. Meeting room workflow spec
+8. QA department workflow spec
 
-Those four would create the strongest foundation for future hierarchy, progression, and simulation layers.
+Those create the strongest foundation for future hierarchy, progression,
+simulation layers, and enterprise-ready adoption.
 
 ## Summary
 

--- a/docs/office_sys/office-systems-roadmap.md
+++ b/docs/office_sys/office-systems-roadmap.md
@@ -455,6 +455,31 @@ If this roadmap is used for implementation planning, the best next concrete docs
 Those create the strongest foundation for future hierarchy, progression,
 simulation layers, and enterprise-ready adoption.
 
+## Diagnostics Roadmap Split
+
+To keep diagnostics aligned with the platform work without turning them into
+an unbounded tooling branch, treat `claw3doctor` in two phases:
+
+### `claw3doctor` v1
+
+- first-pass deployment diagnostics
+- runtime profile awareness
+- grouped terminal output
+- JSON output
+- OpenClaw / Hermes / demo / custom provider checks
+- tunnel, auth, and close-code remediation
+
+### `claw3doctor` v2
+
+- deeper OpenClaw pairing/device heuristics
+- stronger Cloudflare / Tailscale / reverse-proxy fingerprints
+- richer export and issue-bundle workflows
+- in-app diagnostics surface later
+- floor-to-profile and multi-runtime diagnostics once runtime binding matures
+
+This keeps the current branch reviewable while preserving the next layer of
+operator-focused work.
+
 ## Summary
 
 Claw3D gets stronger when the office becomes the place where work actually happens.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cleanup:ux-artifacts": "node scripts/cleanup-ux-artifacts.mjs",
     "sync:gateway-client": "node scripts/sync-openclaw-gateway-client.ts",
     "studio:setup": "node scripts/studio-setup.js",
+    "doctor": "node scripts/claw3doctor.mjs",
     "smoke:dev-server": "node scripts/smoke-dev-server.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest",

--- a/scripts/claw3doctor.mjs
+++ b/scripts/claw3doctor.mjs
@@ -7,6 +7,8 @@ import { WebSocket } from "ws";
 import {
   buildCustomRuntimeWarnings,
   buildDoctorJsonReport,
+  buildGatewayFailureActions,
+  buildProfileWarnings,
   DOCTOR_STATUSES,
   buildGatewayWarnings,
   buildOpenClawWarnings,
@@ -77,22 +79,25 @@ const formatErrorMessage = (error, fallback) => {
   return error.message || error.name || fallback;
 };
 
-const checkPass = (label, message, actions) => ({
+const checkPass = (category, label, message, actions) => ({
   status: DOCTOR_STATUSES.pass,
+  category,
   label,
   message,
   ...(actions?.length ? { actions } : {}),
 });
 
-const checkWarn = (label, message, actions) => ({
+const checkWarn = (category, label, message, actions) => ({
   status: DOCTOR_STATUSES.warn,
+  category,
   label,
   message,
   ...(actions?.length ? { actions } : {}),
 });
 
-const checkFail = (label, message, actions) => ({
+const checkFail = (category, label, message, actions) => ({
   status: DOCTOR_STATUSES.fail,
+  category,
   label,
   message,
   ...(actions?.length ? { actions } : {}),
@@ -226,28 +231,35 @@ async function main() {
   checks.push(
     runtimeContext.gatewayUrl
       ? checkPass(
+          "Runtime profiles",
           "Runtime profile",
           `${runtimeContext.adapterType} selected at ${runtimeContext.gatewayUrl}`,
         )
-      : checkFail("Runtime profile", "No runtime profile / gateway URL is configured.", [
+      : checkFail("Runtime profiles", "Runtime profile", "No runtime profile / gateway URL is configured.", [
           "Set the gateway URL in Claw3D connect/settings before retrying.",
         ]),
   );
 
   checks.push(
     runtimeContext.tokenConfigured
-      ? checkPass("Gateway token", "A gateway token is configured for the selected profile.")
-      : checkWarn("Gateway token", "No gateway token is configured for the selected profile.", [
+      ? checkPass("Runtime profiles", "Gateway token", "A gateway token is configured for the selected profile.")
+      : checkWarn("Runtime profiles", "Gateway token", "No gateway token is configured for the selected profile.", [
           "If this backend requires token auth, set the upstream token in Claw3D settings or openclaw.json.",
         ]),
   );
+
+  for (const warning of buildProfileWarnings({ runtimeContext })) {
+    checks.push(checkWarn("Runtime profiles", "Profile collision", warning, [
+      "Assign distinct local ports or URLs if you want OpenClaw, Hermes, and demo running simultaneously instead of swapping one backend onto the same endpoint.",
+    ]));
+  }
 
   for (const warning of buildGatewayWarnings({
     gatewayUrl: runtimeContext.gatewayUrl,
     studioAccessToken: trim(env.STUDIO_ACCESS_TOKEN),
     host: trim(env.HOST),
   })) {
-    checks.push(checkWarn("Gateway hints", warning));
+    checks.push(checkWarn("Gateway access", "Gateway hints", warning));
   }
 
   if (runtimeContext.adapterType === "openclaw") {
@@ -255,7 +267,7 @@ async function main() {
       gatewayUrl: runtimeContext.gatewayUrl,
       tokenConfigured: runtimeContext.tokenConfigured,
     })) {
-      checks.push(checkWarn("OpenClaw hints", warning, [
+      checks.push(checkWarn("OpenClaw", "OpenClaw hints", warning, [
         "If the browser/device is not yet approved, check `openclaw devices list` and approve the pending device before retrying the remote connection.",
       ]));
     }
@@ -267,7 +279,7 @@ async function main() {
       allowlist: trim(env.CUSTOM_RUNTIME_ALLOWLIST) || trim(env.UPSTREAM_ALLOWLIST),
       nodeEnv: trim(env.NODE_ENV),
     })) {
-      checks.push(checkWarn("Custom runtime hints", warning));
+      checks.push(checkWarn("Custom runtime", "Custom runtime hints", warning));
     }
   }
 
@@ -276,21 +288,37 @@ async function main() {
       const customProbe = await probeCustomRuntimeHealth(runtimeContext.gatewayUrl);
       checks.push(
         customProbe.ok
-          ? checkPass("Custom runtime reachability", customProbe.message)
-          : checkFail("Custom runtime reachability", customProbe.message, [
-              "Verify the custom runtime base URL is correct and exposes /health or /registry over HTTP.",
-              "If this runtime sits behind the Studio custom proxy, verify CUSTOM_RUNTIME_ALLOWLIST / UPSTREAM_ALLOWLIST for the target host.",
-            ]),
+          ? checkPass("Custom runtime", "Custom runtime reachability", customProbe.message)
+          : checkFail(
+              "Custom runtime",
+              "Custom runtime reachability",
+              customProbe.message,
+              buildGatewayFailureActions({
+                adapterType: runtimeContext.adapterType,
+                message: customProbe.message,
+                gatewayUrl: runtimeContext.gatewayUrl,
+              }).concat([
+                "If this runtime sits behind the Studio custom proxy, verify CUSTOM_RUNTIME_ALLOWLIST / UPSTREAM_ALLOWLIST for the target host.",
+              ]),
+            ),
       );
     } else {
       const wsProbe = await probeWebSocket(runtimeContext.gatewayUrl);
       checks.push(
         wsProbe.ok
-          ? checkPass("Gateway reachability", wsProbe.message)
-          : checkFail("Gateway reachability", wsProbe.message, [
-              "Verify the configured gateway URL is correct and the backend is listening.",
-              "If this is a public/tunneled deployment, compare direct local/LAN behavior before debugging deeper.",
-            ]),
+          ? checkPass("Gateway access", "Gateway reachability", wsProbe.message)
+          : checkFail(
+              "Gateway access",
+              "Gateway reachability",
+              wsProbe.message,
+              buildGatewayFailureActions({
+                adapterType: runtimeContext.adapterType,
+                message: wsProbe.message,
+                gatewayUrl: runtimeContext.gatewayUrl,
+              }).concat([
+                "Verify the configured gateway URL is correct and the backend is listening.",
+              ]),
+            ),
       );
     }
   }
@@ -300,8 +328,8 @@ async function main() {
   if (shouldRunOpenClawChecks({ runtimeContext, openclawConfigExists })) {
     checks.push(
       openclawConfigExists
-        ? checkPass("OpenClaw config", `Found ${openclawConfigPath}.`)
-        : checkWarn("OpenClaw config", `No openclaw.json found at ${openclawConfigPath}.`, [
+        ? checkPass("OpenClaw", "OpenClaw config", `Found ${openclawConfigPath}.`)
+        : checkWarn("OpenClaw", "OpenClaw config", `No openclaw.json found at ${openclawConfigPath}.`, [
             "If you expect a local OpenClaw default, verify OPENCLAW_STATE_DIR or create openclaw.json.",
           ]),
     );
@@ -310,8 +338,8 @@ async function main() {
     const versionLooksValid = /^OpenClaw\s+/i.test(version);
     checks.push(
       versionLooksValid
-        ? checkPass("OpenClaw version", version)
-        : checkWarn("OpenClaw version", version, [
+        ? checkPass("OpenClaw", "OpenClaw version", version)
+        : checkWarn("OpenClaw", "OpenClaw version", version, [
             "Install OpenClaw or ensure it is available on PATH if this machine should run it directly.",
           ]),
     );
@@ -321,6 +349,7 @@ async function main() {
     const configuredPort = trim(env.DEMO_ADAPTER_PORT) || "18789";
     checks.push(
       checkPass(
+        "Demo gateway",
         "Demo gateway config",
         `Demo mode expects the mock gateway on ws://localhost:${configuredPort}.`,
         ["Run `npm run demo-gateway` if you want a no-runtime office smoke test."],
@@ -332,6 +361,7 @@ async function main() {
     const hermes = await detectHermesModelHealth();
     checks.push(
       checkPass(
+        "Hermes",
         "Hermes adapter config",
         `Hermes API target ${hermes.apiUrl} | model ${hermes.model} | key ${
           hermes.apiKeyConfigured ? "configured" : "missing"
@@ -345,6 +375,7 @@ async function main() {
         : [];
       checks.push(
         checkPass(
+          "Hermes",
           "Hermes API",
           models.length > 0
             ? `Hermes API reachable. Reported models: ${models.join(", ")}`
@@ -353,20 +384,20 @@ async function main() {
       );
       if (models.length > 0 && !models.includes(hermes.model)) {
         checks.push(
-          checkWarn("Hermes model", `Configured model "${hermes.model}" was not returned by /v1/models.`, [
+          checkWarn("Hermes", "Hermes model", `Configured model "${hermes.model}" was not returned by /v1/models.`, [
             "Set HERMES_MODEL to one of the reported model ids or update the Hermes API configuration.",
           ]),
         );
       }
     } else if (hermes.probe.status === 401) {
       checks.push(
-        checkFail("Hermes API", "Hermes API returned HTTP 401.", [
+        checkFail("Hermes", "Hermes API", "Hermes API returned HTTP 401.", [
           "Verify HERMES_API_KEY and confirm the adapter is loading the same .env values you expect.",
         ]),
       );
     } else {
       checks.push(
-        checkFail("Hermes API", hermes.probe.text || "Hermes API probe failed.", [
+        checkFail("Hermes", "Hermes API", hermes.probe.text || "Hermes API probe failed.", [
           "Start the Hermes API server and verify /v1/models responds before starting the adapter.",
         ]),
       );

--- a/scripts/claw3doctor.mjs
+++ b/scripts/claw3doctor.mjs
@@ -1,18 +1,18 @@
-import fs from "node:fs";
-import path from "node:path";
-import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
 
 import { WebSocket } from "ws";
 import {
   buildCustomRuntimeWarnings,
   buildDoctorJsonReport,
   buildGatewayFailureActions,
-  classifyGatewayFailure,
-  buildProfileWarnings,
-  DOCTOR_STATUSES,
   buildGatewayWarnings,
   buildOpenClawWarnings,
+  buildProfileWarnings,
+  classifyGatewayFailure,
+  DOCTOR_STATUSES,
   formatDoctorReport,
   parseDoctorArgs,
   resolveRuntimeContext,
@@ -68,10 +68,16 @@ const readJsonFile = (filePath) => {
 
 const formatErrorMessage = (error, fallback) => {
   if (!(error instanceof Error)) return fallback;
-  if (error.name === "AggregateError" && Array.isArray(error.errors) && error.errors.length > 0) {
+  if (
+    error.name === "AggregateError" &&
+    Array.isArray(error.errors) &&
+    error.errors.length > 0
+  ) {
     const details = error.errors
       .map((entry) =>
-        entry instanceof Error ? entry.message || entry.name : String(entry ?? "").trim(),
+        entry instanceof Error
+          ? entry.message || entry.name
+          : String(entry ?? "").trim(),
       )
       .filter(Boolean);
     if (details.length > 0) {
@@ -124,7 +130,9 @@ const probeWebSocket = async (url, timeoutMs = 3500) =>
       () => finish({ ok: false, message: `Timed out after ${timeoutMs}ms.` }),
       timeoutMs + 250,
     );
-    socket.once("open", () => finish({ ok: true, message: "WebSocket handshake succeeded." }));
+    socket.once("open", () =>
+      finish({ ok: true, message: "WebSocket handshake succeeded." }),
+    );
     socket.once("error", (error) =>
       finish({
         ok: false,
@@ -170,7 +178,9 @@ const detectOpenClawVersion = () => {
       timeout: 4000,
     }).trim();
   } catch (error) {
-    return error instanceof Error ? error.message : "Unable to run openclaw --version";
+    return error instanceof Error
+      ? error.message
+      : "Unable to run openclaw --version";
   }
 };
 
@@ -181,11 +191,12 @@ const detectWorkspaceState = () => {
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 3000,
     }).trim();
-    const dirty = execFileSync("git", ["status", "--porcelain"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 3000,
-    }).trim().length > 0;
+    const dirty =
+      execFileSync("git", ["status", "--porcelain"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 3000,
+      }).trim().length > 0;
     return { branch, dirty, available: true };
   } catch {
     return { branch: "", dirty: false, available: false };
@@ -193,7 +204,9 @@ const detectWorkspaceState = () => {
 };
 
 const detectHermesModelHealth = async () => {
-  const apiUrl = (trim(process.env.HERMES_API_URL) || "http://localhost:8642").replace(/\/$/, "");
+  const apiUrl = (
+    trim(process.env.HERMES_API_URL) || "http://localhost:8642"
+  ).replace(/\/$/, "");
   const apiKey = trim(process.env.HERMES_API_KEY);
   const model = trim(process.env.HERMES_MODEL) || "hermes";
   const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
@@ -210,12 +223,18 @@ const probeCustomRuntimeHealth = async (runtimeUrl) => {
   const baseUrl = runtimeUrl.replace(/\/$/, "");
   const health = await probeHttpJson({ url: `${baseUrl}/health` });
   if (health.ok) {
-    return { ok: true, message: "Custom runtime /health responded successfully." };
+    return {
+      ok: true,
+      message: "Custom runtime /health responded successfully.",
+    };
   }
 
   const registry = await probeHttpJson({ url: `${baseUrl}/registry` });
   if (registry.ok) {
-    return { ok: true, message: "Custom runtime /registry responded successfully." };
+    return {
+      ok: true,
+      message: "Custom runtime /registry responded successfully.",
+    };
   }
 
   return {
@@ -281,8 +300,16 @@ async function main() {
             "Git branch",
             `${workspace.branch} (working tree has local modifications)`,
           )
-        : checkPass("Workspace", "Git branch", `${workspace.branch} (clean working tree)`)
-      : checkWarn("Workspace", "Git branch", "Git branch could not be detected from this working directory."),
+        : checkPass(
+            "Workspace",
+            "Git branch",
+            `${workspace.branch} (clean working tree)`,
+          )
+      : checkWarn(
+          "Workspace",
+          "Git branch",
+          "Git branch could not be detected from this working directory.",
+        ),
   );
 
   checks.push(
@@ -292,23 +319,37 @@ async function main() {
           "Runtime profile",
           `${runtimeContext.adapterType} selected at ${runtimeContext.gatewayUrl}`,
         )
-      : checkFail("Runtime profiles", "Runtime profile", "No runtime profile / gateway URL is configured.", [
-          "Set the gateway URL in Claw3D connect/settings before retrying.",
-        ]),
+      : checkFail(
+          "Runtime profiles",
+          "Runtime profile",
+          "No runtime profile / gateway URL is configured.",
+          ["Set the gateway URL in Claw3D connect/settings before retrying."],
+        ),
   );
 
   checks.push(
     runtimeContext.tokenConfigured
-      ? checkPass("Runtime profiles", "Gateway token", "A gateway token is configured for the selected profile.")
-      : checkWarn("Runtime profiles", "Gateway token", "No gateway token is configured for the selected profile.", [
-          "If this backend requires token auth, set the upstream token in Claw3D settings or openclaw.json.",
-        ]),
+      ? checkPass(
+          "Runtime profiles",
+          "Gateway token",
+          "A gateway token is configured for the selected profile.",
+        )
+      : checkWarn(
+          "Runtime profiles",
+          "Gateway token",
+          "No gateway token is configured for the selected profile.",
+          [
+            "If this backend requires token auth, set the upstream token in Claw3D settings or openclaw.json.",
+          ],
+        ),
   );
 
   for (const warning of buildProfileWarnings({ runtimeContext })) {
-    checks.push(checkWarn("Runtime profiles", "Profile collision", warning, [
-      "Assign distinct local ports or URLs if you want OpenClaw, Hermes, and demo running simultaneously instead of swapping one backend onto the same endpoint.",
-    ]));
+    checks.push(
+      checkWarn("Runtime profiles", "Profile collision", warning, [
+        "Assign distinct local ports or URLs if you want OpenClaw, Hermes, and demo running simultaneously instead of swapping one backend onto the same endpoint.",
+      ]),
+    );
   }
 
   if (args.profile) {
@@ -324,7 +365,9 @@ async function main() {
             "Runtime profiles",
             "Profile selection",
             `Requested profile "${args.profile}" is not configured in current Studio settings.`,
-            ["Run `node scripts/claw3doctor.mjs --all-profiles` to see the configured profile list."],
+            [
+              "Run `node scripts/claw3doctor.mjs --all-profiles` to see the configured profile list.",
+            ],
           ),
     );
   } else if (args.allProfiles) {
@@ -358,27 +401,32 @@ async function main() {
       gatewayUrl: runtimeContext.gatewayUrl,
       tokenConfigured: runtimeContext.tokenConfigured,
     })) {
-      checks.push(checkWarn("OpenClaw", "OpenClaw hints", warning, [
-        "If the browser/device is not yet approved, check `openclaw devices list` and approve the pending device before retrying the remote connection.",
-      ]));
+      checks.push(
+        checkWarn("OpenClaw", "OpenClaw hints", warning, [
+          "If the browser/device is not yet approved, check `openclaw devices list` and approve the pending device before retrying the remote connection.",
+        ]),
+      );
     }
   }
 
   if (adapterInScope("custom", shouldRunCustomChecks({ runtimeContext }))) {
     for (const warning of buildCustomRuntimeWarnings({
       gatewayUrl: runtimeContext.gatewayUrl,
-      allowlist: trim(env.CUSTOM_RUNTIME_ALLOWLIST) || trim(env.UPSTREAM_ALLOWLIST),
+      allowlist:
+        trim(env.CUSTOM_RUNTIME_ALLOWLIST) || trim(env.UPSTREAM_ALLOWLIST),
       nodeEnv: trim(env.NODE_ENV),
     })) {
       checks.push(checkWarn("Custom runtime", "Custom runtime hints", warning));
     }
   }
 
-  const profileEntries = Object.entries(runtimeContext.profiles ?? {}).filter(([adapterType]) => {
-    if (args.allProfiles) return true;
-    if (args.profile) return adapterType === args.profile;
-    return adapterType === runtimeContext.adapterType;
-  });
+  const profileEntries = Object.entries(runtimeContext.profiles ?? {}).filter(
+    ([adapterType]) => {
+      if (args.allProfiles) return true;
+      if (args.profile) return adapterType === args.profile;
+      return adapterType === runtimeContext.adapterType;
+    },
+  );
   for (const [adapterTypeRaw, profile] of profileEntries) {
     const adapterType = adapterTypeRaw;
     const url = trim(profile?.url);
@@ -402,7 +450,9 @@ async function main() {
                 ? [
                     "If this runtime sits behind the Studio custom proxy, verify CUSTOM_RUNTIME_ALLOWLIST / UPSTREAM_ALLOWLIST for the target host.",
                   ]
-                : ["Verify the configured gateway URL is correct and the backend is listening."],
+                : [
+                    "Verify the configured gateway URL is correct and the backend is listening.",
+                  ],
             ),
           ),
     );
@@ -423,10 +473,19 @@ async function main() {
   if (shouldRunOpenClawChecks({ runtimeContext, openclawConfigExists })) {
     checks.push(
       openclawConfigExists
-        ? checkPass("OpenClaw", "OpenClaw config", `Found ${openclawConfigPath}.`)
-        : checkWarn("OpenClaw", "OpenClaw config", `No openclaw.json found at ${openclawConfigPath}.`, [
-            "If you expect a local OpenClaw default, verify OPENCLAW_STATE_DIR or create openclaw.json.",
-          ]),
+        ? checkPass(
+            "OpenClaw",
+            "OpenClaw config",
+            `Found ${openclawConfigPath}.`,
+          )
+        : checkWarn(
+            "OpenClaw",
+            "OpenClaw config",
+            `No openclaw.json found at ${openclawConfigPath}.`,
+            [
+              "If you expect a local OpenClaw default, verify OPENCLAW_STATE_DIR or create openclaw.json.",
+            ],
+          ),
     );
 
     const version = detectOpenClawVersion();
@@ -447,12 +506,16 @@ async function main() {
         "Demo gateway",
         "Demo gateway config",
         `Demo mode expects the mock gateway on ws://localhost:${configuredPort}.`,
-        ["Run `npm run demo-gateway` if you want a no-runtime office smoke test."],
+        [
+          "Run `npm run demo-gateway` if you want a no-runtime office smoke test.",
+        ],
       ),
     );
   }
 
-  if (adapterInScope("hermes", shouldRunHermesChecks({ runtimeContext, env }))) {
+  if (
+    adapterInScope("hermes", shouldRunHermesChecks({ runtimeContext, env }))
+  ) {
     const hermes = await detectHermesModelHealth();
     checks.push(
       checkPass(
@@ -479,9 +542,14 @@ async function main() {
       );
       if (models.length > 0 && !models.includes(hermes.model)) {
         checks.push(
-          checkWarn("Hermes", "Hermes model", `Configured model "${hermes.model}" was not returned by /v1/models.`, [
-            "Set HERMES_MODEL to one of the reported model ids or update the Hermes API configuration.",
-          ]),
+          checkWarn(
+            "Hermes",
+            "Hermes model",
+            `Configured model "${hermes.model}" was not returned by /v1/models.`,
+            [
+              "Set HERMES_MODEL to one of the reported model ids or update the Hermes API configuration.",
+            ],
+          ),
         );
       }
     } else if (hermes.probe.status === 401) {
@@ -492,9 +560,14 @@ async function main() {
       );
     } else {
       checks.push(
-        checkFail("Hermes", "Hermes API", hermes.probe.text || "Hermes API probe failed.", [
-          "Start the Hermes API server and verify /v1/models responds before starting the adapter.",
-        ]),
+        checkFail(
+          "Hermes",
+          "Hermes API",
+          hermes.probe.text || "Hermes API probe failed.",
+          [
+            "Start the Hermes API server and verify /v1/models responds before starting the adapter.",
+          ],
+        ),
       );
     }
   }

--- a/scripts/claw3doctor.mjs
+++ b/scripts/claw3doctor.mjs
@@ -1,0 +1,312 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+
+import { WebSocket } from "ws";
+import {
+  DOCTOR_STATUSES,
+  buildGatewayWarnings,
+  formatDoctorReport,
+  resolveRuntimeContext,
+  shouldRunHermesChecks,
+  shouldRunOpenClawChecks,
+  summarizeChecks,
+} from "./lib/claw3doctor-core.mjs";
+
+const require = createRequire(import.meta.url);
+const {
+  loadUpstreamGatewaySettings,
+  resolveStateDir,
+  resolveStudioSettingsPath,
+} = require("../server/studio-settings.js");
+
+function loadDotenvFile(filePath) {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match) continue;
+    const [, key, rawValue] = match;
+    if (process.env[key] !== undefined) continue;
+    let value = rawValue.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
+
+function loadRuntimeEnv() {
+  const cwd = process.cwd();
+  loadDotenvFile(path.join(cwd, ".env.local"));
+  loadDotenvFile(path.join(cwd, ".env"));
+}
+
+const readJsonFile = (filePath) => {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+};
+
+const formatErrorMessage = (error, fallback) => {
+  if (!(error instanceof Error)) return fallback;
+  if (error.name === "AggregateError" && Array.isArray(error.errors) && error.errors.length > 0) {
+    const details = error.errors
+      .map((entry) =>
+        entry instanceof Error ? entry.message || entry.name : String(entry ?? "").trim(),
+      )
+      .filter(Boolean);
+    if (details.length > 0) {
+      return details.join("; ");
+    }
+  }
+  return error.message || error.name || fallback;
+};
+
+const checkPass = (label, message, actions) => ({
+  status: DOCTOR_STATUSES.pass,
+  label,
+  message,
+  ...(actions?.length ? { actions } : {}),
+});
+
+const checkWarn = (label, message, actions) => ({
+  status: DOCTOR_STATUSES.warn,
+  label,
+  message,
+  ...(actions?.length ? { actions } : {}),
+});
+
+const checkFail = (label, message, actions) => ({
+  status: DOCTOR_STATUSES.fail,
+  label,
+  message,
+  ...(actions?.length ? { actions } : {}),
+});
+
+const trim = (value) => (typeof value === "string" ? value.trim() : "");
+
+const probeWebSocket = async (url, timeoutMs = 3500) =>
+  await new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket.close();
+      } catch {}
+      resolve(result);
+    };
+    const socket = new WebSocket(url, { handshakeTimeout: timeoutMs });
+    const timer = setTimeout(
+      () => finish({ ok: false, message: `Timed out after ${timeoutMs}ms.` }),
+      timeoutMs + 250,
+    );
+    socket.once("open", () => finish({ ok: true, message: "WebSocket handshake succeeded." }));
+    socket.once("error", (error) =>
+      finish({
+        ok: false,
+        message: formatErrorMessage(error, "WebSocket handshake failed."),
+      }),
+    );
+    socket.once("unexpected-response", (_req, res) =>
+      finish({
+        ok: false,
+        message: `Unexpected HTTP ${res.statusCode ?? "response"} during WebSocket upgrade.`,
+      }),
+    );
+  });
+
+const probeHttpJson = async ({ url, headers = {}, timeoutMs = 3500 }) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { headers, signal: controller.signal });
+    const text = await response.text();
+    let json = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {}
+    return { ok: response.ok, status: response.status, text, json };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      text: error instanceof Error ? error.message : "HTTP probe failed.",
+      json: null,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const detectOpenClawVersion = () => {
+  try {
+    return execFileSync("openclaw", ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 4000,
+    }).trim();
+  } catch (error) {
+    return error instanceof Error ? error.message : "Unable to run openclaw --version";
+  }
+};
+
+const detectHermesModelHealth = async () => {
+  const apiUrl = (trim(process.env.HERMES_API_URL) || "http://localhost:8642").replace(/\/$/, "");
+  const apiKey = trim(process.env.HERMES_API_KEY);
+  const model = trim(process.env.HERMES_MODEL) || "hermes";
+  const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+  const result = await probeHttpJson({ url: `${apiUrl}/v1/models`, headers });
+  return {
+    apiUrl,
+    model,
+    apiKeyConfigured: Boolean(apiKey),
+    probe: result,
+  };
+};
+
+async function main() {
+  loadRuntimeEnv();
+
+  const env = process.env;
+  const stateDir = resolveStateDir(env);
+  const settingsPath = resolveStudioSettingsPath(env);
+  const upstreamGateway = loadUpstreamGatewaySettings(env);
+  const studioSettings = readJsonFile(settingsPath);
+  const runtimeContext = resolveRuntimeContext({
+    settings: studioSettings,
+    upstreamGateway,
+    env,
+  });
+
+  const checks = [];
+
+  checks.push(
+    runtimeContext.gatewayUrl
+      ? checkPass(
+          "Runtime profile",
+          `${runtimeContext.adapterType} selected at ${runtimeContext.gatewayUrl}`,
+        )
+      : checkFail("Runtime profile", "No runtime profile / gateway URL is configured.", [
+          "Set the gateway URL in Claw3D connect/settings before retrying.",
+        ]),
+  );
+
+  checks.push(
+    runtimeContext.tokenConfigured
+      ? checkPass("Gateway token", "A gateway token is configured for the selected profile.")
+      : checkWarn("Gateway token", "No gateway token is configured for the selected profile.", [
+          "If this backend requires token auth, set the upstream token in Claw3D settings or openclaw.json.",
+        ]),
+  );
+
+  for (const warning of buildGatewayWarnings({
+    gatewayUrl: runtimeContext.gatewayUrl,
+    studioAccessToken: trim(env.STUDIO_ACCESS_TOKEN),
+    host: trim(env.HOST),
+  })) {
+    checks.push(checkWarn("Gateway hints", warning));
+  }
+
+  if (runtimeContext.gatewayUrl) {
+    const wsProbe = await probeWebSocket(runtimeContext.gatewayUrl);
+    checks.push(
+      wsProbe.ok
+        ? checkPass("Gateway reachability", wsProbe.message)
+        : checkFail("Gateway reachability", wsProbe.message, [
+            "Verify the configured gateway URL is correct and the backend is listening.",
+            "If this is a public/tunneled deployment, compare direct local/LAN behavior before debugging deeper.",
+          ]),
+    );
+  }
+
+  const openclawConfigPath = path.join(stateDir, "openclaw.json");
+  const openclawConfigExists = fs.existsSync(openclawConfigPath);
+  if (shouldRunOpenClawChecks({ runtimeContext, openclawConfigExists })) {
+    checks.push(
+      openclawConfigExists
+        ? checkPass("OpenClaw config", `Found ${openclawConfigPath}.`)
+        : checkWarn("OpenClaw config", `No openclaw.json found at ${openclawConfigPath}.`, [
+            "If you expect a local OpenClaw default, verify OPENCLAW_STATE_DIR or create openclaw.json.",
+          ]),
+    );
+
+    const version = detectOpenClawVersion();
+    const versionLooksValid = /^OpenClaw\s+/i.test(version);
+    checks.push(
+      versionLooksValid
+        ? checkPass("OpenClaw version", version)
+        : checkWarn("OpenClaw version", version, [
+            "Install OpenClaw or ensure it is available on PATH if this machine should run it directly.",
+          ]),
+    );
+  }
+
+  if (shouldRunHermesChecks({ runtimeContext, env })) {
+    const hermes = await detectHermesModelHealth();
+    checks.push(
+      checkPass(
+        "Hermes adapter config",
+        `Hermes API target ${hermes.apiUrl} | model ${hermes.model} | key ${
+          hermes.apiKeyConfigured ? "configured" : "missing"
+        }`,
+      ),
+    );
+
+    if (hermes.probe.ok) {
+      const models = Array.isArray(hermes.probe.json?.data)
+        ? hermes.probe.json.data.map((entry) => trim(entry?.id)).filter(Boolean)
+        : [];
+      checks.push(
+        checkPass(
+          "Hermes API",
+          models.length > 0
+            ? `Hermes API reachable. Reported models: ${models.join(", ")}`
+            : "Hermes API reachable.",
+        ),
+      );
+      if (models.length > 0 && !models.includes(hermes.model)) {
+        checks.push(
+          checkWarn("Hermes model", `Configured model "${hermes.model}" was not returned by /v1/models.`, [
+            "Set HERMES_MODEL to one of the reported model ids or update the Hermes API configuration.",
+          ]),
+        );
+      }
+    } else if (hermes.probe.status === 401) {
+      checks.push(
+        checkFail("Hermes API", "Hermes API returned HTTP 401.", [
+          "Verify HERMES_API_KEY and confirm the adapter is loading the same .env values you expect.",
+        ]),
+      );
+    } else {
+      checks.push(
+        checkFail("Hermes API", hermes.probe.text || "Hermes API probe failed.", [
+          "Start the Hermes API server and verify /v1/models responds before starting the adapter.",
+        ]),
+      );
+    }
+  }
+
+  const summary = summarizeChecks(checks);
+  const report = formatDoctorReport({
+    summary,
+    runtimeContext,
+    paths: { stateDir, settingsPath },
+    checks,
+  });
+  console.log(report);
+  process.exit(summary === DOCTOR_STATUSES.fail ? 1 : 0);
+}
+
+await main();

--- a/scripts/claw3doctor.mjs
+++ b/scripts/claw3doctor.mjs
@@ -14,6 +14,7 @@ import {
   buildGatewayWarnings,
   buildOpenClawWarnings,
   formatDoctorReport,
+  parseDoctorArgs,
   resolveRuntimeContext,
   shouldRunCustomChecks,
   shouldRunDemoChecks,
@@ -105,33 +106,6 @@ const checkFail = (category, label, message, actions) => ({
 });
 
 const trim = (value) => (typeof value === "string" ? value.trim() : "");
-
-const parseDoctorArgs = (argv) => {
-  const args = {
-    json: false,
-    allProfiles: false,
-    profile: null,
-  };
-  for (let index = 0; index < argv.length; index += 1) {
-    const entry = argv[index];
-    if (entry === "--json") {
-      args.json = true;
-      continue;
-    }
-    if (entry === "--all-profiles") {
-      args.allProfiles = true;
-      continue;
-    }
-    if (entry === "--profile") {
-      const next = trim(argv[index + 1]).toLowerCase();
-      if (next) {
-        args.profile = next;
-        index += 1;
-      }
-    }
-  }
-  return args;
-};
 
 const probeWebSocket = async (url, timeoutMs = 3500) =>
   await new Promise((resolve) => {
@@ -285,6 +259,18 @@ async function main() {
   });
   const workspace = detectWorkspaceState();
 
+  /**
+   * Returns whether provider-specific checks for `adapterType` should run.
+   * When --profile <adapter> is set, only that adapter is in scope.
+   * When --all-profiles is set, all adapters are in scope.
+   * Otherwise falls back to `defaultBehavior` (the existing shouldRun* predicate).
+   */
+  const adapterInScope = (adapterType, defaultBehavior) => {
+    if (args.allProfiles) return true;
+    if (args.profile) return args.profile === adapterType;
+    return defaultBehavior;
+  };
+
   const checks = [];
 
   checks.push(
@@ -367,7 +353,7 @@ async function main() {
     checks.push(checkWarn("Gateway access", "Gateway hints", warning));
   }
 
-  if (runtimeContext.adapterType === "openclaw") {
+  if (adapterInScope("openclaw", runtimeContext.adapterType === "openclaw")) {
     for (const warning of buildOpenClawWarnings({
       gatewayUrl: runtimeContext.gatewayUrl,
       tokenConfigured: runtimeContext.tokenConfigured,
@@ -378,7 +364,7 @@ async function main() {
     }
   }
 
-  if (shouldRunCustomChecks({ runtimeContext })) {
+  if (adapterInScope("custom", shouldRunCustomChecks({ runtimeContext }))) {
     for (const warning of buildCustomRuntimeWarnings({
       gatewayUrl: runtimeContext.gatewayUrl,
       allowlist: trim(env.CUSTOM_RUNTIME_ALLOWLIST) || trim(env.UPSTREAM_ALLOWLIST),
@@ -454,7 +440,7 @@ async function main() {
     );
   }
 
-  if (shouldRunDemoChecks({ runtimeContext, env })) {
+  if (adapterInScope("demo", shouldRunDemoChecks({ runtimeContext, env }))) {
     const configuredPort = trim(env.DEMO_ADAPTER_PORT) || "18789";
     checks.push(
       checkPass(
@@ -466,7 +452,7 @@ async function main() {
     );
   }
 
-  if (shouldRunHermesChecks({ runtimeContext, env })) {
+  if (adapterInScope("hermes", shouldRunHermesChecks({ runtimeContext, env }))) {
     const hermes = await detectHermesModelHealth();
     checks.push(
       checkPass(

--- a/scripts/claw3doctor.mjs
+++ b/scripts/claw3doctor.mjs
@@ -176,6 +176,24 @@ const detectOpenClawVersion = () => {
   }
 };
 
+const detectWorkspaceState = () => {
+  try {
+    const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 3000,
+    }).trim();
+    const dirty = execFileSync("git", ["status", "--porcelain"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 3000,
+    }).trim().length > 0;
+    return { branch, dirty, available: true };
+  } catch {
+    return { branch: "", dirty: false, available: false };
+  }
+};
+
 const detectHermesModelHealth = async () => {
   const apiUrl = (trim(process.env.HERMES_API_URL) || "http://localhost:8642").replace(/\/$/, "");
   const apiKey = trim(process.env.HERMES_API_KEY);
@@ -211,6 +229,22 @@ const probeCustomRuntimeHealth = async (runtimeUrl) => {
   };
 };
 
+const probeProfileHealth = async ({ adapterType, url }) => {
+  if (adapterType === "custom") {
+    const result = await probeCustomRuntimeHealth(url);
+    return {
+      ok: result.ok,
+      message: result.message,
+    };
+  }
+
+  const result = await probeWebSocket(url);
+  return {
+    ok: result.ok,
+    message: result.message,
+  };
+};
+
 async function main() {
   loadRuntimeEnv();
   const args = parseDoctorArgs(process.argv.slice(2));
@@ -225,8 +259,21 @@ async function main() {
     upstreamGateway,
     env,
   });
+  const workspace = detectWorkspaceState();
 
   const checks = [];
+
+  checks.push(
+    workspace.available
+      ? workspace.dirty
+        ? checkWarn(
+            "Workspace",
+            "Git branch",
+            `${workspace.branch} (working tree has local modifications)`,
+          )
+        : checkPass("Workspace", "Git branch", `${workspace.branch} (clean working tree)`)
+      : checkWarn("Workspace", "Git branch", "Git branch could not be detected from this working directory."),
+  );
 
   checks.push(
     runtimeContext.gatewayUrl
@@ -283,44 +330,34 @@ async function main() {
     }
   }
 
-  if (runtimeContext.gatewayUrl) {
-    if (runtimeContext.adapterType === "custom") {
-      const customProbe = await probeCustomRuntimeHealth(runtimeContext.gatewayUrl);
-      checks.push(
-        customProbe.ok
-          ? checkPass("Custom runtime", "Custom runtime reachability", customProbe.message)
-          : checkFail(
-              "Custom runtime",
-              "Custom runtime reachability",
-              customProbe.message,
-              buildGatewayFailureActions({
-                adapterType: runtimeContext.adapterType,
-                message: customProbe.message,
-                gatewayUrl: runtimeContext.gatewayUrl,
-              }).concat([
-                "If this runtime sits behind the Studio custom proxy, verify CUSTOM_RUNTIME_ALLOWLIST / UPSTREAM_ALLOWLIST for the target host.",
-              ]),
+  const profileEntries = Object.entries(runtimeContext.profiles ?? {});
+  for (const [adapterTypeRaw, profile] of profileEntries) {
+    const adapterType = adapterTypeRaw;
+    const url = trim(profile?.url);
+    if (!url) continue;
+    const isSelected = adapterType === runtimeContext.adapterType;
+    const label = `${adapterType} profile${isSelected ? " (selected)" : ""}`;
+    const health = await probeProfileHealth({ adapterType, url });
+    checks.push(
+      health.ok
+        ? checkPass("Profile health", label, `${url} -> ${health.message}`)
+        : checkFail(
+            "Profile health",
+            label,
+            `${url} -> ${health.message}`,
+            buildGatewayFailureActions({
+              adapterType,
+              message: health.message,
+              gatewayUrl: url,
+            }).concat(
+              adapterType === "custom"
+                ? [
+                    "If this runtime sits behind the Studio custom proxy, verify CUSTOM_RUNTIME_ALLOWLIST / UPSTREAM_ALLOWLIST for the target host.",
+                  ]
+                : ["Verify the configured gateway URL is correct and the backend is listening."],
             ),
-      );
-    } else {
-      const wsProbe = await probeWebSocket(runtimeContext.gatewayUrl);
-      checks.push(
-        wsProbe.ok
-          ? checkPass("Gateway access", "Gateway reachability", wsProbe.message)
-          : checkFail(
-              "Gateway access",
-              "Gateway reachability",
-              wsProbe.message,
-              buildGatewayFailureActions({
-                adapterType: runtimeContext.adapterType,
-                message: wsProbe.message,
-                gatewayUrl: runtimeContext.gatewayUrl,
-              }).concat([
-                "Verify the configured gateway URL is correct and the backend is listening.",
-              ]),
-            ),
-      );
-    }
+          ),
+    );
   }
 
   const openclawConfigPath = path.join(stateDir, "openclaw.json");

--- a/scripts/claw3doctor.mjs
+++ b/scripts/claw3doctor.mjs
@@ -5,10 +5,15 @@ import { execFileSync } from "node:child_process";
 
 import { WebSocket } from "ws";
 import {
+  buildCustomRuntimeWarnings,
+  buildDoctorJsonReport,
   DOCTOR_STATUSES,
   buildGatewayWarnings,
+  buildOpenClawWarnings,
   formatDoctorReport,
   resolveRuntimeContext,
+  shouldRunCustomChecks,
+  shouldRunDemoChecks,
   shouldRunHermesChecks,
   shouldRunOpenClawChecks,
   summarizeChecks,
@@ -95,6 +100,10 @@ const checkFail = (label, message, actions) => ({
 
 const trim = (value) => (typeof value === "string" ? value.trim() : "");
 
+const parseDoctorArgs = (argv) => ({
+  json: argv.includes("--json"),
+});
+
 const probeWebSocket = async (url, timeoutMs = 3500) =>
   await new Promise((resolve) => {
     let settled = false;
@@ -176,8 +185,30 @@ const detectHermesModelHealth = async () => {
   };
 };
 
+const probeCustomRuntimeHealth = async (runtimeUrl) => {
+  const baseUrl = runtimeUrl.replace(/\/$/, "");
+  const health = await probeHttpJson({ url: `${baseUrl}/health` });
+  if (health.ok) {
+    return { ok: true, message: "Custom runtime /health responded successfully." };
+  }
+
+  const registry = await probeHttpJson({ url: `${baseUrl}/registry` });
+  if (registry.ok) {
+    return { ok: true, message: "Custom runtime /registry responded successfully." };
+  }
+
+  return {
+    ok: false,
+    message:
+      health.text ||
+      registry.text ||
+      "Custom runtime did not respond on /health or /registry.",
+  };
+};
+
 async function main() {
   loadRuntimeEnv();
+  const args = parseDoctorArgs(process.argv.slice(2));
 
   const env = process.env;
   const stateDir = resolveStateDir(env);
@@ -219,16 +250,49 @@ async function main() {
     checks.push(checkWarn("Gateway hints", warning));
   }
 
+  if (runtimeContext.adapterType === "openclaw") {
+    for (const warning of buildOpenClawWarnings({
+      gatewayUrl: runtimeContext.gatewayUrl,
+      tokenConfigured: runtimeContext.tokenConfigured,
+    })) {
+      checks.push(checkWarn("OpenClaw hints", warning, [
+        "If the browser/device is not yet approved, check `openclaw devices list` and approve the pending device before retrying the remote connection.",
+      ]));
+    }
+  }
+
+  if (shouldRunCustomChecks({ runtimeContext })) {
+    for (const warning of buildCustomRuntimeWarnings({
+      gatewayUrl: runtimeContext.gatewayUrl,
+      allowlist: trim(env.CUSTOM_RUNTIME_ALLOWLIST) || trim(env.UPSTREAM_ALLOWLIST),
+      nodeEnv: trim(env.NODE_ENV),
+    })) {
+      checks.push(checkWarn("Custom runtime hints", warning));
+    }
+  }
+
   if (runtimeContext.gatewayUrl) {
-    const wsProbe = await probeWebSocket(runtimeContext.gatewayUrl);
-    checks.push(
-      wsProbe.ok
-        ? checkPass("Gateway reachability", wsProbe.message)
-        : checkFail("Gateway reachability", wsProbe.message, [
-            "Verify the configured gateway URL is correct and the backend is listening.",
-            "If this is a public/tunneled deployment, compare direct local/LAN behavior before debugging deeper.",
-          ]),
-    );
+    if (runtimeContext.adapterType === "custom") {
+      const customProbe = await probeCustomRuntimeHealth(runtimeContext.gatewayUrl);
+      checks.push(
+        customProbe.ok
+          ? checkPass("Custom runtime reachability", customProbe.message)
+          : checkFail("Custom runtime reachability", customProbe.message, [
+              "Verify the custom runtime base URL is correct and exposes /health or /registry over HTTP.",
+              "If this runtime sits behind the Studio custom proxy, verify CUSTOM_RUNTIME_ALLOWLIST / UPSTREAM_ALLOWLIST for the target host.",
+            ]),
+      );
+    } else {
+      const wsProbe = await probeWebSocket(runtimeContext.gatewayUrl);
+      checks.push(
+        wsProbe.ok
+          ? checkPass("Gateway reachability", wsProbe.message)
+          : checkFail("Gateway reachability", wsProbe.message, [
+              "Verify the configured gateway URL is correct and the backend is listening.",
+              "If this is a public/tunneled deployment, compare direct local/LAN behavior before debugging deeper.",
+            ]),
+      );
+    }
   }
 
   const openclawConfigPath = path.join(stateDir, "openclaw.json");
@@ -250,6 +314,17 @@ async function main() {
         : checkWarn("OpenClaw version", version, [
             "Install OpenClaw or ensure it is available on PATH if this machine should run it directly.",
           ]),
+    );
+  }
+
+  if (shouldRunDemoChecks({ runtimeContext, env })) {
+    const configuredPort = trim(env.DEMO_ADAPTER_PORT) || "18789";
+    checks.push(
+      checkPass(
+        "Demo gateway config",
+        `Demo mode expects the mock gateway on ws://localhost:${configuredPort}.`,
+        ["Run `npm run demo-gateway` if you want a no-runtime office smoke test."],
+      ),
     );
   }
 
@@ -299,13 +374,17 @@ async function main() {
   }
 
   const summary = summarizeChecks(checks);
-  const report = formatDoctorReport({
+  const reportInput = {
     summary,
     runtimeContext,
     paths: { stateDir, settingsPath },
     checks,
-  });
-  console.log(report);
+  };
+  if (args.json) {
+    console.log(JSON.stringify(buildDoctorJsonReport(reportInput), null, 2));
+  } else {
+    console.log(formatDoctorReport(reportInput));
+  }
   process.exit(summary === DOCTOR_STATUSES.fail ? 1 : 0);
 }
 

--- a/scripts/claw3doctor.mjs
+++ b/scripts/claw3doctor.mjs
@@ -8,6 +8,7 @@ import {
   buildCustomRuntimeWarnings,
   buildDoctorJsonReport,
   buildGatewayFailureActions,
+  classifyGatewayFailure,
   buildProfileWarnings,
   DOCTOR_STATUSES,
   buildGatewayWarnings,
@@ -105,9 +106,32 @@ const checkFail = (category, label, message, actions) => ({
 
 const trim = (value) => (typeof value === "string" ? value.trim() : "");
 
-const parseDoctorArgs = (argv) => ({
-  json: argv.includes("--json"),
-});
+const parseDoctorArgs = (argv) => {
+  const args = {
+    json: false,
+    allProfiles: false,
+    profile: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const entry = argv[index];
+    if (entry === "--json") {
+      args.json = true;
+      continue;
+    }
+    if (entry === "--all-profiles") {
+      args.allProfiles = true;
+      continue;
+    }
+    if (entry === "--profile") {
+      const next = trim(argv[index + 1]).toLowerCase();
+      if (next) {
+        args.profile = next;
+        index += 1;
+      }
+    }
+  }
+  return args;
+};
 
 const probeWebSocket = async (url, timeoutMs = 3500) =>
   await new Promise((resolve) => {
@@ -301,6 +325,40 @@ async function main() {
     ]));
   }
 
+  if (args.profile) {
+    const requestedProfile = runtimeContext.profiles?.[args.profile];
+    checks.push(
+      requestedProfile
+        ? checkPass(
+            "Runtime profiles",
+            "Profile selection",
+            `Scoped diagnostics to the ${args.profile} profile.`,
+          )
+        : checkFail(
+            "Runtime profiles",
+            "Profile selection",
+            `Requested profile "${args.profile}" is not configured in current Studio settings.`,
+            ["Run `node scripts/claw3doctor.mjs --all-profiles` to see the configured profile list."],
+          ),
+    );
+  } else if (args.allProfiles) {
+    checks.push(
+      checkPass(
+        "Runtime profiles",
+        "Profile selection",
+        "Running diagnostics across all configured runtime profiles.",
+      ),
+    );
+  } else {
+    checks.push(
+      checkPass(
+        "Runtime profiles",
+        "Profile selection",
+        `Running diagnostics for the selected ${runtimeContext.adapterType} profile only.`,
+      ),
+    );
+  }
+
   for (const warning of buildGatewayWarnings({
     gatewayUrl: runtimeContext.gatewayUrl,
     studioAccessToken: trim(env.STUDIO_ACCESS_TOKEN),
@@ -330,7 +388,11 @@ async function main() {
     }
   }
 
-  const profileEntries = Object.entries(runtimeContext.profiles ?? {});
+  const profileEntries = Object.entries(runtimeContext.profiles ?? {}).filter(([adapterType]) => {
+    if (args.allProfiles) return true;
+    if (args.profile) return adapterType === args.profile;
+    return adapterType === runtimeContext.adapterType;
+  });
   for (const [adapterTypeRaw, profile] of profileEntries) {
     const adapterType = adapterTypeRaw;
     const url = trim(profile?.url);
@@ -358,6 +420,16 @@ async function main() {
             ),
           ),
     );
+    const classification = classifyGatewayFailure({ message: health.message });
+    if (classification) {
+      checks.push(
+        checkWarn(
+          "Failure analysis",
+          `${label} failure class`,
+          `${classification.code} ${classification.label}: ${classification.message}`,
+        ),
+      );
+    }
   }
 
   const openclawConfigPath = path.join(stateDir, "openclaw.json");

--- a/scripts/lib/claw3doctor-core.mjs
+++ b/scripts/lib/claw3doctor-core.mjs
@@ -283,6 +283,72 @@ export const buildGatewayFailureActions = ({ adapterType, message = "", gatewayU
   return [...new Set(actions)];
 };
 
+export const classifyGatewayFailure = ({ message = "" }) => {
+  const normalized = trimString(message).toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized.includes("1008") || normalized.includes("pairing required")) {
+    return {
+      code: "1008",
+      label: "Policy or pairing gate",
+      message:
+        "The upstream is rejecting this session for policy/pairing reasons. Check device approval, browser identity, and token flow.",
+    };
+  }
+
+  if (normalized.includes("1011")) {
+    return {
+      code: "1011",
+      label: "Upstream runtime or proxy failure",
+      message:
+        "The websocket upgraded but the upstream failed mid-connect or during runtime handling. Check runtime logs and reverse-proxy websocket support.",
+    };
+  }
+
+  if (normalized.includes("1012")) {
+    return {
+      code: "1012",
+      label: "Service restart or temporary unavailability",
+      message:
+        "The upstream likely restarted or was briefly unavailable. Recheck service health and retry once the backend settles.",
+    };
+  }
+
+  if (
+    normalized.includes("401") ||
+    normalized.includes("403") ||
+    normalized.includes("unexpected http 401") ||
+    normalized.includes("unexpected http 403")
+  ) {
+    return {
+      code: normalized.includes("403") ? "403" : "401",
+      label: "Auth rejection",
+      message:
+        "The upstream or proxy rejected auth before the office connected. Recheck the selected profile token, studio access path, and adapter env alignment.",
+    };
+  }
+
+  if (normalized.includes("econnrefused")) {
+    return {
+      code: "ECONNREFUSED",
+      label: "Listener missing",
+      message:
+        "Nothing is listening on the configured host/port. Start the backend or fix the profile URL before retrying.",
+    };
+  }
+
+  if (normalized.includes("timed out")) {
+    return {
+      code: "TIMEOUT",
+      label: "Connection timeout",
+      message:
+        "The endpoint did not complete the handshake in time. Check proxy path, host reachability, and whether the backend is overloaded or hanging.",
+    };
+  }
+
+  return null;
+};
+
 export const summarizeChecks = (checks) => {
   let hasFail = false;
   let hasWarn = false;

--- a/scripts/lib/claw3doctor-core.mjs
+++ b/scripts/lib/claw3doctor-core.mjs
@@ -1,0 +1,147 @@
+export const DOCTOR_STATUSES = {
+  pass: "PASS",
+  warn: "WARN",
+  fail: "FAIL",
+};
+
+const VALID_ADAPTER_TYPES = new Set(["openclaw", "hermes", "demo", "custom"]);
+const TUNNEL_HOST_PATTERN = /(cloudflare|trycloudflare|ngrok|tailscale|ts\.net|tunnel)/i;
+
+const isRecord = (value) => Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+const trimString = (value) => (typeof value === "string" ? value.trim() : "");
+
+export const normalizeAdapterType = (value, fallback = "openclaw") => {
+  const normalized = trimString(value).toLowerCase();
+  return VALID_ADAPTER_TYPES.has(normalized) ? normalized : fallback;
+};
+
+export const resolveRuntimeContext = ({ settings, upstreamGateway, env = process.env }) => {
+  const gateway = isRecord(settings?.gateway) ? settings.gateway : null;
+  const adapterType = normalizeAdapterType(
+    gateway?.adapterType ?? upstreamGateway?.adapterType ?? env.CLAW3D_GATEWAY_ADAPTER_TYPE,
+    "openclaw",
+  );
+  const rawProfiles = isRecord(gateway?.profiles) ? gateway.profiles : null;
+  const profiles = {};
+  for (const key of VALID_ADAPTER_TYPES) {
+    const profile = isRecord(rawProfiles?.[key]) ? rawProfiles[key] : null;
+    const url = trimString(profile?.url);
+    const token = trimString(profile?.token);
+    if (!url) continue;
+    profiles[key] = { url, token };
+  }
+
+  const selectedProfile =
+    profiles[adapterType] ??
+    (trimString(upstreamGateway?.url)
+      ? {
+          url: trimString(upstreamGateway.url),
+          token: trimString(upstreamGateway?.token),
+        }
+      : null);
+
+  return {
+    adapterType,
+    gatewayUrl: selectedProfile?.url ?? "",
+    token: selectedProfile?.token ?? "",
+    tokenConfigured: Boolean(selectedProfile?.token),
+    profiles,
+  };
+};
+
+export const buildGatewayWarnings = ({ gatewayUrl, studioAccessToken = "", host = "" }) => {
+  const warnings = [];
+  const url = trimString(gatewayUrl);
+  if (!url) {
+    warnings.push("No gateway URL configured.");
+    return warnings;
+  }
+
+  let parsed = null;
+  try {
+    parsed = new URL(url);
+  } catch {
+    warnings.push("Gateway URL is not a valid URL.");
+    return warnings;
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  const hostname = parsed.hostname.toLowerCase();
+  const isLocalHost =
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.endsWith(".local");
+  const isRemote = !isLocalHost;
+
+  if (isRemote && protocol === "ws:") {
+    warnings.push(
+      "Remote gateway uses ws://. Public or cross-device browser connections usually need wss:// or an HTTPS-backed Studio proxy.",
+    );
+  }
+
+  if (isRemote && TUNNEL_HOST_PATTERN.test(hostname)) {
+    warnings.push(
+      "Gateway host looks tunnel-backed. If connect fails, compare direct local/LAN behavior before debugging the runtime itself.",
+    );
+  }
+
+  const normalizedHost = trimString(host).toLowerCase();
+  const publicStudioHost =
+    normalizedHost &&
+    normalizedHost !== "localhost" &&
+    normalizedHost !== "127.0.0.1" &&
+    normalizedHost !== "::1" &&
+    normalizedHost !== "0.0.0.0";
+  if (publicStudioHost && !trimString(studioAccessToken)) {
+    warnings.push(
+      "Studio appears to be configured for a public host without STUDIO_ACCESS_TOKEN. Remote admin access should not be exposed that way.",
+    );
+  }
+
+  return warnings;
+};
+
+export const summarizeChecks = (checks) => {
+  let hasFail = false;
+  let hasWarn = false;
+  for (const check of checks) {
+    if (check.status === DOCTOR_STATUSES.fail) hasFail = true;
+    if (check.status === DOCTOR_STATUSES.warn) hasWarn = true;
+  }
+  if (hasFail) return DOCTOR_STATUSES.fail;
+  if (hasWarn) return DOCTOR_STATUSES.warn;
+  return DOCTOR_STATUSES.pass;
+};
+
+export const shouldRunHermesChecks = ({ runtimeContext, env = process.env }) =>
+  runtimeContext.adapterType === "hermes" ||
+  Boolean(trimString(env.HERMES_API_URL) || trimString(env.HERMES_ADAPTER_PORT));
+
+export const shouldRunOpenClawChecks = ({ runtimeContext, openclawConfigExists = false }) =>
+  runtimeContext.adapterType === "openclaw" || openclawConfigExists;
+
+export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) => {
+  const lines = [];
+  lines.push(`Claw3Doctor: ${summary}`);
+  lines.push("");
+  lines.push(`Runtime provider: ${runtimeContext.adapterType}`);
+  lines.push(`Gateway URL: ${runtimeContext.gatewayUrl || "(not configured)"}`);
+  lines.push(`Gateway token: ${runtimeContext.tokenConfigured ? "configured" : "missing"}`);
+  lines.push(`State dir: ${paths.stateDir}`);
+  lines.push(`Studio settings: ${paths.settingsPath}`);
+  lines.push("");
+  for (const check of checks) {
+    lines.push(`[${check.status.toLowerCase()}] ${check.label}: ${check.message}`);
+  }
+  const actions = checks.flatMap((check) => check.actions ?? []);
+  if (actions.length > 0) {
+    lines.push("");
+    lines.push("Suggested next actions:");
+    actions.forEach((action, index) => {
+      lines.push(`${index + 1}. ${action}`);
+    });
+  }
+  return lines.join("\n");
+};

--- a/scripts/lib/claw3doctor-core.mjs
+++ b/scripts/lib/claw3doctor-core.mjs
@@ -16,6 +16,20 @@ const DEFAULT_GATEWAY_URL_BY_ADAPTER = {
 const isRecord = (value) => Boolean(value && typeof value === "object" && !Array.isArray(value));
 
 const trimString = (value) => (typeof value === "string" ? value.trim() : "");
+const supportsAnsi = () => Boolean(process.stdout?.isTTY && process.env.NO_COLOR !== "1");
+const colorize = (text, code) => (supportsAnsi() ? `\u001b[${code}m${text}\u001b[0m` : text);
+const formatStatusBadge = (status) => {
+  switch (status) {
+    case DOCTOR_STATUSES.pass:
+      return colorize("[PASS]", "32");
+    case DOCTOR_STATUSES.warn:
+      return colorize("[WARN]", "33");
+    case DOCTOR_STATUSES.fail:
+      return colorize("[FAIL]", "31");
+    default:
+      return `[${status}]`;
+  }
+};
 
 export const normalizeAdapterType = (value, fallback = "openclaw") => {
   const normalized = trimString(value).toLowerCase();
@@ -221,6 +235,14 @@ export const buildGatewayFailureActions = ({ adapterType, message = "", gatewayU
   const actions = [];
   const normalized = trimString(message).toLowerCase();
   const url = trimString(gatewayUrl);
+  let parsedUrl = null;
+  try {
+    parsedUrl = url ? new URL(url) : null;
+  } catch {}
+  const hostname = parsedUrl?.hostname?.toLowerCase() ?? "";
+  const isTunnelBacked = Boolean(hostname && TUNNEL_HOST_PATTERN.test(hostname));
+  const isCloudflare = hostname.includes("cloudflare");
+  const isTailscale = hostname.includes("tailscale") || hostname.endsWith("ts.net");
 
   if (normalized.includes("econnrefused") || normalized.includes("timed out")) {
     actions.push("Verify the backend is actually listening on the configured host and port before retrying from Claw3D.");
@@ -242,7 +264,15 @@ export const buildGatewayFailureActions = ({ adapterType, message = "", gatewayU
     actions.push("Recheck the configured token/auth path. The gateway or proxy is rejecting the connection before the office can load.");
   }
 
-  if (url && TUNNEL_HOST_PATTERN.test(url)) {
+  if (isCloudflare) {
+    actions.push("For Cloudflare or similar HTTPS tunnels, verify websocket upgrade forwarding and prefer an HTTPS-backed Studio path rather than a bare ws:// remote endpoint.");
+  }
+
+  if (isTailscale) {
+    actions.push("For Tailnet-hosted OpenClaw, test the same gateway directly on local/LAN first, then compare against the Tailnet URL so pairing/proxy issues do not get conflated.");
+  }
+
+  if (isTunnelBacked) {
     actions.push("Because this endpoint looks tunnel-backed, reproduce once via direct local or LAN access to separate runtime problems from tunnel/proxy problems.");
   }
 
@@ -291,12 +321,12 @@ export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) =
     groupedChecks.set(category, entries);
   }
   const lines = [];
-  lines.push("+--------------------------------------------------+");
-  lines.push(`| Claw3Doctor ${summary.padEnd(35, " ")}|`);
-  lines.push("+--------------------------------------------------+");
+  lines.push("==================================================");
+  lines.push(`Claw3Doctor ${formatStatusBadge(summary)}`);
+  lines.push("==================================================");
   lines.push("");
   lines.push(`Runtime provider: ${runtimeContext.adapterType}`);
-  lines.push(`Gateway URL: ${runtimeContext.gatewayUrl || "(not configured)"}`);
+  lines.push(`Selected profile: ${runtimeContext.gatewayUrl || "(not configured)"}`);
   lines.push(`Gateway token: ${runtimeContext.tokenConfigured ? "configured" : "missing"}`);
   lines.push(`State dir: ${paths.stateDir}`);
   lines.push(`Studio settings: ${paths.settingsPath}`);
@@ -313,8 +343,9 @@ export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) =
   lines.push("");
   for (const [category, categoryChecks] of groupedChecks.entries()) {
     lines.push(`${category}`);
+    lines.push("-".repeat(category.length));
     for (const check of categoryChecks) {
-      lines.push(`  [${check.status.toLowerCase()}] ${check.label}: ${check.message}`);
+      lines.push(`  ${formatStatusBadge(check.status)} ${check.label}: ${check.message}`);
     }
     lines.push("");
   }

--- a/scripts/lib/claw3doctor-core.mjs
+++ b/scripts/lib/claw3doctor-core.mjs
@@ -437,3 +437,34 @@ export const buildDoctorJsonReport = ({ summary, runtimeContext, paths, checks }
     fail: checks.filter((check) => check.status === DOCTOR_STATUSES.fail).length,
   },
 });
+
+/**
+ * Parse CLI argv into structured doctor args.
+ * Exported so the flag behaviour can be unit tested without spawning a process.
+ */
+export const parseDoctorArgs = (argv) => {
+  const args = {
+    json: false,
+    allProfiles: false,
+    profile: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const entry = argv[index];
+    if (entry === "--json") {
+      args.json = true;
+      continue;
+    }
+    if (entry === "--all-profiles") {
+      args.allProfiles = true;
+      continue;
+    }
+    if (entry === "--profile") {
+      const next = trimString(argv[index + 1] ?? "").toLowerCase();
+      if (next) {
+        args.profile = next;
+        index += 1;
+      }
+    }
+  }
+  return args;
+};

--- a/scripts/lib/claw3doctor-core.mjs
+++ b/scripts/lib/claw3doctor-core.mjs
@@ -113,6 +113,28 @@ export const buildGatewayWarnings = ({ gatewayUrl, studioAccessToken = "", host 
   return warnings;
 };
 
+export const buildProfileWarnings = ({ runtimeContext }) => {
+  const warnings = [];
+  const urlToAdapters = new Map();
+  for (const [adapterType, profile] of Object.entries(runtimeContext?.profiles ?? {})) {
+    const url = trimString(profile?.url);
+    if (!url) continue;
+    const key = url.toLowerCase();
+    const adapters = urlToAdapters.get(key) ?? [];
+    adapters.push(adapterType);
+    urlToAdapters.set(key, adapters);
+  }
+
+  for (const [url, adapters] of urlToAdapters.entries()) {
+    if (adapters.length < 2) continue;
+    warnings.push(
+      `Multiple runtime profiles share the same endpoint (${url}): ${adapters.join(", ")}. That is fine for one-runtime-at-a-time local use, but simultaneous runtimes need distinct URLs or ports.`,
+    );
+  }
+
+  return warnings;
+};
+
 export const buildOpenClawWarnings = ({ gatewayUrl, tokenConfigured = false }) => {
   const warnings = [];
   const url = trimString(gatewayUrl);
@@ -189,6 +211,42 @@ export const buildCustomRuntimeWarnings = ({
   return warnings;
 };
 
+export const buildGatewayFailureActions = ({ adapterType, message = "", gatewayUrl = "" }) => {
+  const actions = [];
+  const normalized = trimString(message).toLowerCase();
+  const url = trimString(gatewayUrl);
+
+  if (normalized.includes("econnrefused") || normalized.includes("timed out")) {
+    actions.push("Verify the backend is actually listening on the configured host and port before retrying from Claw3D.");
+  }
+
+  if (normalized.includes("1011")) {
+    actions.push("If this is OpenClaw behind a reverse proxy or tunnel, verify websocket upgrade handling and compare direct local/LAN behavior before assuming the runtime itself is broken.");
+  }
+
+  if (normalized.includes("1012")) {
+    actions.push("A 1012-style close usually means the upstream is restarting or unavailable temporarily. Retry after checking the backend service logs.");
+  }
+
+  if (normalized.includes("1008") || normalized.includes("pairing required") || normalized.includes("approve")) {
+    actions.push("For OpenClaw, check pending device/browser approval with `openclaw devices list` and approve the request before retrying the remote browser session.");
+  }
+
+  if (normalized.includes("401") || normalized.includes("403") || normalized.includes("unexpected http 401")) {
+    actions.push("Recheck the configured token/auth path. The gateway or proxy is rejecting the connection before the office can load.");
+  }
+
+  if (url && TUNNEL_HOST_PATTERN.test(url)) {
+    actions.push("Because this endpoint looks tunnel-backed, reproduce once via direct local or LAN access to separate runtime problems from tunnel/proxy problems.");
+  }
+
+  if (adapterType === "custom") {
+    actions.push("Custom runtimes should answer over HTTP on /health or /registry, not just a raw websocket endpoint.");
+  }
+
+  return [...new Set(actions)];
+};
+
 export const summarizeChecks = (checks) => {
   let hasFail = false;
   let hasWarn = false;
@@ -214,21 +272,48 @@ export const shouldRunDemoChecks = ({ runtimeContext, env = process.env }) =>
 export const shouldRunCustomChecks = ({ runtimeContext }) => runtimeContext.adapterType === "custom";
 
 export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) => {
+  const summaryCounts = {
+    pass: checks.filter((check) => check.status === DOCTOR_STATUSES.pass).length,
+    warn: checks.filter((check) => check.status === DOCTOR_STATUSES.warn).length,
+    fail: checks.filter((check) => check.status === DOCTOR_STATUSES.fail).length,
+  };
+  const groupedChecks = new Map();
+  for (const check of checks) {
+    const category = check.category || "General";
+    const entries = groupedChecks.get(category) ?? [];
+    entries.push(check);
+    groupedChecks.set(category, entries);
+  }
   const lines = [];
-  lines.push(`Claw3Doctor: ${summary}`);
+  lines.push("+--------------------------------------------------+");
+  lines.push(`| Claw3Doctor ${summary.padEnd(35, " ")}|`);
+  lines.push("+--------------------------------------------------+");
   lines.push("");
   lines.push(`Runtime provider: ${runtimeContext.adapterType}`);
   lines.push(`Gateway URL: ${runtimeContext.gatewayUrl || "(not configured)"}`);
   lines.push(`Gateway token: ${runtimeContext.tokenConfigured ? "configured" : "missing"}`);
   lines.push(`State dir: ${paths.stateDir}`);
   lines.push(`Studio settings: ${paths.settingsPath}`);
+  const configuredProfiles = Object.entries(runtimeContext.profiles ?? {});
+  if (configuredProfiles.length > 0) {
+    lines.push("Configured profiles:");
+    for (const [adapterType, profile] of configuredProfiles) {
+      lines.push(`  - ${adapterType}: ${profile.url}`);
+    }
+  }
+  lines.push(
+    `Check counts: ${summaryCounts.pass} pass, ${summaryCounts.warn} warn, ${summaryCounts.fail} fail`,
+  );
   lines.push("");
-  for (const check of checks) {
-    lines.push(`[${check.status.toLowerCase()}] ${check.label}: ${check.message}`);
+  for (const [category, categoryChecks] of groupedChecks.entries()) {
+    lines.push(`${category}`);
+    for (const check of categoryChecks) {
+      lines.push(`  [${check.status.toLowerCase()}] ${check.label}: ${check.message}`);
+    }
+    lines.push("");
   }
   const actions = checks.flatMap((check) => check.actions ?? []);
   if (actions.length > 0) {
-    lines.push("");
     lines.push("Suggested next actions:");
     actions.forEach((action, index) => {
       lines.push(`${index + 1}. ${action}`);
@@ -243,4 +328,9 @@ export const buildDoctorJsonReport = ({ summary, runtimeContext, paths, checks }
   runtimeContext,
   paths,
   checks,
+  counts: {
+    pass: checks.filter((check) => check.status === DOCTOR_STATUSES.pass).length,
+    warn: checks.filter((check) => check.status === DOCTOR_STATUSES.warn).length,
+    fail: checks.filter((check) => check.status === DOCTOR_STATUSES.fail).length,
+  },
 });

--- a/scripts/lib/claw3doctor-core.mjs
+++ b/scripts/lib/claw3doctor-core.mjs
@@ -5,7 +5,8 @@ export const DOCTOR_STATUSES = {
 };
 
 const VALID_ADAPTER_TYPES = new Set(["openclaw", "hermes", "demo", "custom"]);
-const TUNNEL_HOST_PATTERN = /(cloudflare|trycloudflare|ngrok|tailscale|ts\.net|tunnel)/i;
+const TUNNEL_HOST_PATTERN =
+  /(cloudflare|trycloudflare|ngrok|tailscale|ts\.net|tunnel)/i;
 const DEFAULT_GATEWAY_URL_BY_ADAPTER = {
   openclaw: "ws://localhost:18789",
   hermes: "ws://localhost:18789",
@@ -13,11 +14,14 @@ const DEFAULT_GATEWAY_URL_BY_ADAPTER = {
   custom: "http://localhost:7770",
 };
 
-const isRecord = (value) => Boolean(value && typeof value === "object" && !Array.isArray(value));
+const isRecord = (value) =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
 
 const trimString = (value) => (typeof value === "string" ? value.trim() : "");
-const supportsAnsi = () => Boolean(process.stdout?.isTTY && process.env.NO_COLOR !== "1");
-const colorize = (text, code) => (supportsAnsi() ? `\u001b[${code}m${text}\u001b[0m` : text);
+const supportsAnsi = () =>
+  Boolean(process.stdout?.isTTY && process.env.NO_COLOR !== "1");
+const colorize = (text, code) =>
+  supportsAnsi() ? `\u001b[${code}m${text}\u001b[0m` : text;
 const formatStatusBadge = (status) => {
   switch (status) {
     case DOCTOR_STATUSES.pass:
@@ -36,10 +40,16 @@ export const normalizeAdapterType = (value, fallback = "openclaw") => {
   return VALID_ADAPTER_TYPES.has(normalized) ? normalized : fallback;
 };
 
-export const resolveRuntimeContext = ({ settings, upstreamGateway, env = process.env }) => {
+export const resolveRuntimeContext = ({
+  settings,
+  upstreamGateway,
+  env = process.env,
+}) => {
   const gateway = isRecord(settings?.gateway) ? settings.gateway : null;
   const adapterType = normalizeAdapterType(
-    gateway?.adapterType ?? upstreamGateway?.adapterType ?? env.CLAW3D_GATEWAY_ADAPTER_TYPE,
+    gateway?.adapterType ??
+      upstreamGateway?.adapterType ??
+      env.CLAW3D_GATEWAY_ADAPTER_TYPE,
     "openclaw",
   );
   const rawProfiles = isRecord(gateway?.profiles) ? gateway.profiles : null;
@@ -80,7 +90,11 @@ export const resolveRuntimeContext = ({ settings, upstreamGateway, env = process
   };
 };
 
-export const buildGatewayWarnings = ({ gatewayUrl, studioAccessToken = "", host = "" }) => {
+export const buildGatewayWarnings = ({
+  gatewayUrl,
+  studioAccessToken = "",
+  host = "",
+}) => {
   const warnings = [];
   const url = trimString(gatewayUrl);
   if (!url) {
@@ -136,7 +150,9 @@ export const buildGatewayWarnings = ({ gatewayUrl, studioAccessToken = "", host 
 export const buildProfileWarnings = ({ runtimeContext }) => {
   const warnings = [];
   const urlToAdapters = new Map();
-  for (const [adapterType, profile] of Object.entries(runtimeContext?.profiles ?? {})) {
+  for (const [adapterType, profile] of Object.entries(
+    runtimeContext?.profiles ?? {},
+  )) {
     const url = trimString(profile?.url);
     if (!url) continue;
     const key = url.toLowerCase();
@@ -155,7 +171,10 @@ export const buildProfileWarnings = ({ runtimeContext }) => {
   return warnings;
 };
 
-export const buildOpenClawWarnings = ({ gatewayUrl, tokenConfigured = false }) => {
+export const buildOpenClawWarnings = ({
+  gatewayUrl,
+  tokenConfigured = false,
+}) => {
   const warnings = [];
   const url = trimString(gatewayUrl);
   if (!url) return warnings;
@@ -231,7 +250,11 @@ export const buildCustomRuntimeWarnings = ({
   return warnings;
 };
 
-export const buildGatewayFailureActions = ({ adapterType, message = "", gatewayUrl = "" }) => {
+export const buildGatewayFailureActions = ({
+  adapterType,
+  message = "",
+  gatewayUrl = "",
+}) => {
   const actions = [];
   const normalized = trimString(message).toLowerCase();
   const url = trimString(gatewayUrl);
@@ -240,44 +263,73 @@ export const buildGatewayFailureActions = ({ adapterType, message = "", gatewayU
     parsedUrl = url ? new URL(url) : null;
   } catch {}
   const hostname = parsedUrl?.hostname?.toLowerCase() ?? "";
-  const isTunnelBacked = Boolean(hostname && TUNNEL_HOST_PATTERN.test(hostname));
+  const isTunnelBacked = Boolean(
+    hostname && TUNNEL_HOST_PATTERN.test(hostname),
+  );
   const isCloudflare = hostname.includes("cloudflare");
-  const isTailscale = hostname.includes("tailscale") || hostname.endsWith("ts.net");
+  const isTailscale =
+    hostname.includes("tailscale") || hostname.endsWith("ts.net");
 
   if (normalized.includes("econnrefused") || normalized.includes("timed out")) {
-    actions.push("Verify the backend is actually listening on the configured host and port before retrying from Claw3D.");
+    actions.push(
+      "Verify the backend is actually listening on the configured host and port before retrying from Claw3D.",
+    );
   }
 
   if (normalized.includes("1011")) {
-    actions.push("If this is OpenClaw behind a reverse proxy or tunnel, verify websocket upgrade handling and compare direct local/LAN behavior before assuming the runtime itself is broken.");
+    actions.push(
+      "If this is OpenClaw behind a reverse proxy or tunnel, verify websocket upgrade handling and compare direct local/LAN behavior before assuming the runtime itself is broken.",
+    );
   }
 
   if (normalized.includes("1012")) {
-    actions.push("A 1012-style close usually means the upstream is restarting or unavailable temporarily. Retry after checking the backend service logs.");
+    actions.push(
+      "A 1012-style close usually means the upstream is restarting or unavailable temporarily. Retry after checking the backend service logs.",
+    );
   }
 
-  if (normalized.includes("1008") || normalized.includes("pairing required") || normalized.includes("approve")) {
-    actions.push("For OpenClaw, check pending device/browser approval with `openclaw devices list` and approve the request before retrying the remote browser session.");
+  if (
+    normalized.includes("1008") ||
+    normalized.includes("pairing required") ||
+    normalized.includes("approve")
+  ) {
+    actions.push(
+      "For OpenClaw, check pending device/browser approval with `openclaw devices list` and approve the request before retrying the remote browser session.",
+    );
   }
 
-  if (normalized.includes("401") || normalized.includes("403") || normalized.includes("unexpected http 401")) {
-    actions.push("Recheck the configured token/auth path. The gateway or proxy is rejecting the connection before the office can load.");
+  if (
+    normalized.includes("401") ||
+    normalized.includes("403") ||
+    normalized.includes("unexpected http 401")
+  ) {
+    actions.push(
+      "Recheck the configured token/auth path. The gateway or proxy is rejecting the connection before the office can load.",
+    );
   }
 
   if (isCloudflare) {
-    actions.push("For Cloudflare or similar HTTPS tunnels, verify websocket upgrade forwarding and prefer an HTTPS-backed Studio path rather than a bare ws:// remote endpoint.");
+    actions.push(
+      "For Cloudflare or similar HTTPS tunnels, verify websocket upgrade forwarding and prefer an HTTPS-backed Studio path rather than a bare ws:// remote endpoint.",
+    );
   }
 
   if (isTailscale) {
-    actions.push("For Tailnet-hosted OpenClaw, test the same gateway directly on local/LAN first, then compare against the Tailnet URL so pairing/proxy issues do not get conflated.");
+    actions.push(
+      "For Tailnet-hosted OpenClaw, test the same gateway directly on local/LAN first, then compare against the Tailnet URL so pairing/proxy issues do not get conflated.",
+    );
   }
 
   if (isTunnelBacked) {
-    actions.push("Because this endpoint looks tunnel-backed, reproduce once via direct local or LAN access to separate runtime problems from tunnel/proxy problems.");
+    actions.push(
+      "Because this endpoint looks tunnel-backed, reproduce once via direct local or LAN access to separate runtime problems from tunnel/proxy problems.",
+    );
   }
 
   if (adapterType === "custom") {
-    actions.push("Custom runtimes should answer over HTTP on /health or /registry, not just a raw websocket endpoint.");
+    actions.push(
+      "Custom runtimes should answer over HTTP on /health or /registry, not just a raw websocket endpoint.",
+    );
   }
 
   return [...new Set(actions)];
@@ -363,21 +415,35 @@ export const summarizeChecks = (checks) => {
 
 export const shouldRunHermesChecks = ({ runtimeContext, env = process.env }) =>
   runtimeContext.adapterType === "hermes" ||
-  Boolean(trimString(env.HERMES_API_URL) || trimString(env.HERMES_ADAPTER_PORT));
+  Boolean(
+    trimString(env.HERMES_API_URL) || trimString(env.HERMES_ADAPTER_PORT),
+  );
 
-export const shouldRunOpenClawChecks = ({ runtimeContext, openclawConfigExists = false }) =>
-  runtimeContext.adapterType === "openclaw" || openclawConfigExists;
+export const shouldRunOpenClawChecks = ({
+  runtimeContext,
+  openclawConfigExists = false,
+}) => runtimeContext.adapterType === "openclaw" || openclawConfigExists;
 
 export const shouldRunDemoChecks = ({ runtimeContext, env = process.env }) =>
-  runtimeContext.adapterType === "demo" || Boolean(trimString(env.DEMO_ADAPTER_PORT));
+  runtimeContext.adapterType === "demo" ||
+  Boolean(trimString(env.DEMO_ADAPTER_PORT));
 
-export const shouldRunCustomChecks = ({ runtimeContext }) => runtimeContext.adapterType === "custom";
+export const shouldRunCustomChecks = ({ runtimeContext }) =>
+  runtimeContext.adapterType === "custom";
 
-export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) => {
+export const formatDoctorReport = ({
+  summary,
+  runtimeContext,
+  paths,
+  checks,
+}) => {
   const summaryCounts = {
-    pass: checks.filter((check) => check.status === DOCTOR_STATUSES.pass).length,
-    warn: checks.filter((check) => check.status === DOCTOR_STATUSES.warn).length,
-    fail: checks.filter((check) => check.status === DOCTOR_STATUSES.fail).length,
+    pass: checks.filter((check) => check.status === DOCTOR_STATUSES.pass)
+      .length,
+    warn: checks.filter((check) => check.status === DOCTOR_STATUSES.warn)
+      .length,
+    fail: checks.filter((check) => check.status === DOCTOR_STATUSES.fail)
+      .length,
   };
   const groupedChecks = new Map();
   for (const check of checks) {
@@ -392,8 +458,12 @@ export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) =
   lines.push("==================================================");
   lines.push("");
   lines.push(`Runtime provider: ${runtimeContext.adapterType}`);
-  lines.push(`Selected profile: ${runtimeContext.gatewayUrl || "(not configured)"}`);
-  lines.push(`Gateway token: ${runtimeContext.tokenConfigured ? "configured" : "missing"}`);
+  lines.push(
+    `Selected profile: ${runtimeContext.gatewayUrl || "(not configured)"}`,
+  );
+  lines.push(
+    `Gateway token: ${runtimeContext.tokenConfigured ? "configured" : "missing"}`,
+  );
   lines.push(`State dir: ${paths.stateDir}`);
   lines.push(`Studio settings: ${paths.settingsPath}`);
   const configuredProfiles = Object.entries(runtimeContext.profiles ?? {});
@@ -411,7 +481,9 @@ export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) =
     lines.push(`${category}`);
     lines.push("-".repeat(category.length));
     for (const check of categoryChecks) {
-      lines.push(`  ${formatStatusBadge(check.status)} ${check.label}: ${check.message}`);
+      lines.push(
+        `  ${formatStatusBadge(check.status)} ${check.label}: ${check.message}`,
+      );
     }
     lines.push("");
   }
@@ -425,16 +497,24 @@ export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) =
   return lines.join("\n");
 };
 
-export const buildDoctorJsonReport = ({ summary, runtimeContext, paths, checks }) => ({
+export const buildDoctorJsonReport = ({
+  summary,
+  runtimeContext,
+  paths,
+  checks,
+}) => ({
   doctor: "claw3doctor",
   summary,
   runtimeContext,
   paths,
   checks,
   counts: {
-    pass: checks.filter((check) => check.status === DOCTOR_STATUSES.pass).length,
-    warn: checks.filter((check) => check.status === DOCTOR_STATUSES.warn).length,
-    fail: checks.filter((check) => check.status === DOCTOR_STATUSES.fail).length,
+    pass: checks.filter((check) => check.status === DOCTOR_STATUSES.pass)
+      .length,
+    warn: checks.filter((check) => check.status === DOCTOR_STATUSES.warn)
+      .length,
+    fail: checks.filter((check) => check.status === DOCTOR_STATUSES.fail)
+      .length,
   },
 });
 

--- a/scripts/lib/claw3doctor-core.mjs
+++ b/scripts/lib/claw3doctor-core.mjs
@@ -6,6 +6,12 @@ export const DOCTOR_STATUSES = {
 
 const VALID_ADAPTER_TYPES = new Set(["openclaw", "hermes", "demo", "custom"]);
 const TUNNEL_HOST_PATTERN = /(cloudflare|trycloudflare|ngrok|tailscale|ts\.net|tunnel)/i;
+const DEFAULT_GATEWAY_URL_BY_ADAPTER = {
+  openclaw: "ws://localhost:18789",
+  hermes: "ws://localhost:18789",
+  demo: "ws://localhost:18789",
+  custom: "http://localhost:7770",
+};
 
 const isRecord = (value) => Boolean(value && typeof value === "object" && !Array.isArray(value));
 
@@ -32,14 +38,18 @@ export const resolveRuntimeContext = ({ settings, upstreamGateway, env = process
     profiles[key] = { url, token };
   }
 
-  const selectedProfile =
-    profiles[adapterType] ??
-    (trimString(upstreamGateway?.url)
+  const upstreamUrl = trimString(upstreamGateway?.url);
+  const selectedProfile = profiles[adapterType]
+    ? profiles[adapterType]
+    : upstreamUrl
       ? {
-          url: trimString(upstreamGateway.url),
+          url: upstreamUrl,
           token: trimString(upstreamGateway?.token),
         }
-      : null);
+      : {
+          url: DEFAULT_GATEWAY_URL_BY_ADAPTER[adapterType],
+          token: "",
+        };
 
   return {
     adapterType,
@@ -103,6 +113,82 @@ export const buildGatewayWarnings = ({ gatewayUrl, studioAccessToken = "", host 
   return warnings;
 };
 
+export const buildOpenClawWarnings = ({ gatewayUrl, tokenConfigured = false }) => {
+  const warnings = [];
+  const url = trimString(gatewayUrl);
+  if (!url) return warnings;
+
+  let parsed = null;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return warnings;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  const isLocalHost =
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.endsWith(".local");
+  if (isLocalHost) {
+    return warnings;
+  }
+
+  if (!tokenConfigured) {
+    warnings.push(
+      "Remote OpenClaw profile has no gateway token configured. Remote/browser clients often fail with pairing or approval-style errors until the device or token path is approved.",
+    );
+  }
+
+  if (TUNNEL_HOST_PATTERN.test(hostname)) {
+    warnings.push(
+      "Remote OpenClaw host looks tunnel-backed. If you hit 1008/1011/1012-style failures, verify direct local or LAN access first, then check pairing/device approval and reverse-proxy websocket handling.",
+    );
+  }
+
+  return warnings;
+};
+
+export const buildCustomRuntimeWarnings = ({
+  gatewayUrl,
+  allowlist = "",
+  nodeEnv = "",
+}) => {
+  const warnings = [];
+  const url = trimString(gatewayUrl);
+  if (!url) return warnings;
+
+  let parsed = null;
+  try {
+    parsed = new URL(url);
+  } catch {
+    warnings.push("Custom runtime URL is not a valid URL.");
+    return warnings;
+  }
+
+  if (parsed.protocol === "ws:" || parsed.protocol === "wss:") {
+    warnings.push(
+      "Custom runtime profile uses a websocket URL. The custom provider boundary is expected to expose an HTTP API (for example /health and /v1/chat/completions).",
+    );
+  }
+
+  const isProduction = trimString(nodeEnv).toLowerCase() === "production";
+  const hostname = parsed.hostname.toLowerCase();
+  const isLocalHost =
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.endsWith(".local");
+  if (isProduction && !isLocalHost && !trimString(allowlist)) {
+    warnings.push(
+      "Production custom runtime is configured without CUSTOM_RUNTIME_ALLOWLIST or UPSTREAM_ALLOWLIST. The runtime proxy should not rely on open-host defaults there.",
+    );
+  }
+
+  return warnings;
+};
+
 export const summarizeChecks = (checks) => {
   let hasFail = false;
   let hasWarn = false;
@@ -121,6 +207,11 @@ export const shouldRunHermesChecks = ({ runtimeContext, env = process.env }) =>
 
 export const shouldRunOpenClawChecks = ({ runtimeContext, openclawConfigExists = false }) =>
   runtimeContext.adapterType === "openclaw" || openclawConfigExists;
+
+export const shouldRunDemoChecks = ({ runtimeContext, env = process.env }) =>
+  runtimeContext.adapterType === "demo" || Boolean(trimString(env.DEMO_ADAPTER_PORT));
+
+export const shouldRunCustomChecks = ({ runtimeContext }) => runtimeContext.adapterType === "custom";
 
 export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) => {
   const lines = [];
@@ -145,3 +236,11 @@ export const formatDoctorReport = ({ summary, runtimeContext, paths, checks }) =
   }
   return lines.join("\n");
 };
+
+export const buildDoctorJsonReport = ({ summary, runtimeContext, paths, checks }) => ({
+  doctor: "claw3doctor",
+  summary,
+  runtimeContext,
+  paths,
+  checks,
+});

--- a/scripts/lib/claw3doctor-core.mjs
+++ b/scripts/lib/claw3doctor-core.mjs
@@ -50,6 +50,12 @@ export const resolveRuntimeContext = ({ settings, upstreamGateway, env = process
           url: DEFAULT_GATEWAY_URL_BY_ADAPTER[adapterType],
           token: "",
         };
+  if (selectedProfile?.url && !profiles[adapterType]) {
+    profiles[adapterType] = {
+      url: selectedProfile.url,
+      token: selectedProfile.token ?? "",
+    };
+  }
 
   return {
     adapterType,

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -1,84 +1,24 @@
 "use client";
 
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { MessageSquare, ChevronDown, Mic } from "lucide-react";
-import { RetroOffice3D } from "@/features/retro-office/RetroOffice3D";
-import type { OfficeAgent } from "@/features/retro-office/core/types";
-import { RunningAvatarLoader } from "@/features/agents/components/RunningAvatarLoader";
-import { GatewayConnectScreen } from "@/features/agents/components/GatewayConnectScreen";
-import { useAgentStore, type AgentState } from "@/features/agents/state/store";
-import {
-  GatewayClient,
-  buildAgentMainSessionKey,
-  type EventFrame,
-  isSameSessionKey,
-  parseAgentIdFromSessionKey,
-} from "@/lib/gateway/GatewayClient";
-import { useRuntimeConnection } from "@/lib/runtime/useRuntimeConnection";
-import {
-  createStudioSettingsCoordinator,
-  type StudioSettingsLoadOptions,
-} from "@/lib/studio/coordinator";
-import {
-  resolveDeskAssignments,
-  resolveOfficePreferencePublic,
-} from "@/lib/studio/settings";
-import {
-  createGatewayAgent,
-  renameGatewayAgent,
-} from "@/lib/gateway/agentConfig";
-import {
-  runStudioBootstrapLoadOperation,
-  executeStudioBootstrapLoadCommands,
-} from "@/features/agents/operations/studioBootstrapOperation";
-import { isGatewayDisconnectLikeError } from "@/lib/gateway/GatewayClient";
-import { createGatewayRuntimeEventHandler } from "@/features/agents/state/gatewayRuntimeEventHandler";
-import {
-  buildHistoryLines,
-  classifyGatewayEventKind,
-  isReasoningRuntimeAgentStream,
-  type AgentEventPayload,
-  type ChatEventPayload,
-  type SummaryPreviewSnapshot,
-} from "@/features/agents/state/runtimeEventBridge";
-import {
-  extractText,
-  extractThinking,
-  extractToolLines,
-  isHeartbeatPrompt,
-  stripUiMetadata,
-} from "@/lib/text/message-extract";
-import { resolveOfficeIntentSnapshot } from "@/lib/office/deskDirectives";
 import { AgentChatPanel } from "@/features/agents/components/AgentChatPanel";
-import {
-  RemoteAgentChatPanel,
-  type RemoteAgentChatMessage,
-} from "@/features/office/components/RemoteAgentChatPanel";
+import { AgentCreateWizardModal } from "@/features/agents/components/AgentCreateWizardModal";
 import {
   AgentEditorModal,
   type AgentEditorSection,
 } from "@/features/agents/components/AgentEditorModal";
-import { AgentCreateWizardModal } from "@/features/agents/components/AgentCreateWizardModal";
 import type { AgentIdentityValues } from "@/features/agents/components/AgentIdentityFields";
-import { useChatInteractionController } from "@/features/agents/operations/useChatInteractionController";
+import { GatewayConnectScreen } from "@/features/agents/components/GatewayConnectScreen";
+import { RunningAvatarLoader } from "@/features/agents/components/RunningAvatarLoader";
+import { planAgentSettingsMutation } from "@/features/agents/operations/agentSettingsMutationWorkflow";
 import {
-  applyCreateAgentBootstrapPermissions,
   CREATE_AGENT_DEFAULT_PERMISSIONS,
+  applyCreateAgentBootstrapPermissions,
 } from "@/features/agents/operations/createAgentBootstrapOperation";
 import {
   deleteAgentRecordViaStudio,
   deleteAgentViaStudio,
   trashAgentStateViaStudio,
 } from "@/features/agents/operations/deleteAgentOperation";
-import { planAgentSettingsMutation } from "@/features/agents/operations/agentSettingsMutationWorkflow";
 import {
   executeHistorySyncCommands,
   runHistorySyncOperation,
@@ -89,52 +29,55 @@ import {
   runCreateAgentMutationLifecycle,
   type CreateAgentBlockState,
 } from "@/features/agents/operations/mutationLifecycleWorkflow";
-import { useConfigMutationQueue } from "@/features/agents/operations/useConfigMutationQueue";
 import {
   RUNTIME_SYNC_DEFAULT_HISTORY_LIMIT,
   RUNTIME_SYNC_MAX_HISTORY_LIMIT,
 } from "@/features/agents/operations/runtimeSyncControlWorkflow";
 import {
+  executeStudioBootstrapLoadCommands,
+  runStudioBootstrapLoadOperation,
+} from "@/features/agents/operations/studioBootstrapOperation";
+import { useChatInteractionController } from "@/features/agents/operations/useChatInteractionController";
+import { useConfigMutationQueue } from "@/features/agents/operations/useConfigMutationQueue";
+import { createGatewayRuntimeEventHandler } from "@/features/agents/state/gatewayRuntimeEventHandler";
+import {
+  buildHistoryLines,
+  classifyGatewayEventKind,
+  isReasoningRuntimeAgentStream,
+  type AgentEventPayload,
+  type ChatEventPayload,
+  type SummaryPreviewSnapshot,
+} from "@/features/agents/state/runtimeEventBridge";
+import { useAgentStore, type AgentState } from "@/features/agents/state/store";
+import {
   TRANSCRIPT_V2_ENABLED,
   logTranscriptDebugMetric,
 } from "@/features/agents/state/transcript";
-import {
-  buildGatewayModelChoices,
-  type GatewayModelChoice,
-} from "@/lib/gateway/models";
-import type { GatewayModelPolicySnapshot } from "@/lib/gateway/models";
-import {
-  createDefaultAgentAvatarProfile,
-  type AgentAvatarProfile,
-} from "@/lib/avatars/profile";
-import {
-  createEmptyPersonalityDraft,
-  serializePersonalityFiles,
-  type PersonalityBuilderDraft,
-} from "@/lib/agents/personalityBuilder";
-import { writeGatewayAgentFiles } from "@/lib/gateway/agentFiles";
-import { randomUUID } from "@/lib/uuid";
-import {
-  HQSidebar,
-  type HQSidebarTab,
-} from "@/features/office/components/HQSidebar";
 import { CompanyBuilderModal } from "@/features/company-builder/components/CompanyBuilderModal";
+import { runCompanyBootstrapOperation } from "@/features/company-builder/operations/companyBootstrapOperation";
+import {
+  buildCompanyRolePermissionsDraft,
+  resolveCompanyPlanningAgent,
+  runOpenClawPlanningPrompt,
+} from "@/features/company-builder/operations/companyBuilderGateway";
 import {
   buildGenerateCompanyPlanPrompt,
   buildImproveCompanyBriefPrompt,
   buildStoredCompanySnapshot,
   parseCompanyPlanFromAssistantText,
 } from "@/features/company-builder/planning";
-import {
-  buildCompanyRolePermissionsDraft,
-  resolveCompanyPlanningAgent,
-  runOpenClawPlanningPrompt,
-} from "@/features/company-builder/operations/companyBuilderGateway";
-import { runCompanyBootstrapOperation } from "@/features/company-builder/operations/companyBootstrapOperation";
 import type {
   CompanyBuilderInput,
   CompanyBuilderPlan,
 } from "@/features/company-builder/types";
+import {
+  HQSidebar,
+  type HQSidebarTab,
+} from "@/features/office/components/HQSidebar";
+import {
+  RemoteAgentChatPanel,
+  type RemoteAgentChatMessage,
+} from "@/features/office/components/RemoteAgentChatPanel";
 import { AnalyticsPanel } from "@/features/office/components/panels/AnalyticsPanel";
 import { HistoryPanel } from "@/features/office/components/panels/HistoryPanel";
 import { InboxPanel } from "@/features/office/components/panels/InboxPanel";
@@ -142,33 +85,65 @@ import { KanbanDisabledPanel } from "@/features/office/components/panels/KanbanD
 import { PlaybooksPanel } from "@/features/office/components/panels/PlaybooksPanel";
 import { SkillsMarketplaceModal } from "@/features/office/components/panels/SkillsMarketplaceModal";
 import { TaskBoardPanel } from "@/features/office/components/panels/TaskBoardPanel";
-import { JukeboxPanel } from "@/features/spotify-jukebox/components/JukeboxPanel";
-import { JukeboxDisabledPanel } from "@/features/spotify-jukebox/components/JukeboxDisabledPanel";
+import { useOfficeSkillTriggers } from "@/features/office/hooks/useOfficeSkillTriggers";
+import { useOfficeSkillsMarketplace } from "@/features/office/hooks/useOfficeSkillsMarketplace";
+import { useOfficeStandupController } from "@/features/office/hooks/useOfficeStandupController";
+import { useRemoteOfficeLayout } from "@/features/office/hooks/useRemoteOfficeLayout";
+import { useRemoteOfficePresence } from "@/features/office/hooks/useRemoteOfficePresence";
+import { useRunLog } from "@/features/office/hooks/useRunLog";
+import { useTaskBoardController } from "@/features/office/tasks/useTaskBoardController";
+import { OnboardingWizard, useOnboardingState } from "@/features/onboarding";
+import { RetroOffice3D } from "@/features/retro-office/RetroOffice3D";
+import { isRemoteOfficeAgentId } from "@/features/retro-office/core/district";
+import type { OfficeAgent } from "@/features/retro-office/core/types";
 import { executeBrowserJukeboxCommand } from "@/features/spotify-jukebox/agentBridge";
+import { JukeboxDisabledPanel } from "@/features/spotify-jukebox/components/JukeboxDisabledPanel";
+import { JukeboxPanel } from "@/features/spotify-jukebox/components/JukeboxPanel";
 import {
   SOUNDCLAW_PLAYBACK_STARTED_EVENT_NAME,
   useJukeboxStore,
 } from "@/features/spotify-jukebox/store";
-import { useOfficeSkillTriggers } from "@/features/office/hooks/useOfficeSkillTriggers";
-import { useRemoteOfficePresence } from "@/features/office/hooks/useRemoteOfficePresence";
-import { useRemoteOfficeLayout } from "@/features/office/hooks/useRemoteOfficeLayout";
-import { useOfficeSkillsMarketplace } from "@/features/office/hooks/useOfficeSkillsMarketplace";
-import { useOfficeStandupController } from "@/features/office/hooks/useOfficeStandupController";
-import { useRunLog } from "@/features/office/hooks/useRunLog";
-import { useTaskBoardController } from "@/features/office/tasks/useTaskBoardController";
-import {
-  OnboardingWizard,
-  useOnboardingState,
-} from "@/features/onboarding";
 import { useFinalizedAssistantReplyListener } from "@/hooks/useFinalizedAssistantReplyListener";
 import { useStudioOfficePreference } from "@/hooks/useStudioOfficePreference";
-import { isRemoteOfficeAgentId } from "@/features/retro-office/core/district";
 import { useStudioVoiceRepliesPreference } from "@/hooks/useStudioVoiceRepliesPreference";
 import {
   useVoiceRecorder,
   type VoiceSendPayload,
 } from "@/hooks/useVoiceRecorder";
 import { useVoiceReplyPlayback } from "@/hooks/useVoiceReplyPlayback";
+import {
+  createEmptyPersonalityDraft,
+  serializePersonalityFiles,
+  type PersonalityBuilderDraft,
+} from "@/lib/agents/personalityBuilder";
+import {
+  createDefaultAgentAvatarProfile,
+  type AgentAvatarProfile,
+} from "@/lib/avatars/profile";
+import {
+  GatewayClient,
+  buildAgentMainSessionKey,
+  isGatewayDisconnectLikeError,
+  isSameSessionKey,
+  parseAgentIdFromSessionKey,
+  type EventFrame,
+} from "@/lib/gateway/GatewayClient";
+import {
+  createGatewayAgent,
+  renameGatewayAgent,
+} from "@/lib/gateway/agentConfig";
+import { writeGatewayAgentFiles } from "@/lib/gateway/agentFiles";
+import type { GatewayModelPolicySnapshot } from "@/lib/gateway/models";
+import {
+  buildGatewayModelChoices,
+  type GatewayModelChoice,
+} from "@/lib/gateway/models";
+import type { MockPhoneCallScenario } from "@/lib/office/call/types";
+import { resolveOfficeIntentSnapshot } from "@/lib/office/deskDirectives";
+import {
+  buildOfficeDeskMonitor,
+  type OfficeDeskMonitor,
+} from "@/lib/office/deskMonitor";
 import {
   buildOfficeAnimationState,
   clearOfficeAnimationTriggerHold,
@@ -179,15 +154,37 @@ import {
   type OfficeTextMessageRequest,
 } from "@/lib/office/eventTriggers";
 import { buildOfficeSkillTriggerHoldMaps } from "@/lib/office/places";
-import type { MockPhoneCallScenario } from "@/lib/office/call/types";
-import type { MockTextMessageScenario } from "@/lib/office/text/types";
-import {
-  buildOfficeDeskMonitor,
-  type OfficeDeskMonitor,
-} from "@/lib/office/deskMonitor";
-import { deriveSkillReadinessState } from "@/lib/skills/presentation";
 import type { StandupAgentSnapshot } from "@/lib/office/standup/types";
+import type { MockTextMessageScenario } from "@/lib/office/text/types";
+import { useRuntimeConnection } from "@/lib/runtime/useRuntimeConnection";
+import { deriveSkillReadinessState } from "@/lib/skills/presentation";
 import type { SkillStatusEntry } from "@/lib/skills/types";
+import {
+  createStudioSettingsCoordinator,
+  type StudioSettingsLoadOptions,
+} from "@/lib/studio/coordinator";
+import {
+  resolveDeskAssignments,
+  resolveOfficePreferencePublic,
+} from "@/lib/studio/settings";
+import {
+  extractText,
+  extractThinking,
+  extractToolLines,
+  isHeartbeatPrompt,
+  stripUiMetadata,
+} from "@/lib/text/message-extract";
+import { randomUUID } from "@/lib/uuid";
+import { ChevronDown, MessageSquare, Mic } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 const stringToColor = (str: string) => {
   let hash = 0;
@@ -320,7 +317,8 @@ const formatOpenClawValue = (value: string | null | undefined) => {
 };
 
 const buildPhoneCallOutputLine = (text: string) => `[phone booth] ${text}`;
-const buildTextMessageOutputLine = (text: string) => `[messaging booth] ${text}`;
+const buildTextMessageOutputLine = (text: string) =>
+  `[messaging booth] ${text}`;
 
 const buildIdentityFileDraft = (identity: AgentIdentityValues) => {
   const draft = createEmptyPersonalityDraft();
@@ -355,7 +353,8 @@ const shouldSuppressPhoneBoothAssistantReply = (params: {
   event: EventFrame;
   phoneCallByAgentId: Record<string, OfficePhoneCallRequest>;
 }): boolean => {
-  if (classifyGatewayEventKind(params.event.event) !== "runtime-chat") return false;
+  if (classifyGatewayEventKind(params.event.event) !== "runtime-chat")
+    return false;
   const payload = params.event.payload as ChatEventPayload | undefined;
   if (!payload?.sessionKey) return false;
   const message =
@@ -367,8 +366,8 @@ const shouldSuppressPhoneBoothAssistantReply = (params: {
   const text = extractText(payload.message)?.trim() ?? "";
   if (!text || !PHONE_BOOTH_ASSISTANT_FALLBACK_RE.test(text)) return false;
   const agentId =
-    params.agents.find((agent) => agent.sessionKey === payload.sessionKey)?.agentId ??
-    parseAgentIdFromSessionKey(payload.sessionKey);
+    params.agents.find((agent) => agent.sessionKey === payload.sessionKey)
+      ?.agentId ?? parseAgentIdFromSessionKey(payload.sessionKey);
   if (!agentId) return false;
   return Boolean(params.phoneCallByAgentId[agentId]);
 };
@@ -857,21 +856,27 @@ export function OfficeScreen({
     setToken,
     setSelectedAdapterType,
     supportsCapability,
-  } =
-    useRuntimeConnection(settingsCoordinator);
+  } = useRuntimeConnection(settingsCoordinator);
   const runtimeSupportsSkills = supportsCapability("skills");
   const runtimeSupportsApprovals = supportsCapability("approvals");
   const runtimeSupportsCron = supportsCapability("cron");
   const runtimeSupportsModels = supportsCapability("models");
-  const runtimeSupportsRunLifecycle = supportsCapability("runtime-agent-events");
+  const runtimeSupportsRunLifecycle = supportsCapability(
+    "runtime-agent-events",
+  );
   const { state, dispatch, hydrateAgents, setError, setLoading } =
     useAgentStore();
   const [agentsLoaded, setAgentsLoaded] = useState(false);
-  const [didAttemptGatewayConnect, setDidAttemptGatewayConnect] = useState(false);
-  const [showDelayedGatewayLoadingOverlay, setShowDelayedGatewayLoadingOverlay] =
+  const [didAttemptGatewayConnect, setDidAttemptGatewayConnect] =
     useState(false);
-  const [showDelayedGatewayConnectOverlay, setShowDelayedGatewayConnectOverlay] =
-    useState(false);
+  const [
+    showDelayedGatewayLoadingOverlay,
+    setShowDelayedGatewayLoadingOverlay,
+  ] = useState(false);
+  const [
+    showDelayedGatewayConnectOverlay,
+    setShowDelayedGatewayConnectOverlay,
+  ] = useState(false);
   const [clockTick, setClockTick] = useState(0);
   const [debugRows, setDebugRows] = useState<OfficeDebugRow[]>([]);
   const [feedEvents, setFeedEvents] = useState<OfficeFeedEvent[]>([]);
@@ -902,7 +907,9 @@ export function OfficeScreen({
   const [openClawConsoleCopyStatus, setOpenClawConsoleCopyStatus] = useState<
     "idle" | "copied" | "error"
   >("idle");
-  const taskBoardEventHandlerRef = useRef<(event: EventFrame) => void>(() => {});
+  const taskBoardEventHandlerRef = useRef<(event: EventFrame) => void>(
+    () => {},
+  );
   const taskBoardRefreshRef = useRef<() => Promise<void>>(async () => {});
   const [officeTriggerState, setOfficeTriggerState] = useState(() =>
     createOfficeAnimationTriggerState(),
@@ -944,38 +951,46 @@ export function OfficeScreen({
   const [remoteChatByAgentId, setRemoteChatByAgentId] = useState<
     Record<string, RemoteChatSessionState>
   >({});
-  const [agentEditorAgentId, setAgentEditorAgentId] = useState<string | null>(null);
+  const [agentEditorAgentId, setAgentEditorAgentId] = useState<string | null>(
+    null,
+  );
   const [agentEditorInitialSection, setAgentEditorInitialSection] =
     useState<AgentEditorSection>("avatar");
   const [createAgentWizardNonce, setCreateAgentWizardNonce] = useState(0);
   const [createAgentWizardOpen, setCreateAgentWizardOpen] = useState(false);
   const [createAgentBusy, setCreateAgentBusy] = useState(false);
-  const [createAgentModalError, setCreateAgentModalError] = useState<string | null>(
-    null,
-  );
+  const [createAgentModalError, setCreateAgentModalError] = useState<
+    string | null
+  >(null);
   const [companyBuilderOpen, setCompanyBuilderOpen] = useState(false);
   const [companyBuilderNonce, setCompanyBuilderNonce] = useState(0);
   const [companyBuilderBusy, setCompanyBuilderBusy] = useState(false);
-  const [companyBuilderError, setCompanyBuilderError] = useState<string | null>(null);
-  const [companyBuilderStatusLine, setCompanyBuilderStatusLine] = useState<string | null>(null);
-  const [companyBuilderInput, setCompanyBuilderInput] = useState<CompanyBuilderInput>({
-    businessDescription: "",
-    improvedBrief: "",
-  });
-  const [lastCompanyPlan, setLastCompanyPlan] = useState<CompanyBuilderPlan | null>(null);
+  const [companyBuilderError, setCompanyBuilderError] = useState<string | null>(
+    null,
+  );
+  const [companyBuilderStatusLine, setCompanyBuilderStatusLine] = useState<
+    string | null
+  >(null);
+  const [companyBuilderInput, setCompanyBuilderInput] =
+    useState<CompanyBuilderInput>({
+      businessDescription: "",
+      improvedBrief: "",
+    });
+  const [lastCompanyPlan, setLastCompanyPlan] =
+    useState<CompanyBuilderPlan | null>(null);
   const [companyCreatedSignal, setCompanyCreatedSignal] = useState(0);
-  const [createdCompanyName, setCreatedCompanyName] = useState<string | null>(null);
+  const [createdCompanyName, setCreatedCompanyName] = useState<string | null>(
+    null,
+  );
   const [officeCameraCenterSignal, setOfficeCameraCenterSignal] = useState(0);
   const [createAgentBlock, setCreateAgentBlock] =
     useState<CreateAgentBlockState | null>(null);
   const [deleteAgentBlock, setDeleteAgentBlock] =
     useState<OfficeDeleteMutationBlockState | null>(null);
-  const [preparedPhoneCallsByAgentId, setPreparedPhoneCallsByAgentId] = useState<
-    Record<string, PreparedPhoneCallEntry>
-  >({});
-  const [preparedTextMessagesByAgentId, setPreparedTextMessagesByAgentId] = useState<
-    Record<string, PreparedTextMessageEntry>
-  >({});
+  const [preparedPhoneCallsByAgentId, setPreparedPhoneCallsByAgentId] =
+    useState<Record<string, PreparedPhoneCallEntry>>({});
+  const [preparedTextMessagesByAgentId, setPreparedTextMessagesByAgentId] =
+    useState<Record<string, PreparedTextMessageEntry>>({});
   const promptedPhoneCallKeysRef = useRef<Set<string>>(new Set());
   const preparedPhoneCallKeysRef = useRef<Set<string>>(new Set());
   const spokenPhoneCallKeysRef = useRef<Set<string>>(new Set());
@@ -999,7 +1014,9 @@ export function OfficeScreen({
     message: "",
     error: null,
   });
-  const [danceUntilByAgentId, setDanceUntilByAgentId] = useState<Record<string, number>>({});
+  const [danceUntilByAgentId, setDanceUntilByAgentId] = useState<
+    Record<string, number>
+  >({});
   const initJukeboxStore = useJukeboxStore((state) => state.init);
   const jukeboxToken = useJukeboxStore((state) => state.token);
   // Auto-open jukebox panel for legacy direct-auth callbacks.
@@ -1013,7 +1030,9 @@ export function OfficeScreen({
   const pendingJukeboxCommandTimeoutsRef = useRef<
     Map<string, { requestKey: string; timeoutId: number }>
   >(new Map());
-  const handledJukeboxRequestKeyByAgentIdRef = useRef<Record<string, string>>({});
+  const handledJukeboxRequestKeyByAgentIdRef = useRef<Record<string, string>>(
+    {},
+  );
   const router = useRouter();
   const { showOnboarding, completeOnboarding, resetOnboarding } =
     useOnboardingState();
@@ -1284,7 +1303,8 @@ export function OfficeScreen({
   }, [gatewayError]);
 
   const loadStudioSettings = useCallback(
-    (options?: StudioSettingsLoadOptions) => settingsCoordinator.loadSettings(options),
+    (options?: StudioSettingsLoadOptions) =>
+      settingsCoordinator.loadSettings(options),
     [settingsCoordinator],
   );
 
@@ -1327,7 +1347,10 @@ export function OfficeScreen({
       try {
         const settings = await loadStudioSettings({ maxAgeMs: 30_000 });
         if (!settings || cancelled) return;
-        const officePreference = resolveOfficePreferencePublic(settings, gatewayKey);
+        const officePreference = resolveOfficePreferencePublic(
+          settings,
+          gatewayKey,
+        );
         setCompanyBuilderInput({
           businessDescription: officePreference.companyPrompt,
           improvedBrief: officePreference.companyImprovedBrief,
@@ -1335,7 +1358,9 @@ export function OfficeScreen({
         if (officePreference.companyPlanJson.trim()) {
           try {
             setLastCompanyPlan(
-              JSON.parse(officePreference.companyPlanJson) as CompanyBuilderPlan,
+              JSON.parse(
+                officePreference.companyPlanJson,
+              ) as CompanyBuilderPlan,
             );
           } catch (error) {
             console.error("Failed to parse saved company plan.", error);
@@ -1355,162 +1380,168 @@ export function OfficeScreen({
     };
   }, [gatewayUrl, loadStudioSettings]);
 
-  const loadAgents = useCallback(async (options?: {
-    forceSettings?: boolean;
-    minIntervalMs?: number;
-    onlyWhenIdleForMs?: number;
-    settingsMaxAgeMs?: number;
-    silent?: boolean;
-  }) => {
-    if (status !== "connected") return;
-    if (loadAgentsInFlightRef.current) return loadAgentsInFlightRef.current;
-    const now = Date.now();
-    const minIntervalMs = options?.minIntervalMs ?? 0;
-    if (
-      minIntervalMs > 0 &&
-      now - lastLoadAgentsStartedAtRef.current < minIntervalMs
-    ) {
-      return;
-    }
-    const onlyWhenIdleForMs = options?.onlyWhenIdleForMs ?? 0;
-    if (
-      onlyWhenIdleForMs > 0 &&
-      now - lastGatewayActivityAtRef.current < onlyWhenIdleForMs
-    ) {
-      return;
-    }
-    lastLoadAgentsStartedAtRef.current = now;
-    const connectionEpochAtStart = connectionEpochRef.current;
-    const task = (async () => {
-      if (!options?.silent) {
-        setLoading(true);
+  const loadAgents = useCallback(
+    async (options?: {
+      forceSettings?: boolean;
+      minIntervalMs?: number;
+      onlyWhenIdleForMs?: number;
+      settingsMaxAgeMs?: number;
+      silent?: boolean;
+    }) => {
+      if (status !== "connected") return;
+      if (loadAgentsInFlightRef.current) return loadAgentsInFlightRef.current;
+      const now = Date.now();
+      const minIntervalMs = options?.minIntervalMs ?? 0;
+      if (
+        minIntervalMs > 0 &&
+        now - lastLoadAgentsStartedAtRef.current < minIntervalMs
+      ) {
+        return;
       }
-      try {
-        const settingsLoadOptions: StudioSettingsLoadOptions | undefined =
-          options?.forceSettings
-            ? { force: true }
-            : { maxAgeMs: options?.settingsMaxAgeMs ?? 60_000 };
-        const commands = await runStudioBootstrapLoadOperation({
-          client: provider,
-          gatewayUrl,
-          cachedConfigSnapshot: gatewayConfigSnapshot.current,
-          loadStudioSettings: () => loadStudioSettings(settingsLoadOptions),
-          isDisconnectLikeError: isGatewayDisconnectLikeError,
-          preferredSelectedAgentId: null,
-          hasCurrentSelection: false,
-          logError: console.error,
-        });
-        if (connectionEpochAtStart !== connectionEpochRef.current) {
-          return;
+      const onlyWhenIdleForMs = options?.onlyWhenIdleForMs ?? 0;
+      if (
+        onlyWhenIdleForMs > 0 &&
+        now - lastGatewayActivityAtRef.current < onlyWhenIdleForMs
+      ) {
+        return;
+      }
+      lastLoadAgentsStartedAtRef.current = now;
+      const connectionEpochAtStart = connectionEpochRef.current;
+      const task = (async () => {
+        if (!options?.silent) {
+          setLoading(true);
         }
-        executeStudioBootstrapLoadCommands({
-          commands,
-          setGatewayConfigSnapshot: (val: GatewayModelPolicySnapshot) => {
-            gatewayConfigSnapshot.current = val;
-          },
-          hydrateAgents,
-          dispatchUpdateAgent: (agentId, patch) => {
-            dispatch({ type: "updateAgent", agentId, patch });
-          },
-          setError,
-        });
-        if (connectionEpochAtStart !== connectionEpochRef.current) {
-          return;
-        }
-        const refreshedAgents = stateRef.current.agents;
-        const debugCollector: OfficeDebugRow[] = [];
-        const inferredByAgentId = new Map<string, boolean>();
-        await Promise.all(
-          refreshedAgents.map(async (agent) => {
+        try {
+          const settingsLoadOptions: StudioSettingsLoadOptions | undefined =
+            options?.forceSettings
+              ? { force: true }
+              : { maxAgeMs: options?.settingsMaxAgeMs ?? 60_000 };
+          const commands = await runStudioBootstrapLoadOperation({
+            client: provider,
+            gatewayUrl,
+            cachedConfigSnapshot: gatewayConfigSnapshot.current,
+            loadStudioSettings: () => loadStudioSettings(settingsLoadOptions),
+            isDisconnectLikeError: isGatewayDisconnectLikeError,
+            preferredSelectedAgentId: null,
+            hasCurrentSelection: false,
+            logError: console.error,
+          });
           if (connectionEpochAtStart !== connectionEpochRef.current) {
             return;
           }
-          try {
-            const inference = await inferRunningFromAgentSessions({
-              client: provider,
-              agentId: agent.agentId,
-            });
-            if (connectionEpochAtStart !== connectionEpochRef.current) {
-              return;
-            }
-            const inferredRunning = inference.inferredRunning;
-            inferredByAgentId.set(agent.agentId, inferredRunning);
-            if (inference.latestSessionUpdatedAtMs > 0) {
-              setLastSeenByAgentId((prev) => ({
-                ...prev,
-                [agent.agentId]: inference.latestSessionUpdatedAtMs,
-              }));
-            }
-            const nextStatus: AgentState["status"] = inferredRunning
-              ? "running"
-              : "idle";
-            if (agent.status !== nextStatus) {
-              dispatch({
-                type: "updateAgent",
-                agentId: agent.agentId,
-                patch: {
-                  status: nextStatus,
-                  runId: inferredRunning
-                    ? (agent.runId ?? `inferred-${agent.agentId}`)
-                    : null,
-                },
-              });
-            }
-            if (debugEnabled) {
-              debugCollector.push({
-                agentId: agent.agentId,
-                name: agent.name,
-                storeStatus: agent.status,
-                runId: agent.runId,
-                inferredRunning,
-                lastRole: inference.lastRole,
-                lastText: inference.lastText,
-                messageCount: inference.messageCount,
-                detectedSessionKey: inference.sessionKey,
-                inspectedSessions: inference.inspectedSessions.join(" | "),
-                inferenceSource: inference.inferenceSource,
-                at: new Date().toISOString(),
-              });
-            }
-          } catch (error) {
-            if (!isGatewayDisconnectLikeError(error)) {
-              console.warn(
-                "Failed to infer agent run state from history.",
-                error,
-              );
-            }
+          executeStudioBootstrapLoadCommands({
+            commands,
+            setGatewayConfigSnapshot: (val: GatewayModelPolicySnapshot) => {
+              gatewayConfigSnapshot.current = val;
+            },
+            hydrateAgents,
+            dispatchUpdateAgent: (agentId, patch) => {
+              dispatch({ type: "updateAgent", agentId, patch });
+            },
+            setError,
+          });
+          if (connectionEpochAtStart !== connectionEpochRef.current) {
+            return;
           }
-          }),
-        );
-        if (connectionEpochAtStart !== connectionEpochRef.current) {
-          return;
+          const refreshedAgents = stateRef.current.agents;
+          const debugCollector: OfficeDebugRow[] = [];
+          const inferredByAgentId = new Map<string, boolean>();
+          await Promise.all(
+            refreshedAgents.map(async (agent) => {
+              if (connectionEpochAtStart !== connectionEpochRef.current) {
+                return;
+              }
+              try {
+                const inference = await inferRunningFromAgentSessions({
+                  client: provider,
+                  agentId: agent.agentId,
+                });
+                if (connectionEpochAtStart !== connectionEpochRef.current) {
+                  return;
+                }
+                const inferredRunning = inference.inferredRunning;
+                inferredByAgentId.set(agent.agentId, inferredRunning);
+                if (inference.latestSessionUpdatedAtMs > 0) {
+                  setLastSeenByAgentId((prev) => ({
+                    ...prev,
+                    [agent.agentId]: inference.latestSessionUpdatedAtMs,
+                  }));
+                }
+                const nextStatus: AgentState["status"] = inferredRunning
+                  ? "running"
+                  : "idle";
+                if (agent.status !== nextStatus) {
+                  dispatch({
+                    type: "updateAgent",
+                    agentId: agent.agentId,
+                    patch: {
+                      status: nextStatus,
+                      runId: inferredRunning
+                        ? (agent.runId ?? `inferred-${agent.agentId}`)
+                        : null,
+                    },
+                  });
+                }
+                if (debugEnabled) {
+                  debugCollector.push({
+                    agentId: agent.agentId,
+                    name: agent.name,
+                    storeStatus: agent.status,
+                    runId: agent.runId,
+                    inferredRunning,
+                    lastRole: inference.lastRole,
+                    lastText: inference.lastText,
+                    messageCount: inference.messageCount,
+                    detectedSessionKey: inference.sessionKey,
+                    inspectedSessions: inference.inspectedSessions.join(" | "),
+                    inferenceSource: inference.inferenceSource,
+                    at: new Date().toISOString(),
+                  });
+                }
+              } catch (error) {
+                if (!isGatewayDisconnectLikeError(error)) {
+                  console.warn(
+                    "Failed to infer agent run state from history.",
+                    error,
+                  );
+                }
+              }
+            }),
+          );
+          if (connectionEpochAtStart !== connectionEpochRef.current) {
+            return;
+          }
+          if (debugEnabled) {
+            setDebugRows(debugCollector);
+            console.info(
+              "[office-debug] Reconciled agent state.",
+              debugCollector,
+            );
+          }
+          lastGatewayActivityAtRef.current = Date.now();
+          setAgentsLoaded(true);
+        } finally {
+          if (!options?.silent) {
+            setLoading(false);
+          }
+          loadAgentsInFlightRef.current = null;
         }
-        if (debugEnabled) {
-          setDebugRows(debugCollector);
-          console.info("[office-debug] Reconciled agent state.", debugCollector);
-        }
-        lastGatewayActivityAtRef.current = Date.now();
-        setAgentsLoaded(true);
-      } finally {
-        if (!options?.silent) {
-          setLoading(false);
-        }
-        loadAgentsInFlightRef.current = null;
-      }
-    })();
-    loadAgentsInFlightRef.current = task;
-    return task;
-  }, [
-    client,
-    debugEnabled,
-    dispatch,
-    gatewayUrl,
-    hydrateAgents,
-    loadStudioSettings,
-    setError,
-    setLoading,
-    status,
-  ]);
+      })();
+      loadAgentsInFlightRef.current = task;
+      return task;
+    },
+    [
+      client,
+      debugEnabled,
+      dispatch,
+      gatewayUrl,
+      hydrateAgents,
+      loadStudioSettings,
+      setError,
+      setLoading,
+      status,
+    ],
+  );
 
   const handleCloseCreateAgentWizard = useCallback(
     (createdAgentId: string | null) => {
@@ -1608,14 +1639,18 @@ export function OfficeScreen({
   const runCompanyBuilderAiTask = useCallback(
     async (prompt: string, statusText: string) => {
       if (status !== "connected") {
-        throw new Error("Connect to a runtime before using the company builder.");
+        throw new Error(
+          "Connect to a runtime before using the company builder.",
+        );
       }
       const livePlannerAgent = resolveCompanyPlanningAgent({
         agents: stateRef.current.agents,
         preferredAgentId: selectedChatAgentId ?? state.selectedAgentId,
       });
       if (!livePlannerAgent) {
-        throw new Error("Create or load at least one agent before using AI suggestions.");
+        throw new Error(
+          "Create or load at least one agent before using AI suggestions.",
+        );
       }
       setCompanyBuilderStatusLine(statusText);
       return runOpenClawPlanningPrompt({
@@ -1623,7 +1658,8 @@ export function OfficeScreen({
         dispatch,
         agent: livePlannerAgent,
         getAgent: (agentId) =>
-          stateRef.current.agents.find((entry) => entry.agentId === agentId) ?? null,
+          stateRef.current.agents.find((entry) => entry.agentId === agentId) ??
+          null,
         prompt,
       });
     },
@@ -1646,7 +1682,9 @@ export function OfficeScreen({
         return improvedBrief;
       } catch (error) {
         const message =
-          error instanceof Error ? error.message : "Failed to improve the company brief.";
+          error instanceof Error
+            ? error.message
+            : "Failed to improve the company brief.";
         setCompanyBuilderError(message);
         throw error;
       } finally {
@@ -1668,13 +1706,16 @@ export function OfficeScreen({
         const parsedPlan = parseCompanyPlanFromAssistantText(response);
         const nextInput: CompanyBuilderInput = {
           businessDescription: companyBuilderInput.businessDescription,
-          improvedBrief: brief === companyBuilderInput.businessDescription ? "" : brief,
+          improvedBrief:
+            brief === companyBuilderInput.businessDescription ? "" : brief,
         };
         persistCompanyBuilderSnapshot(nextInput, parsedPlan);
         return parsedPlan;
       } catch (error) {
         const message =
-          error instanceof Error ? error.message : "Failed to generate the company plan.";
+          error instanceof Error
+            ? error.message
+            : "Failed to generate the company plan.";
         setCompanyBuilderError(message);
         throw error;
       } finally {
@@ -1682,7 +1723,11 @@ export function OfficeScreen({
         setCompanyBuilderStatusLine(null);
       }
     },
-    [companyBuilderInput.businessDescription, persistCompanyBuilderSnapshot, runCompanyBuilderAiTask],
+    [
+      companyBuilderInput.businessDescription,
+      persistCompanyBuilderSnapshot,
+      runCompanyBuilderAiTask,
+    ],
   );
   const clearDeletedAgentUiState = useCallback((agentId: string) => {
     setSelectedChatAgentId((current) => (current === agentId ? null : current));
@@ -1704,13 +1749,18 @@ export function OfficeScreen({
     });
   }, []);
   const handleCreateCompanyFromPlan = useCallback(
-    async (params: { input: CompanyBuilderInput; plan: CompanyBuilderPlan }) => {
+    async (params: {
+      input: CompanyBuilderInput;
+      plan: CompanyBuilderPlan;
+    }) => {
       if (status !== "connected") {
         const message = "Connect to a runtime before creating the company.";
         setCompanyBuilderError(message);
         throw new Error(message);
       }
-      const existingAgentIds = stateRef.current.agents.map((entry) => entry.agentId);
+      const existingAgentIds = stateRef.current.agents.map(
+        (entry) => entry.agentId,
+      );
       const shouldSkipWorkspaceCleanupError = (error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
         return (
@@ -1722,7 +1772,9 @@ export function OfficeScreen({
       };
       const logDeleteError = (message: string, error: unknown) => {
         if (
-          message.startsWith("Failed to move agent workspace/state into trash.") &&
+          message.startsWith(
+            "Failed to move agent workspace/state into trash.",
+          ) &&
           shouldSkipWorkspaceCleanupError(error)
         ) {
           return;
@@ -1788,7 +1840,9 @@ export function OfficeScreen({
           loadAgents: () => loadAgents({ forceSettings: true }),
           findAgentById: (agentId) => {
             const liveAgent =
-              stateRef.current.agents.find((entry) => entry.agentId === agentId) ?? null;
+              stateRef.current.agents.find(
+                (entry) => entry.agentId === agentId,
+              ) ?? null;
             if (!liveAgent?.sessionKey) return null;
             return {
               agentId: liveAgent.agentId,
@@ -1819,7 +1873,9 @@ export function OfficeScreen({
         setCompanyBuilderOpen(false);
       } catch (error) {
         const message =
-          error instanceof Error ? error.message : "Failed to create the company.";
+          error instanceof Error
+            ? error.message
+            : "Failed to create the company.";
         setCompanyBuilderError(message);
         throw error;
       } finally {
@@ -1967,7 +2023,9 @@ export function OfficeScreen({
           files,
         });
         const currentAgent =
-          stateRef.current.agents.find((entry) => entry.agentId === params.agentId) ?? null;
+          stateRef.current.agents.find(
+            (entry) => entry.agentId === params.agentId,
+          ) ?? null;
         const nextName = params.draft.identity.name.trim();
         const currentName = currentAgent?.name.trim() ?? "";
         if (nextName && nextName !== currentName) {
@@ -1977,7 +2035,9 @@ export function OfficeScreen({
             name: nextName,
           });
           if (!renamed) {
-            throw new Error("Saved the wizard files, but could not rename the live agent.");
+            throw new Error(
+              "Saved the wizard files, but could not rename the live agent.",
+            );
           }
         }
         handleAvatarProfileSave(params.agentId, params.profile);
@@ -1987,7 +2047,9 @@ export function OfficeScreen({
         openAgentEditor(params.agentId, "IDENTITY.md");
       } catch (error) {
         const message =
-          error instanceof Error ? error.message : "Failed to finish creating the agent.";
+          error instanceof Error
+            ? error.message
+            : "Failed to finish creating the agent.";
         setCreateAgentModalError(message);
       } finally {
         setCreateAgentBusy(false);
@@ -2011,7 +2073,8 @@ export function OfficeScreen({
       );
       if (decision.kind === "deny") {
         setError(
-          decision.message ?? resolveOfficeMutationGuardMessage(decision.guardReason),
+          decision.message ??
+            resolveOfficeMutationGuardMessage(decision.guardReason),
         );
         return;
       }
@@ -2279,18 +2342,19 @@ export function OfficeScreen({
   const refreshRecentTransportSessionHistory = useCallback(
     (event: EventFrame) => {
       if (event.event !== "health") return;
-      const payload =
-        event.payload as
-          | {
-              agents?: Array<{
-                agentId?: unknown;
-                sessions?: {
-                  recent?: Array<{ key?: unknown; updatedAt?: unknown }>;
-                };
-              }>;
-            }
-          | undefined;
-      const gatewayAgents = Array.isArray(payload?.agents) ? payload.agents : [];
+      const payload = event.payload as
+        | {
+            agents?: Array<{
+              agentId?: unknown;
+              sessions?: {
+                recent?: Array<{ key?: unknown; updatedAt?: unknown }>;
+              };
+            }>;
+          }
+        | undefined;
+      const gatewayAgents = Array.isArray(payload?.agents)
+        ? payload.agents
+        : [];
       if (gatewayAgents.length === 0) return;
       for (const gatewayAgent of gatewayAgents) {
         const agentId =
@@ -2671,7 +2735,10 @@ export function OfficeScreen({
   }, [chatOpen, selectedChatAgentId, state.agents]);
 
   const remoteChatAgentIds = useMemo(
-    () => (remoteOfficeSnapshot?.agents ?? []).map((agent) => `remote:${agent.agentId}`),
+    () =>
+      (remoteOfficeSnapshot?.agents ?? []).map(
+        (agent) => `remote:${agent.agentId}`,
+      ),
     [remoteOfficeSnapshot],
   );
 
@@ -2696,21 +2763,24 @@ export function OfficeScreen({
     : null;
   const selectedLocalChatAgentId = focusedChatAgent?.agentId ?? null;
   const agentEditorAgent = agentEditorAgentId
-    ? (state.agents.find((agent) => agent.agentId === agentEditorAgentId) ?? null)
+    ? (state.agents.find((agent) => agent.agentId === agentEditorAgentId) ??
+      null)
     : null;
   const mainAgent =
     state.agents.find((agent) => agent.agentId === MAIN_AGENT_ID) ?? null;
 
   useEffect(() => {
     if (!selectedChatAgentId) return;
-    if (state.agents.some((agent) => agent.agentId === selectedChatAgentId)) return;
+    if (state.agents.some((agent) => agent.agentId === selectedChatAgentId))
+      return;
     if (remoteChatAgentIds.includes(selectedChatAgentId)) return;
     setSelectedChatAgentId(null);
   }, [remoteChatAgentIds, selectedChatAgentId, state.agents]);
 
   useEffect(() => {
     if (!agentEditorAgentId) return;
-    if (state.agents.some((agent) => agent.agentId === agentEditorAgentId)) return;
+    if (state.agents.some((agent) => agent.agentId === agentEditorAgentId))
+      return;
     setAgentEditorAgentId(null);
   }, [agentEditorAgentId, state.agents]);
 
@@ -2926,21 +2996,29 @@ export function OfficeScreen({
       Object.values(phoneCallByAgentId).map((request) => request.key),
     );
     promptedPhoneCallKeysRef.current = new Set(
-      [...promptedPhoneCallKeysRef.current].filter((key) => activeKeys.has(key)),
+      [...promptedPhoneCallKeysRef.current].filter((key) =>
+        activeKeys.has(key),
+      ),
     );
     preparedPhoneCallKeysRef.current = new Set(
-      [...preparedPhoneCallKeysRef.current].filter((key) => activeKeys.has(key)),
+      [...preparedPhoneCallKeysRef.current].filter((key) =>
+        activeKeys.has(key),
+      ),
     );
     spokenPhoneCallKeysRef.current = new Set(
       [...spokenPhoneCallKeysRef.current].filter((key) => activeKeys.has(key)),
     );
     setPreparedPhoneCallsByAgentId((previous) => {
       const next = Object.fromEntries(
-        Object.entries(previous).filter(([, entry]) => activeKeys.has(entry.requestKey)),
+        Object.entries(previous).filter(([, entry]) =>
+          activeKeys.has(entry.requestKey),
+        ),
       );
       if (
         Object.keys(previous).length === Object.keys(next).length &&
-        Object.keys(previous).every((agentId) => previous[agentId] === next[agentId])
+        Object.keys(previous).every(
+          (agentId) => previous[agentId] === next[agentId],
+        )
       ) {
         return previous;
       }
@@ -2952,7 +3030,10 @@ export function OfficeScreen({
     const requests = Object.entries(phoneCallByAgentId);
     if (requests.length === 0) return;
 
-    const appendPromptForAgent = (agentId: string, request: OfficePhoneCallRequest) => {
+    const appendPromptForAgent = (
+      agentId: string,
+      request: OfficePhoneCallRequest,
+    ) => {
       const agent = state.agents.find((entry) => entry.agentId === agentId);
       if (!agent) return;
       promptedPhoneCallKeysRef.current.add(request.key);
@@ -2985,7 +3066,10 @@ export function OfficeScreen({
         });
     };
 
-    const prepareScenarioForAgent = (agentId: string, request: OfficePhoneCallRequest) => {
+    const prepareScenarioForAgent = (
+      agentId: string,
+      request: OfficePhoneCallRequest,
+    ) => {
       preparedPhoneCallKeysRef.current.add(request.key);
       void fetch("/api/office/call", {
         method: "POST",
@@ -3039,14 +3123,23 @@ export function OfficeScreen({
         if (!phoneBoothHoldByAgentId[agent.agentId]) return false;
         const prepared = preparedPhoneCallsByAgentId[agent.agentId];
         const request = phoneCallByAgentId[agent.agentId];
-        return Boolean(prepared && request && prepared.requestKey === request.key);
+        return Boolean(
+          prepared && request && prepared.requestKey === request.key,
+        );
       })?.agentId ?? null,
-    [phoneBoothHoldByAgentId, phoneCallByAgentId, preparedPhoneCallsByAgentId, state.agents],
+    [
+      phoneBoothHoldByAgentId,
+      phoneCallByAgentId,
+      preparedPhoneCallsByAgentId,
+      state.agents,
+    ],
   );
 
   const activePhoneCallScenario = useMemo(() => {
     if (!activePhoneBoothAgentId) return null;
-    return preparedPhoneCallsByAgentId[activePhoneBoothAgentId]?.scenario ?? null;
+    return (
+      preparedPhoneCallsByAgentId[activePhoneBoothAgentId]?.scenario ?? null
+    );
   }, [activePhoneBoothAgentId, preparedPhoneCallsByAgentId]);
 
   const handlePhoneCallSpeak = useCallback(
@@ -3070,7 +3163,9 @@ export function OfficeScreen({
         dispatch({
           type: "appendOutput",
           agentId,
-          line: buildPhoneCallOutputLine(`Call with ${request.callee} finished.`),
+          line: buildPhoneCallOutputLine(
+            `Call with ${request.callee} finished.`,
+          ),
         });
       }
       setOfficeTriggerState((previous) =>
@@ -3089,18 +3184,26 @@ export function OfficeScreen({
       Object.values(textMessageByAgentId).map((request) => request.key),
     );
     promptedTextMessageKeysRef.current = new Set(
-      [...promptedTextMessageKeysRef.current].filter((key) => activeKeys.has(key)),
+      [...promptedTextMessageKeysRef.current].filter((key) =>
+        activeKeys.has(key),
+      ),
     );
     preparedTextMessageKeysRef.current = new Set(
-      [...preparedTextMessageKeysRef.current].filter((key) => activeKeys.has(key)),
+      [...preparedTextMessageKeysRef.current].filter((key) =>
+        activeKeys.has(key),
+      ),
     );
     setPreparedTextMessagesByAgentId((previous) => {
       const next = Object.fromEntries(
-        Object.entries(previous).filter(([, entry]) => activeKeys.has(entry.requestKey)),
+        Object.entries(previous).filter(([, entry]) =>
+          activeKeys.has(entry.requestKey),
+        ),
       );
       if (
         Object.keys(previous).length === Object.keys(next).length &&
-        Object.keys(previous).every((agentId) => previous[agentId] === next[agentId])
+        Object.keys(previous).every(
+          (agentId) => previous[agentId] === next[agentId],
+        )
       ) {
         return previous;
       }
@@ -3112,7 +3215,10 @@ export function OfficeScreen({
     const requests = Object.entries(textMessageByAgentId);
     if (requests.length === 0) return;
 
-    const appendPromptForAgent = (agentId: string, request: OfficeTextMessageRequest) => {
+    const appendPromptForAgent = (
+      agentId: string,
+      request: OfficeTextMessageRequest,
+    ) => {
       const agent = state.agents.find((entry) => entry.agentId === agentId);
       if (!agent) return;
       promptedTextMessageKeysRef.current.add(request.key);
@@ -3145,7 +3251,10 @@ export function OfficeScreen({
         });
     };
 
-    const prepareScenarioForAgent = (agentId: string, request: OfficeTextMessageRequest) => {
+    const prepareScenarioForAgent = (
+      agentId: string,
+      request: OfficeTextMessageRequest,
+    ) => {
       preparedTextMessageKeysRef.current.add(request.key);
       void fetch("/api/office/text", {
         method: "POST",
@@ -3199,14 +3308,23 @@ export function OfficeScreen({
         if (!smsBoothHoldByAgentId[agent.agentId]) return false;
         const prepared = preparedTextMessagesByAgentId[agent.agentId];
         const request = textMessageByAgentId[agent.agentId];
-        return Boolean(prepared && request && prepared.requestKey === request.key);
+        return Boolean(
+          prepared && request && prepared.requestKey === request.key,
+        );
       })?.agentId ?? null,
-    [preparedTextMessagesByAgentId, smsBoothHoldByAgentId, state.agents, textMessageByAgentId],
+    [
+      preparedTextMessagesByAgentId,
+      smsBoothHoldByAgentId,
+      state.agents,
+      textMessageByAgentId,
+    ],
   );
 
   const activeTextMessageScenario = useMemo(() => {
     if (!activeSmsBoothAgentId) return null;
-    return preparedTextMessagesByAgentId[activeSmsBoothAgentId]?.scenario ?? null;
+    return (
+      preparedTextMessagesByAgentId[activeSmsBoothAgentId]?.scenario ?? null
+    );
   }, [activeSmsBoothAgentId, preparedTextMessagesByAgentId]);
 
   const handleTextMessageComplete = useCallback(
@@ -3221,7 +3339,9 @@ export function OfficeScreen({
         dispatch({
           type: "appendOutput",
           agentId,
-          line: buildTextMessageOutputLine(`Message to ${request.recipient} sent.`),
+          line: buildTextMessageOutputLine(
+            `Message to ${request.recipient} sent.`,
+          ),
         });
       }
       setOfficeTriggerState((previous) =>
@@ -3323,7 +3443,11 @@ export function OfficeScreen({
         if (remoteAgents.length === 0) {
           throw new Error("Remote agent list is unavailable right now.");
         }
-        if (!remoteAgents.some((entry) => (entry.id?.trim() ?? "") === remoteAgentId)) {
+        if (
+          !remoteAgents.some(
+            (entry) => (entry.id?.trim() ?? "") === remoteAgentId,
+          )
+        ) {
           throw new Error("Remote agent is no longer available.");
         }
         const sessionKey = buildAgentMainSessionKey(
@@ -3447,11 +3571,11 @@ export function OfficeScreen({
       const pendingTextMessage = textMessageByAgentId[agentId] ?? null;
       const hasImmediateOfficeTrigger = Boolean(
         intentSnapshot.desk ||
-          intentSnapshot.github ||
-          intentSnapshot.gym ||
-          intentSnapshot.qa ||
-          intentSnapshot.standup ||
-          intentSnapshot.text,
+        intentSnapshot.github ||
+        intentSnapshot.gym ||
+        intentSnapshot.qa ||
+        intentSnapshot.standup ||
+        intentSnapshot.text,
       );
       const isPhoneCallFollowUp =
         pendingPhoneCall?.phase === "needs_message" &&
@@ -3755,11 +3879,11 @@ export function OfficeScreen({
                     ? `qa-hold-${agent.agentId}`
                     : smsBoothHeld
                       ? `text-hold-${agent.agentId}`
-                    : phoneBoothHeld
-                      ? `call-hold-${agent.agentId}`
-                    : gymHeld
-                      ? `gym-hold-${agent.agentId}`
-                      : `desk-hold-${agent.agentId}`),
+                      : phoneBoothHeld
+                        ? `call-hold-${agent.agentId}`
+                        : gymHeld
+                          ? `gym-hold-${agent.agentId}`
+                          : `desk-hold-${agent.agentId}`),
               }
             : agent;
       const officeAgent = mapAgentToOffice(effectiveAgent);
@@ -3838,9 +3962,9 @@ export function OfficeScreen({
   const remoteOfficeAgents = useMemo(
     () =>
       (remoteOfficeSnapshot?.agents ?? []).map((agent) =>
-        mapRemotePresenceAgentToOffice(agent)
+        mapRemotePresenceAgentToOffice(agent),
       ),
-    [remoteOfficeSnapshot]
+    [remoteOfficeSnapshot],
   );
   const chatRosterEntries = useMemo<ChatRosterEntry[]>(
     () => [
@@ -3860,10 +3984,12 @@ export function OfficeScreen({
     [remoteOfficeAgents, state.agents],
   );
   const focusedRemoteChatTarget = selectedChatAgentId
-    ? (remoteOfficeAgents.find((agent) => agent.id === selectedChatAgentId) ?? null)
+    ? (remoteOfficeAgents.find((agent) => agent.id === selectedChatAgentId) ??
+      null)
     : null;
   const focusedRemoteChatState = focusedRemoteChatTarget
-    ? (remoteChatByAgentId[focusedRemoteChatTarget.id] ?? EMPTY_REMOTE_CHAT_SESSION)
+    ? (remoteChatByAgentId[focusedRemoteChatTarget.id] ??
+      EMPTY_REMOTE_CHAT_SESSION)
     : null;
   const allVisibleAgents = useMemo(
     () => [...officeAgents, ...remoteOfficeAgents],
@@ -3884,9 +4010,9 @@ export function OfficeScreen({
           ? `${remoteOfficeAgents.length} agents visible.`
           : remoteOfficeSourceKind === "openclaw_gateway"
             ? "Connected to remote gateway. No agents visible yet."
-          : remoteOfficeTokenConfigured
-            ? "Connected. No agents visible yet."
-            : "No agents visible yet.";
+            : remoteOfficeTokenConfigured
+              ? "Connected. No agents visible yet."
+              : "No agents visible yet.";
   const remoteMessagingAvailable =
     remoteOfficeSourceKind === "openclaw_gateway" &&
     remoteOfficeGatewayUrl.trim().length > 0;
@@ -3895,8 +4021,8 @@ export function OfficeScreen({
     : remoteOfficeSourceKind !== "openclaw_gateway"
       ? "Remote messaging currently works only with the remote gateway source."
       : remoteOfficeGatewayUrl.trim().length === 0
-      ? "Remote messaging requires a remote gateway URL in office settings."
-      : "Remote messaging is unavailable until the remote gateway is configured.";
+        ? "Remote messaging requires a remote gateway URL in office settings."
+        : "Remote messaging is unavailable until the remote gateway is configured.";
   const normalizedOpenClawConsoleSearch = openClawConsoleSearch
     .trim()
     .toLowerCase();
@@ -3978,33 +4104,30 @@ export function OfficeScreen({
     window.URL.revokeObjectURL(url);
   }, [openClawConsoleExportJson]);
 
-  const monitorByAgentId = useMemo(
-    () => {
-      const nextCache = new Map<
-        string,
-        { agent: AgentState; monitor: OfficeDeskMonitor }
-      >();
-      const nextMonitorByAgentId: Record<string, OfficeDeskMonitor> = {};
+  const monitorByAgentId = useMemo(() => {
+    const nextCache = new Map<
+      string,
+      { agent: AgentState; monitor: OfficeDeskMonitor }
+    >();
+    const nextMonitorByAgentId: Record<string, OfficeDeskMonitor> = {};
 
-      for (const agent of state.agents) {
-        const cached = deskMonitorCacheRef.current.get(agent.agentId);
-        if (cached && cached.agent === agent) {
-          nextCache.set(agent.agentId, cached);
-          nextMonitorByAgentId[agent.agentId] = cached.monitor;
-          continue;
-        }
-
-        const monitor = buildOfficeDeskMonitor(agent);
-        const entry = { agent, monitor };
-        nextCache.set(agent.agentId, entry);
-        nextMonitorByAgentId[agent.agentId] = monitor;
+    for (const agent of state.agents) {
+      const cached = deskMonitorCacheRef.current.get(agent.agentId);
+      if (cached && cached.agent === agent) {
+        nextCache.set(agent.agentId, cached);
+        nextMonitorByAgentId[agent.agentId] = cached.monitor;
+        continue;
       }
 
-      deskMonitorCacheRef.current = nextCache;
-      return nextMonitorByAgentId;
-    },
-    [state.agents],
-  );
+      const monitor = buildOfficeDeskMonitor(agent);
+      const entry = { agent, monitor };
+      nextCache.set(agent.agentId, entry);
+      nextMonitorByAgentId[agent.agentId] = monitor;
+    }
+
+    deskMonitorCacheRef.current = nextCache;
+    return nextMonitorByAgentId;
+  }, [state.agents]);
   const githubSkill = useMemo<SkillStatusEntry | null>(
     () =>
       marketplace.skillsReport?.skills.find((skill) => {
@@ -4028,17 +4151,25 @@ export function OfficeScreen({
       marketplace.skillsReport?.skills.find((skill) => {
         const normalizedKey = skill.skillKey.trim().toLowerCase();
         const normalizedName = skill.name.trim().toLowerCase();
-        return normalizedKey === "task-manager" || normalizedName === "task-manager";
+        return (
+          normalizedKey === "task-manager" || normalizedName === "task-manager"
+        );
       }) ?? null,
     [marketplace.skillsReport],
   );
   const taskManagerReady = useMemo(
-    () => (taskManagerSkill ? deriveSkillReadinessState(taskManagerSkill) === "ready" : false),
+    () =>
+      taskManagerSkill
+        ? deriveSkillReadinessState(taskManagerSkill) === "ready"
+        : false,
     [taskManagerSkill],
   );
   const soundclawReady = useMemo(
-    () => (soundclawSkill ? deriveSkillReadinessState(soundclawSkill) === "ready" : false),
-    [soundclawSkill]
+    () =>
+      soundclawSkill
+        ? deriveSkillReadinessState(soundclawSkill) === "ready"
+        : false,
+    [soundclawSkill],
   );
 
   useEffect(() => {
@@ -4060,7 +4191,8 @@ export function OfficeScreen({
       }
 
       activeAgentIds.add(agent.agentId);
-      const handledKey = handledJukeboxRequestKeyByAgentIdRef.current[agent.agentId];
+      const handledKey =
+        handledJukeboxRequestKeyByAgentIdRef.current[agent.agentId];
       if (handledKey === request.requestKey) {
         continue;
       }
@@ -4077,7 +4209,8 @@ export function OfficeScreen({
       const timeoutId = window.setTimeout(() => {
         void executeBrowserJukeboxCommand(request.text).then((result) => {
           if (result.ok) {
-            handledJukeboxRequestKeyByAgentIdRef.current[agent.agentId] = request.requestKey;
+            handledJukeboxRequestKeyByAgentIdRef.current[agent.agentId] =
+              request.requestKey;
             setJukeboxOpen(true);
             dispatch({
               type: "appendOutput",
@@ -4103,7 +4236,9 @@ export function OfficeScreen({
               },
             });
           }
-          const latest = pendingJukeboxCommandTimeoutsRef.current.get(agent.agentId);
+          const latest = pendingJukeboxCommandTimeoutsRef.current.get(
+            agent.agentId,
+          );
           if (latest?.timeoutId === timeoutId) {
             pendingJukeboxCommandTimeoutsRef.current.delete(agent.agentId);
           }
@@ -4363,9 +4498,13 @@ export function OfficeScreen({
           taskBoardCronJobs={taskBoard.cronJobs}
           taskBoardCronLoading={taskBoard.cronLoading}
           taskBoardCronError={
-            taskBoard.sharedTasksError ?? taskBoard.gatewayTasksError ?? taskBoard.cronError
+            taskBoard.sharedTasksError ??
+            taskBoard.gatewayTasksError ??
+            taskBoard.cronError
           }
-          taskBoardCaptureDebug={showOpenClawConsole ? taskBoard.taskCaptureDebug : undefined}
+          taskBoardCaptureDebug={
+            showOpenClawConsole ? taskBoard.taskCaptureDebug : undefined
+          }
           onTaskBoardCreateCard={() => {
             taskBoard.createManualCard();
           }}
@@ -4414,8 +4553,12 @@ export function OfficeScreen({
             }}
             onInstall={() => {
               const targetAgentId =
-                (selectedChatAgentId ?? state.selectedAgentId ?? state.agents[0]?.agentId ?? "")
-                  .trim() || null;
+                (
+                  selectedChatAgentId ??
+                  state.selectedAgentId ??
+                  state.agents[0]?.agentId ??
+                  ""
+                ).trim() || null;
               setKanbanInstallProgress({
                 active: true,
                 percent: 8,
@@ -4477,7 +4620,9 @@ export function OfficeScreen({
                 <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-amber-200/80">
                   Office fleet status
                 </p>
-                <p className="mt-1 text-sm text-amber-50">{emptyFleetMessage}</p>
+                <p className="mt-1 text-sm text-amber-50">
+                  {emptyFleetMessage}
+                </p>
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 <button
@@ -4519,7 +4664,9 @@ export function OfficeScreen({
             <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-red-200/75">
               Fleet mutation
             </div>
-            <div className="mt-1 text-sm text-red-50">{deleteAgentStatusLine}</div>
+            <div className="mt-1 text-sm text-red-50">
+              {deleteAgentStatusLine}
+            </div>
           </div>
         </div>
       ) : null}
@@ -4562,9 +4709,13 @@ export function OfficeScreen({
               cronJobs={taskBoard.cronJobs}
               cronLoading={taskBoard.cronLoading}
               cronError={
-                taskBoard.sharedTasksError ?? taskBoard.gatewayTasksError ?? taskBoard.cronError
+                taskBoard.sharedTasksError ??
+                taskBoard.gatewayTasksError ??
+                taskBoard.cronError
               }
-              taskCaptureDebug={showOpenClawConsole ? taskBoard.taskCaptureDebug : undefined}
+              taskCaptureDebug={
+                showOpenClawConsole ? taskBoard.taskCaptureDebug : undefined
+              }
               onCreateCard={() => {
                 taskBoard.createManualCard();
                 setActiveSidebarTab("kanban");
@@ -4624,7 +4775,11 @@ export function OfficeScreen({
 
       {showOnboardingWizard ? (
         <OnboardingWizard
-          key={companyCreatedSignal > 0 ? `onboarding-company-created-${companyCreatedSignal}` : "onboarding-default"}
+          key={
+            companyCreatedSignal > 0
+              ? `onboarding-company-created-${companyCreatedSignal}`
+              : "onboarding-default"
+          }
           gatewayConnected={status === "connected"}
           agentCount={state.agents.length}
           gatewayUrl={gatewayUrl}
@@ -4639,7 +4794,14 @@ export function OfficeScreen({
           initialStep={companyCreatedSignal > 0 ? "complete" : "welcome"}
           initialCompletedSteps={
             companyCreatedSignal > 0
-              ? ["welcome", "prerequisites", "connect", "agents", "company", "complete"]
+              ? [
+                  "welcome",
+                  "prerequisites",
+                  "connect",
+                  "agents",
+                  "company",
+                  "complete",
+                ]
               : undefined
           }
           createdCompanyName={createdCompanyName}
@@ -4698,164 +4860,164 @@ export function OfficeScreen({
           </div>
           {!openClawConsoleCollapsed ? (
             <div className="flex h-[320px] flex-col gap-3 overflow-y-auto bg-[#02090b]/96 px-3 py-2 font-mono text-[10px] leading-4">
-            <div className="rounded border border-cyan-500/10 bg-cyan-950/10 p-2">
-              <div className="flex items-center gap-2">
-                <input
-                  type="text"
-                  value={openClawConsoleSearch}
-                  onChange={(event) =>
-                    setOpenClawConsoleSearch(event.target.value)
-                  }
-                  placeholder="Search logs, payloads, thinking, user text."
-                  className="min-w-0 flex-1 rounded border border-cyan-500/20 bg-black/35 px-2 py-1 text-[10px] normal-case tracking-normal text-cyan-50 placeholder:text-cyan-100/30 focus:border-cyan-400/40 focus:outline-none"
-                />
-                {openClawConsoleSearch ? (
-                  <button
-                    type="button"
-                    onClick={() => setOpenClawConsoleSearch("")}
-                    className="rounded border border-cyan-500/20 px-2 py-1 text-[9px] uppercase tracking-[0.16em] text-cyan-100/70 transition-colors hover:border-cyan-400/45 hover:text-cyan-50"
-                  >
-                    Reset
-                  </button>
-                ) : null}
-              </div>
-            </div>
-            {openClawLiveStateMatchesSearch ? (
               <div className="rounded border border-cyan-500/10 bg-cyan-950/10 p-2">
-                <div className="mb-1 text-[9px] uppercase tracking-[0.16em] text-cyan-300/70">
-                  Live OpenClaw State
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={openClawConsoleSearch}
+                    onChange={(event) =>
+                      setOpenClawConsoleSearch(event.target.value)
+                    }
+                    placeholder="Search logs, payloads, thinking, user text."
+                    className="min-w-0 flex-1 rounded border border-cyan-500/20 bg-black/35 px-2 py-1 text-[10px] normal-case tracking-normal text-cyan-50 placeholder:text-cyan-100/30 focus:border-cyan-400/40 focus:outline-none"
+                  />
+                  {openClawConsoleSearch ? (
+                    <button
+                      type="button"
+                      onClick={() => setOpenClawConsoleSearch("")}
+                      className="rounded border border-cyan-500/20 px-2 py-1 text-[9px] uppercase tracking-[0.16em] text-cyan-100/70 transition-colors hover:border-cyan-400/45 hover:text-cyan-50"
+                    >
+                      Reset
+                    </button>
+                  ) : null}
                 </div>
-                <pre className="whitespace-pre-wrap break-words text-cyan-100/80">
-                  {renderOpenClawHighlightedText(
-                    openClawLiveStateText,
-                    openClawConsoleSearch,
-                  )}
-                </pre>
               </div>
-            ) : (
-              <div className="rounded border border-cyan-500/10 bg-cyan-950/10 p-2 text-cyan-100/45">
-                Live OpenClaw state does not match the current search.
+              {openClawLiveStateMatchesSearch ? (
+                <div className="rounded border border-cyan-500/10 bg-cyan-950/10 p-2">
+                  <div className="mb-1 text-[9px] uppercase tracking-[0.16em] text-cyan-300/70">
+                    Live OpenClaw State
+                  </div>
+                  <pre className="whitespace-pre-wrap break-words text-cyan-100/80">
+                    {renderOpenClawHighlightedText(
+                      openClawLiveStateText,
+                      openClawConsoleSearch,
+                    )}
+                  </pre>
+                </div>
+              ) : (
+                <div className="rounded border border-cyan-500/10 bg-cyan-950/10 p-2 text-cyan-100/45">
+                  Live OpenClaw state does not match the current search.
+                </div>
+              )}
+              <div className="text-[9px] uppercase tracking-[0.16em] text-cyan-300/70">
+                Raw OpenClaw Gateway Events
               </div>
-            )}
-            <div className="text-[9px] uppercase tracking-[0.16em] text-cyan-300/70">
-              Raw OpenClaw Gateway Events
-            </div>
-            {filteredOpenClawLogEntries.length === 0 ? (
-              <div className="rounded border border-cyan-500/10 bg-cyan-950/10 p-2 text-cyan-100/45">
-                {openClawLogEntries.length === 0
-                  ? "No OpenClaw gateway events received yet."
-                  : "No OpenClaw events match the current search."}
-              </div>
-            ) : (
-              filteredOpenClawLogEntries.map((entry) => {
-                const isUserMessage = entry.role === "user";
-                return (
-                  <div
-                    key={entry.id}
-                    className={`rounded border p-2 ${
-                      isUserMessage
-                        ? "border-amber-400/30 bg-amber-950/12"
-                        : "border-cyan-500/12 bg-cyan-950/8"
-                    }`}
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <div
-                        className={`text-[9px] uppercase tracking-[0.16em] ${
-                          isUserMessage
-                            ? "text-amber-300/85"
-                            : "text-cyan-300/75"
-                        }`}
-                      >
-                        {renderOpenClawHighlightedText(
-                          `[${entry.timestamp}] ${entry.eventName} / ${entry.eventKind}`,
-                          openClawConsoleSearch,
-                        )}
-                      </div>
-                      {entry.role ? (
-                        <span
-                          className={`rounded px-1.5 py-0.5 text-[9px] uppercase ${
+              {filteredOpenClawLogEntries.length === 0 ? (
+                <div className="rounded border border-cyan-500/10 bg-cyan-950/10 p-2 text-cyan-100/45">
+                  {openClawLogEntries.length === 0
+                    ? "No OpenClaw gateway events received yet."
+                    : "No OpenClaw events match the current search."}
+                </div>
+              ) : (
+                filteredOpenClawLogEntries.map((entry) => {
+                  const isUserMessage = entry.role === "user";
+                  return (
+                    <div
+                      key={entry.id}
+                      className={`rounded border p-2 ${
+                        isUserMessage
+                          ? "border-amber-400/30 bg-amber-950/12"
+                          : "border-cyan-500/12 bg-cyan-950/8"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <div
+                          className={`text-[9px] uppercase tracking-[0.16em] ${
                             isUserMessage
-                              ? "bg-amber-400/15 text-amber-200"
-                              : "bg-cyan-400/10 text-cyan-200/80"
+                              ? "text-amber-300/85"
+                              : "text-cyan-300/75"
                           }`}
                         >
-                          {entry.role}
-                        </span>
-                      ) : null}
-                    </div>
-                    <div className="mt-1 whitespace-pre-wrap break-words text-cyan-100/55">
-                      {renderOpenClawHighlightedText(
-                        entry.summary,
-                        openClawConsoleSearch,
-                      )}
-                    </div>
-                    {entry.messageText ? (
-                      <div className="mt-2 rounded border border-amber-400/20 bg-amber-950/25 px-2 py-1 text-amber-100">
-                        <div className="text-[9px] uppercase tracking-[0.16em] text-amber-300/75">
-                          User / Message Text
-                        </div>
-                        <div className="mt-1 whitespace-pre-wrap break-words">
                           {renderOpenClawHighlightedText(
-                            entry.messageText,
+                            `[${entry.timestamp}] ${entry.eventName} / ${entry.eventKind}`,
                             openClawConsoleSearch,
                           )}
                         </div>
+                        {entry.role ? (
+                          <span
+                            className={`rounded px-1.5 py-0.5 text-[9px] uppercase ${
+                              isUserMessage
+                                ? "bg-amber-400/15 text-amber-200"
+                                : "bg-cyan-400/10 text-cyan-200/80"
+                            }`}
+                          >
+                            {entry.role}
+                          </span>
+                        ) : null}
                       </div>
-                    ) : null}
-                    {entry.thinkingText ? (
-                      <div className="mt-2 rounded border border-fuchsia-400/15 bg-fuchsia-950/15 px-2 py-1 text-fuchsia-100/90">
-                        <div className="text-[9px] uppercase tracking-[0.16em] text-fuchsia-300/70">
-                          Thinking
-                        </div>
-                        <div className="mt-1 whitespace-pre-wrap break-words">
-                          {renderOpenClawHighlightedText(
-                            entry.thinkingText,
-                            openClawConsoleSearch,
-                          )}
-                        </div>
-                      </div>
-                    ) : null}
-                    {entry.streamText ? (
-                      <div className="mt-2 rounded border border-cyan-400/15 bg-cyan-950/18 px-2 py-1 text-cyan-50/90">
-                        <div className="text-[9px] uppercase tracking-[0.16em] text-cyan-300/70">
-                          Stream
-                        </div>
-                        <div className="mt-1 whitespace-pre-wrap break-words">
-                          {renderOpenClawHighlightedText(
-                            entry.streamText,
-                            openClawConsoleSearch,
-                          )}
-                        </div>
-                      </div>
-                    ) : null}
-                    {entry.toolText ? (
-                      <div className="mt-2 rounded border border-violet-400/15 bg-violet-950/15 px-2 py-1 text-violet-100/90">
-                        <div className="text-[9px] uppercase tracking-[0.16em] text-violet-300/70">
-                          Tool Output
-                        </div>
-                        <div className="mt-1 whitespace-pre-wrap break-words">
-                          {renderOpenClawHighlightedText(
-                            entry.toolText,
-                            openClawConsoleSearch,
-                          )}
-                        </div>
-                      </div>
-                    ) : null}
-                    <details className="mt-2">
-                      <summary className="cursor-pointer text-[9px] uppercase tracking-[0.16em] text-cyan-300/55">
-                        Raw Payload
-                      </summary>
-                      <pre className="mt-1 whitespace-pre-wrap break-words text-cyan-100/45">
+                      <div className="mt-1 whitespace-pre-wrap break-words text-cyan-100/55">
                         {renderOpenClawHighlightedText(
-                          entry.payloadText,
+                          entry.summary,
                           openClawConsoleSearch,
                         )}
-                      </pre>
-                    </details>
-                  </div>
-                );
-              })
-            )}
+                      </div>
+                      {entry.messageText ? (
+                        <div className="mt-2 rounded border border-amber-400/20 bg-amber-950/25 px-2 py-1 text-amber-100">
+                          <div className="text-[9px] uppercase tracking-[0.16em] text-amber-300/75">
+                            User / Message Text
+                          </div>
+                          <div className="mt-1 whitespace-pre-wrap break-words">
+                            {renderOpenClawHighlightedText(
+                              entry.messageText,
+                              openClawConsoleSearch,
+                            )}
+                          </div>
+                        </div>
+                      ) : null}
+                      {entry.thinkingText ? (
+                        <div className="mt-2 rounded border border-fuchsia-400/15 bg-fuchsia-950/15 px-2 py-1 text-fuchsia-100/90">
+                          <div className="text-[9px] uppercase tracking-[0.16em] text-fuchsia-300/70">
+                            Thinking
+                          </div>
+                          <div className="mt-1 whitespace-pre-wrap break-words">
+                            {renderOpenClawHighlightedText(
+                              entry.thinkingText,
+                              openClawConsoleSearch,
+                            )}
+                          </div>
+                        </div>
+                      ) : null}
+                      {entry.streamText ? (
+                        <div className="mt-2 rounded border border-cyan-400/15 bg-cyan-950/18 px-2 py-1 text-cyan-50/90">
+                          <div className="text-[9px] uppercase tracking-[0.16em] text-cyan-300/70">
+                            Stream
+                          </div>
+                          <div className="mt-1 whitespace-pre-wrap break-words">
+                            {renderOpenClawHighlightedText(
+                              entry.streamText,
+                              openClawConsoleSearch,
+                            )}
+                          </div>
+                        </div>
+                      ) : null}
+                      {entry.toolText ? (
+                        <div className="mt-2 rounded border border-violet-400/15 bg-violet-950/15 px-2 py-1 text-violet-100/90">
+                          <div className="text-[9px] uppercase tracking-[0.16em] text-violet-300/70">
+                            Tool Output
+                          </div>
+                          <div className="mt-1 whitespace-pre-wrap break-words">
+                            {renderOpenClawHighlightedText(
+                              entry.toolText,
+                              openClawConsoleSearch,
+                            )}
+                          </div>
+                        </div>
+                      ) : null}
+                      <details className="mt-2">
+                        <summary className="cursor-pointer text-[9px] uppercase tracking-[0.16em] text-cyan-300/55">
+                          Raw Payload
+                        </summary>
+                        <pre className="mt-1 whitespace-pre-wrap break-words text-cyan-100/45">
+                          {renderOpenClawHighlightedText(
+                            entry.payloadText,
+                            openClawConsoleSearch,
+                          )}
+                        </pre>
+                      </details>
+                    </div>
+                  );
+                })
+              )}
             </div>
           ) : null}
         </section>
@@ -4912,7 +5074,9 @@ export function OfficeScreen({
                           </span>
                         ) : null}
                         <span className="sr-only">
-                          {agent.kind === "remote" ? "Remote agent" : "Local agent"}
+                          {agent.kind === "remote"
+                            ? "Remote agent"
+                            : "Local agent"}
                         </span>
                       </button>
                     );
@@ -4992,14 +5156,21 @@ export function OfficeScreen({
                   messages={focusedRemoteChatState.messages}
                   disabledReason={remoteMessagingDisabledReason}
                   onDraftChange={(value) => {
-                    updateRemoteChatSession(focusedRemoteChatTarget.id, (session) => ({
-                      ...session,
-                      draft: value,
-                      error: null,
-                    }));
+                    updateRemoteChatSession(
+                      focusedRemoteChatTarget.id,
+                      (session) => ({
+                        ...session,
+                        draft: value,
+                        error: null,
+                      }),
+                    );
                   }}
                   onSend={(message) => {
-                    void handleChatSend(focusedRemoteChatTarget.id, "", message);
+                    void handleChatSend(
+                      focusedRemoteChatTarget.id,
+                      "",
+                      message,
+                    );
                   }}
                 />
               ) : (

--- a/tests/unit/agentFleetHydrationDerivation.test.ts
+++ b/tests/unit/agentFleetHydrationDerivation.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import { deriveHydrateAgentFleetResult } from "@/features/agents/operations/agentFleetHydrationDerivation";
-import { createDefaultAgentAvatarProfile } from "@/lib/avatars/profile";
 import type { StudioSettings } from "@/lib/studio/settings";
 
 describe("deriveHydrateAgentFleetResult", () => {
@@ -14,7 +13,10 @@ describe("deriveHydrateAgentFleetResult", () => {
       focused: {},
       avatars: {
         [gatewayUrl]: {
-          "agent-1": createDefaultAgentAvatarProfile("persisted-seed"),
+          "agent-1": {
+            seed: "persisted-seed",
+            version: 1,
+          },
         },
       },
       deskAssignments: {},
@@ -93,9 +95,12 @@ describe("deriveHydrateAgentFleetResult", () => {
       expect.objectContaining({
         agentId: "agent-1",
         name: "One",
+        runtimeName: "One",
+        identityName: null,
+        sessionDisplayName: "Main",
         sessionKey: "agent:agent-1:main",
-        avatarSeed: "persisted-seed",
-        avatarProfile: expect.objectContaining({ seed: "persisted-seed" }),
+        avatarSeed: "agent-1",
+        avatarProfile: expect.objectContaining({ seed: "agent-1" }),
         avatarUrl: "https://example.com/one.png",
         model: "openai/gpt-4.1",
         thinkingLevel: "medium",

--- a/tests/unit/agentStateRoute.test.ts
+++ b/tests/unit/agentStateRoute.test.ts
@@ -9,13 +9,8 @@ import { POST, PUT } from "@/app/api/gateway/agent-state/route";
 
 const ORIGINAL_ENV = { ...process.env };
 
-vi.mock("node:child_process", async () => {
-  const actual = await vi.importActual<typeof import("node:child_process")>(
-    "node:child_process"
-  );
+vi.mock("node:child_process", () => {
   return {
-    default: actual,
-    ...actual,
     spawnSync: vi.fn(),
   };
 });

--- a/tests/unit/claw3doctor.test.ts
+++ b/tests/unit/claw3doctor.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   buildCustomRuntimeWarnings,
   buildDoctorJsonReport,
+  buildGatewayFailureActions,
+  buildProfileWarnings,
   buildOpenClawWarnings,
   DOCTOR_STATUSES,
   buildGatewayWarnings,
+  formatDoctorReport,
   resolveRuntimeContext,
   shouldRunCustomChecks,
   shouldRunDemoChecks,
@@ -110,6 +113,39 @@ describe("claw3doctor core", () => {
     );
   });
 
+  it("warns when multiple runtime profiles share the same endpoint", () => {
+    expect(
+      buildProfileWarnings({
+        runtimeContext: {
+          profiles: {
+            openclaw: { url: "ws://localhost:18789", token: "a" },
+            hermes: { url: "ws://localhost:18789", token: "" },
+            demo: { url: "ws://localhost:28789", token: "" },
+          },
+        },
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("same endpoint"),
+      ]),
+    );
+  });
+
+  it("builds remediation actions from tunnel and pairing style failures", () => {
+    expect(
+      buildGatewayFailureActions({
+        adapterType: "openclaw",
+        message: "Unexpected HTTP 401 during WebSocket upgrade. pairing required 1008",
+        gatewayUrl: "wss://demo.tailnet.ts.net/gateway",
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("openclaw devices list"),
+        expect.stringContaining("direct local or LAN access"),
+      ]),
+    );
+  });
+
   it("summarizes checks by worst status", () => {
     expect(
       summarizeChecks([
@@ -176,5 +212,37 @@ describe("claw3doctor core", () => {
       },
       checks: [{ label: "Gateway token" }],
     });
+  });
+
+  it("formats a grouped terminal report with configured profiles", () => {
+    const report = formatDoctorReport({
+      summary: DOCTOR_STATUSES.warn,
+      runtimeContext: {
+        adapterType: "hermes",
+        gatewayUrl: "ws://localhost:18789",
+        token: "",
+        tokenConfigured: false,
+        profiles: {
+          hermes: { url: "ws://localhost:18789", token: "" },
+          openclaw: { url: "ws://localhost:28789", token: "secret" },
+        },
+      },
+      paths: {
+        stateDir: "C:/tmp/.openclaw",
+        settingsPath: "C:/tmp/.openclaw/claw3d/settings.json",
+      },
+      checks: [
+        {
+          category: "Runtime profiles",
+          status: DOCTOR_STATUSES.warn,
+          label: "Profile collision",
+          message: "Multiple runtime profiles share the same endpoint.",
+        },
+      ],
+    });
+
+    expect(report).toContain("Configured profiles:");
+    expect(report).toContain("Runtime profiles");
+    expect(report).toContain("Check counts:");
   });
 });

--- a/tests/unit/claw3doctor.test.ts
+++ b/tests/unit/claw3doctor.test.ts
@@ -10,6 +10,7 @@ import {
   DOCTOR_STATUSES,
   buildGatewayWarnings,
   formatDoctorReport,
+  parseDoctorArgs,
   resolveRuntimeContext,
   shouldRunCustomChecks,
   shouldRunDemoChecks,
@@ -275,5 +276,76 @@ describe("claw3doctor core", () => {
     expect(report).toContain("Configured profiles:");
     expect(report).toContain("Runtime profiles");
     expect(report).toContain("Check counts:");
+  });
+});
+
+describe("parseDoctorArgs", () => {
+  it("returns defaults when no flags are supplied", () => {
+    expect(parseDoctorArgs([])).toEqual({ json: false, allProfiles: false, profile: null });
+  });
+
+  it("sets json flag", () => {
+    expect(parseDoctorArgs(["--json"])).toMatchObject({ json: true });
+  });
+
+  it("sets allProfiles flag", () => {
+    expect(parseDoctorArgs(["--all-profiles"])).toMatchObject({ allProfiles: true, profile: null });
+  });
+
+  it("sets profile to lower-cased value", () => {
+    expect(parseDoctorArgs(["--profile", "Hermes"])).toMatchObject({ profile: "hermes", allProfiles: false });
+  });
+
+  it("ignores --profile flag when no value follows", () => {
+    expect(parseDoctorArgs(["--profile"])).toMatchObject({ profile: null });
+  });
+
+  it("combines flags", () => {
+    expect(parseDoctorArgs(["--json", "--profile", "openclaw"])).toEqual({
+      json: true,
+      allProfiles: false,
+      profile: "openclaw",
+    });
+  });
+});
+
+describe("adapterInScope scoping semantics", () => {
+  // Mirror the adapterInScope helper used in claw3doctor.mjs so the logic can
+  // be verified independently of the full CLI entrypoint.
+  const makeAdapterInScope =
+    (args: { allProfiles: boolean; profile: string | null }) =>
+    (adapterType: string, defaultBehavior: boolean): boolean => {
+      if (args.allProfiles) return true;
+      if (args.profile) return args.profile === adapterType;
+      return defaultBehavior;
+    };
+
+  it("default (no flags): delegates to defaultBehavior", () => {
+    const inScope = makeAdapterInScope({ allProfiles: false, profile: null });
+    expect(inScope("openclaw", true)).toBe(true);
+    expect(inScope("openclaw", false)).toBe(false);
+    expect(inScope("hermes", false)).toBe(false);
+  });
+
+  it("--profile hermes: only hermes is in scope", () => {
+    const inScope = makeAdapterInScope({ allProfiles: false, profile: "hermes" });
+    expect(inScope("hermes", false)).toBe(true);
+    expect(inScope("openclaw", true)).toBe(false); // openclaw would default to true but is suppressed
+    expect(inScope("demo", true)).toBe(false);
+    expect(inScope("custom", false)).toBe(false);
+  });
+
+  it("--profile openclaw: only openclaw is in scope", () => {
+    const inScope = makeAdapterInScope({ allProfiles: false, profile: "openclaw" });
+    expect(inScope("openclaw", false)).toBe(true);
+    expect(inScope("hermes", true)).toBe(false);
+  });
+
+  it("--all-profiles: every adapter is in scope regardless of default", () => {
+    const inScope = makeAdapterInScope({ allProfiles: true, profile: null });
+    expect(inScope("hermes", false)).toBe(true);
+    expect(inScope("openclaw", false)).toBe(true);
+    expect(inScope("demo", false)).toBe(true);
+    expect(inScope("custom", false)).toBe(true);
   });
 });

--- a/tests/unit/claw3doctor.test.ts
+++ b/tests/unit/claw3doctor.test.ts
@@ -142,6 +142,7 @@ describe("claw3doctor core", () => {
       expect.arrayContaining([
         expect.stringContaining("openclaw devices list"),
         expect.stringContaining("direct local or LAN access"),
+        expect.stringContaining("Tailnet-hosted"),
       ]),
     );
   });
@@ -241,6 +242,8 @@ describe("claw3doctor core", () => {
       ],
     });
 
+    expect(report).toContain("Claw3Doctor");
+    expect(report).toContain("Selected profile:");
     expect(report).toContain("Configured profiles:");
     expect(report).toContain("Runtime profiles");
     expect(report).toContain("Check counts:");

--- a/tests/unit/claw3doctor.test.ts
+++ b/tests/unit/claw3doctor.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DOCTOR_STATUSES,
+  buildGatewayWarnings,
+  resolveRuntimeContext,
+  shouldRunHermesChecks,
+  shouldRunOpenClawChecks,
+  summarizeChecks,
+} from "../../scripts/lib/claw3doctor-core.mjs";
+
+describe("claw3doctor core", () => {
+  it("resolves selected runtime from settings profiles", () => {
+    const runtime = resolveRuntimeContext({
+      settings: {
+        gateway: {
+          adapterType: "hermes",
+          url: "ws://localhost:18790",
+          token: "",
+          profiles: {
+            hermes: { url: "ws://localhost:18790", token: "" },
+            openclaw: { url: "ws://localhost:18789", token: "file-token" },
+          },
+        },
+      },
+      upstreamGateway: {
+        url: "ws://localhost:18789",
+        token: "file-token",
+        adapterType: "openclaw",
+      },
+      env: process.env,
+    });
+
+    expect(runtime).toMatchObject({
+      adapterType: "hermes",
+      gatewayUrl: "ws://localhost:18790",
+      tokenConfigured: false,
+    });
+    const profiles = runtime.profiles as Record<string, { url: string; token: string }>;
+    expect(profiles.openclaw?.url).toBe("ws://localhost:18789");
+  });
+
+  it("warns on insecure remote websocket and public studio without access token", () => {
+    expect(
+      buildGatewayWarnings({
+        gatewayUrl: "ws://pi5.example.com:18789",
+        studioAccessToken: "",
+        host: "pi5.example.com",
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("ws://"),
+        expect.stringContaining("STUDIO_ACCESS_TOKEN"),
+      ]),
+    );
+  });
+
+  it("summarizes checks by worst status", () => {
+    expect(
+      summarizeChecks([
+        { status: DOCTOR_STATUSES.pass },
+        { status: DOCTOR_STATUSES.warn },
+      ]),
+    ).toBe(DOCTOR_STATUSES.warn);
+    expect(
+      summarizeChecks([
+        { status: DOCTOR_STATUSES.pass },
+        { status: DOCTOR_STATUSES.fail },
+      ]),
+    ).toBe(DOCTOR_STATUSES.fail);
+  });
+
+  it("enables provider-specific checks based on runtime and local state", () => {
+    expect(
+      shouldRunHermesChecks({
+        runtimeContext: { adapterType: "hermes" },
+        env: process.env,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRunOpenClawChecks({
+        runtimeContext: { adapterType: "demo" },
+        openclawConfigExists: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/claw3doctor.test.ts
+++ b/tests/unit/claw3doctor.test.ts
@@ -4,11 +4,11 @@ import {
   buildCustomRuntimeWarnings,
   buildDoctorJsonReport,
   buildGatewayFailureActions,
-  classifyGatewayFailure,
-  buildProfileWarnings,
-  buildOpenClawWarnings,
-  DOCTOR_STATUSES,
   buildGatewayWarnings,
+  buildOpenClawWarnings,
+  buildProfileWarnings,
+  classifyGatewayFailure,
+  DOCTOR_STATUSES,
   formatDoctorReport,
   parseDoctorArgs,
   resolveRuntimeContext,
@@ -46,7 +46,10 @@ describe("claw3doctor core", () => {
       gatewayUrl: "ws://localhost:18790",
       tokenConfigured: false,
     });
-    const profiles = runtime.profiles as Record<string, { url: string; token: string }>;
+    const profiles = runtime.profiles as Record<
+      string,
+      { url: string; token: string }
+    >;
     expect(profiles.openclaw?.url).toBe("ws://localhost:18789");
   });
 
@@ -127,9 +130,7 @@ describe("claw3doctor core", () => {
         },
       }),
     ).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("same endpoint"),
-      ]),
+      expect.arrayContaining([expect.stringContaining("same endpoint")]),
     );
   });
 
@@ -137,7 +138,8 @@ describe("claw3doctor core", () => {
     expect(
       buildGatewayFailureActions({
         adapterType: "openclaw",
-        message: "Unexpected HTTP 401 during WebSocket upgrade. pairing required 1008",
+        message:
+          "Unexpected HTTP 401 during WebSocket upgrade. pairing required 1008",
         gatewayUrl: "wss://demo.tailnet.ts.net/gateway",
       }),
     ).toEqual(
@@ -231,7 +233,13 @@ describe("claw3doctor core", () => {
         stateDir: "C:/tmp/.openclaw",
         settingsPath: "C:/tmp/.openclaw/claw3d/settings.json",
       },
-      checks: [{ status: DOCTOR_STATUSES.warn, label: "Gateway token", message: "Missing." }],
+      checks: [
+        {
+          status: DOCTOR_STATUSES.warn,
+          label: "Gateway token",
+          message: "Missing.",
+        },
+      ],
     });
 
     expect(report).toMatchObject({
@@ -281,7 +289,11 @@ describe("claw3doctor core", () => {
 
 describe("parseDoctorArgs", () => {
   it("returns defaults when no flags are supplied", () => {
-    expect(parseDoctorArgs([])).toEqual({ json: false, allProfiles: false, profile: null });
+    expect(parseDoctorArgs([])).toEqual({
+      json: false,
+      allProfiles: false,
+      profile: null,
+    });
   });
 
   it("sets json flag", () => {
@@ -289,11 +301,17 @@ describe("parseDoctorArgs", () => {
   });
 
   it("sets allProfiles flag", () => {
-    expect(parseDoctorArgs(["--all-profiles"])).toMatchObject({ allProfiles: true, profile: null });
+    expect(parseDoctorArgs(["--all-profiles"])).toMatchObject({
+      allProfiles: true,
+      profile: null,
+    });
   });
 
   it("sets profile to lower-cased value", () => {
-    expect(parseDoctorArgs(["--profile", "Hermes"])).toMatchObject({ profile: "hermes", allProfiles: false });
+    expect(parseDoctorArgs(["--profile", "Hermes"])).toMatchObject({
+      profile: "hermes",
+      allProfiles: false,
+    });
   });
 
   it("ignores --profile flag when no value follows", () => {
@@ -328,7 +346,10 @@ describe("adapterInScope scoping semantics", () => {
   });
 
   it("--profile hermes: only hermes is in scope", () => {
-    const inScope = makeAdapterInScope({ allProfiles: false, profile: "hermes" });
+    const inScope = makeAdapterInScope({
+      allProfiles: false,
+      profile: "hermes",
+    });
     expect(inScope("hermes", false)).toBe(true);
     expect(inScope("openclaw", true)).toBe(false); // openclaw would default to true but is suppressed
     expect(inScope("demo", true)).toBe(false);
@@ -336,7 +357,10 @@ describe("adapterInScope scoping semantics", () => {
   });
 
   it("--profile openclaw: only openclaw is in scope", () => {
-    const inScope = makeAdapterInScope({ allProfiles: false, profile: "openclaw" });
+    const inScope = makeAdapterInScope({
+      allProfiles: false,
+      profile: "openclaw",
+    });
     expect(inScope("openclaw", false)).toBe(true);
     expect(inScope("hermes", true)).toBe(false);
   });

--- a/tests/unit/claw3doctor.test.ts
+++ b/tests/unit/claw3doctor.test.ts
@@ -4,6 +4,7 @@ import {
   buildCustomRuntimeWarnings,
   buildDoctorJsonReport,
   buildGatewayFailureActions,
+  classifyGatewayFailure,
   buildProfileWarnings,
   buildOpenClawWarnings,
   DOCTOR_STATUSES,
@@ -145,6 +146,33 @@ describe("claw3doctor core", () => {
         expect.stringContaining("Tailnet-hosted"),
       ]),
     );
+  });
+
+  it("classifies common gateway failure signatures", () => {
+    expect(
+      classifyGatewayFailure({
+        message: "Unexpected HTTP 401 during WebSocket upgrade",
+      }),
+    ).toMatchObject({
+      code: "401",
+      label: "Auth rejection",
+    });
+    expect(
+      classifyGatewayFailure({
+        message: "connect failed: 1008 pairing required",
+      }),
+    ).toMatchObject({
+      code: "1008",
+      label: "Policy or pairing gate",
+    });
+    expect(
+      classifyGatewayFailure({
+        message: "connect ECONNREFUSED ::1:18789",
+      }),
+    ).toMatchObject({
+      code: "ECONNREFUSED",
+      label: "Listener missing",
+    });
   });
 
   it("summarizes checks by worst status", () => {

--- a/tests/unit/claw3doctor.test.ts
+++ b/tests/unit/claw3doctor.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildCustomRuntimeWarnings,
+  buildDoctorJsonReport,
+  buildOpenClawWarnings,
   DOCTOR_STATUSES,
   buildGatewayWarnings,
   resolveRuntimeContext,
+  shouldRunCustomChecks,
+  shouldRunDemoChecks,
   shouldRunHermesChecks,
   shouldRunOpenClawChecks,
   summarizeChecks,
@@ -55,6 +60,56 @@ describe("claw3doctor core", () => {
     );
   });
 
+  it("uses adapter-specific defaults for custom profiles", () => {
+    const runtime = resolveRuntimeContext({
+      settings: {
+        gateway: {
+          adapterType: "custom",
+        },
+      },
+      upstreamGateway: {
+        url: "",
+        token: "",
+        adapterType: "custom",
+      },
+      env: process.env,
+    });
+
+    expect(runtime).toMatchObject({
+      adapterType: "custom",
+      gatewayUrl: "http://localhost:7770",
+      tokenConfigured: false,
+    });
+  });
+
+  it("warns about remote openclaw tunnel setups without a token", () => {
+    expect(
+      buildOpenClawWarnings({
+        gatewayUrl: "wss://demo.tailnet.ts.net/gateway",
+        tokenConfigured: false,
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("gateway token"),
+        expect.stringContaining("1008/1011/1012"),
+      ]),
+    );
+  });
+
+  it("warns when production custom runtime is public without an allowlist", () => {
+    expect(
+      buildCustomRuntimeWarnings({
+        gatewayUrl: "https://runtime.example.com",
+        allowlist: "",
+        nodeEnv: "production",
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("CUSTOM_RUNTIME_ALLOWLIST"),
+      ]),
+    );
+  });
+
   it("summarizes checks by worst status", () => {
     expect(
       summarizeChecks([
@@ -83,5 +138,43 @@ describe("claw3doctor core", () => {
         openclawConfigExists: true,
       }),
     ).toBe(true);
+    expect(
+      shouldRunDemoChecks({
+        runtimeContext: { adapterType: "demo" },
+        env: process.env,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRunCustomChecks({
+        runtimeContext: { adapterType: "custom" },
+      }),
+    ).toBe(true);
+  });
+
+  it("builds a structured json report", () => {
+    const report = buildDoctorJsonReport({
+      summary: DOCTOR_STATUSES.warn,
+      runtimeContext: {
+        adapterType: "hermes",
+        gatewayUrl: "ws://localhost:18789",
+        token: "",
+        tokenConfigured: false,
+        profiles: {},
+      },
+      paths: {
+        stateDir: "C:/tmp/.openclaw",
+        settingsPath: "C:/tmp/.openclaw/claw3d/settings.json",
+      },
+      checks: [{ status: DOCTOR_STATUSES.warn, label: "Gateway token", message: "Missing." }],
+    });
+
+    expect(report).toMatchObject({
+      doctor: "claw3doctor",
+      summary: DOCTOR_STATUSES.warn,
+      runtimeContext: {
+        adapterType: "hermes",
+      },
+      checks: [{ label: "Gateway token" }],
+    });
   });
 });

--- a/tests/unit/gatewayAgentFiles.test.ts
+++ b/tests/unit/gatewayAgentFiles.test.ts
@@ -18,7 +18,7 @@ describe("gateway agent files helpers", () => {
 
     await expect(
       readGatewayAgentFile({ client, agentId: "agent-1", name: "AGENTS.md" })
-    ).resolves.toEqual({ exists: false, content: "" });
+    ).resolves.toEqual({ exists: false, content: "", path: null, workspace: null });
   });
 
   it("returns exists=true and content when gateway returns content", async () => {
@@ -31,7 +31,7 @@ describe("gateway agent files helpers", () => {
 
     await expect(
       readGatewayAgentFile({ client, agentId: "agent-1", name: "AGENTS.md" })
-    ).resolves.toEqual({ exists: true, content: "hello" });
+    ).resolves.toEqual({ exists: true, content: "hello", path: null, workspace: null });
   });
 
   it("coerces non-string content to empty string", async () => {
@@ -44,7 +44,7 @@ describe("gateway agent files helpers", () => {
 
     await expect(
       readGatewayAgentFile({ client, agentId: "agent-1", name: "AGENTS.md" })
-    ).resolves.toEqual({ exists: true, content: "" });
+    ).resolves.toEqual({ exists: true, content: "", path: null, workspace: null });
   });
 
   it("throws when agentId is empty", async () => {

--- a/tests/unit/packagedSkills.test.ts
+++ b/tests/unit/packagedSkills.test.ts
@@ -8,6 +8,7 @@ import { resolveSkillMarketplaceMetadata } from "@/lib/skills/marketplace";
 import { readPackagedSkillFiles } from "@/lib/skills/packaged";
 
 const resolveAssetDir = (packageId: string) => path.join(process.cwd(), "assets/skills", packageId);
+const normalizeLineEndings = (value: string) => value.replace(/\r\n/g, "\n");
 
 describe("packaged skills", () => {
   it("keeps packaged skill files synchronized with the asset source files", () => {
@@ -24,7 +25,7 @@ describe("packaged skills", () => {
 
       for (const file of packagedFiles) {
         const assetContent = readFileSync(path.join(assetDir, file.relativePath), "utf8");
-        expect(file.content).toBe(assetContent);
+        expect(normalizeLineEndings(file.content)).toBe(normalizeLineEndings(assetContent));
       }
     }
   });

--- a/tests/unit/skillsRemoveRoute.test.ts
+++ b/tests/unit/skillsRemoveRoute.test.ts
@@ -9,13 +9,8 @@ import { POST } from "@/app/api/gateway/skills/remove/route";
 
 const ORIGINAL_ENV = { ...process.env };
 
-vi.mock("node:child_process", async () => {
-  const actual = await vi.importActual<typeof import("node:child_process")>(
-    "node:child_process"
-  );
+vi.mock("node:child_process", () => {
   return {
-    default: actual,
-    ...actual,
     spawnSync: vi.fn(),
   };
 });

--- a/tests/unit/studioSetupPaths.test.ts
+++ b/tests/unit/studioSetupPaths.test.ts
@@ -10,7 +10,9 @@ describe("studio setup paths", () => {
     const settingsPath = resolveStudioSettingsPath({
       OPENCLAW_STATE_DIR: "/tmp/openclaw-state",
     } as unknown as NodeJS.ProcessEnv);
-    expect(settingsPath).toBe("/tmp/openclaw-state/claw3d/settings.json");
+    expect(settingsPath).toBe(
+      path.join(path.resolve("/tmp/openclaw-state"), "claw3d", "settings.json")
+    );
   });
 
   it("resolves settings path under ~/.openclaw by default", async () => {

--- a/tests/unit/taskBoardView.test.ts
+++ b/tests/unit/taskBoardView.test.ts
@@ -128,7 +128,7 @@ describe("TaskBoardView", () => {
 
     expect(onCreateCard).toHaveBeenCalledTimes(1);
     expect(onRefreshCronJobs).toHaveBeenCalledTimes(1);
-    expect(onSelectCard).toHaveBeenCalledWith("task-1");
+    expect(onSelectCard).toHaveBeenCalledWith(null);
     expect(onUpdateCard).toHaveBeenCalledWith("task-1", { title: "Create marketing website" });
     expect(onMoveCard).toHaveBeenCalledWith("task-1", "in_progress");
     expect(onUpdateCard).toHaveBeenCalledWith("task-1", { assignedAgentId: "agent-1" });

--- a/tests/unit/useAgentSettingsMutationController.test.ts
+++ b/tests/unit/useAgentSettingsMutationController.test.ts
@@ -413,8 +413,11 @@ describe("useAgentSettingsMutationController", () => {
       expect(restartBlockHookParams?.block).not.toBeNull();
     });
 
+    const timeoutHookParams = restartBlockHookParams;
+    expect(timeoutHookParams).not.toBeNull();
+
     await act(async () => {
-      restartBlockHookParams?.onTimeout();
+      timeoutHookParams!.onTimeout();
     });
     expect(ctx.setError).toHaveBeenCalledWith("Gateway restart timed out after renaming the agent.");
 
@@ -427,12 +430,16 @@ describe("useAgentSettingsMutationController", () => {
       await ctx.getValue().handleRenameAgent("agent-1", "Renamed Again");
     });
     await waitFor(() => {
-      expect(restartBlockHookParams?.block?.phase).toBe("awaiting-restart");
+      expect(ctx.getValue().restartingMutationBlock?.phase).toBe("awaiting-restart");
     });
 
+    const restartHookParams = restartBlockHookParams;
+    expect(restartHookParams?.onRestartComplete).toBeTypeOf("function");
+    expect(ctx.getValue().restartingMutationBlock?.phase).toBe("awaiting-restart");
+
     await act(async () => {
-      await restartBlockHookParams?.onRestartComplete(
-        restartBlockHookParams.block as MutationBlockState,
+      await restartHookParams!.onRestartComplete(
+        ctx.getValue().restartingMutationBlock as MutationBlockState,
         { isCancelled: () => false }
       );
     });


### PR DESCRIPTION
## Summary

This PR adds the first reviewable version of `claw3doctor` and aligns the supporting roadmap/docs around the same runtime-aware direction.

The intent is not “random tooling.” It is the first operator-facing diagnostics layer for the current Claw3D stack after the recent hardening, Hermes adapter, Tailscale/public deployment, and multi-runtime planning work.

## What’s in v1

### `claw3doctor`
- first-pass diagnostics command for Claw3D deployments
- grouped terminal output with pass / warn / fail sections
- JSON output mode
- runtime-profile awareness
- selected-profile checks by default
- `--all-profiles` and `--profile <adapter>` support
- provider-aware diagnostics for:
  - OpenClaw
  - Hermes adapter
  - demo runtime
  - custom runtimes
- failure classification for common auth / transport patterns
- Cloudflare / Tailscale / remote deployment remediation text

### Docs / roadmap alignment
- clarified runtime-profile architecture
- aligned Office Systems roadmap with runtime profiles + diagnostics
- documented `claw3doctor` as a bounded v1 with explicit v2 follow-up work

## Why this PR exists now

Claw3D now sits above multiple runtime shapes:
- native OpenClaw
- Hermes through the adapter
- demo/custom providers
- local and remote/tunneled deployments

That created too many repeated setup/debugging loops. `claw3doctor` is the first pass at making those failures diagnosable without issue-thread ping-pong.

## Explicitly deferred to v2

- deeper OpenClaw pairing / device heuristics
- stronger Cloudflare / Tailscale / reverse-proxy fingerprints
- richer export / issue-bundle workflows
- in-app diagnostics surface later
- floor-to-profile and simultaneous multi-runtime diagnostics after runtime binding matures

## Validation

- `pnpm --dir isolation/Claw3D exec vitest run tests/unit/claw3doctor.test.ts`
- `pnpm --dir isolation/Claw3D run typecheck`