### PR TITLE
Add district simulation core for scope A foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "claw3d",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claw3d",
-      "version": "0.1.0",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@noble/ed25519": "^3.0.0",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
-        "@vercel/otel": "^2.1.0",
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -163,7 +162,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -470,7 +468,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -511,7 +508,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1964,134 +1960,10 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/api-logs": {
-      "version": "0.211.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.211.0.tgz",
-      "integrity": "sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.211.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.211.0.tgz",
-      "integrity": "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.211.0",
-        "import-in-the-middle": "^2.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
-      "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.5.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.211.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.211.0.tgz",
-      "integrity": "sha512-O5nPwzgg2JHzo59kpQTPUOTzFi0Nv5LxryG27QoXBciX3zWM3z83g+SNOHhiQVYRWFSxoWn1JM2TGD5iNjOwdA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.211.0",
-        "@opentelemetry/core": "2.5.0",
-        "@opentelemetry/resources": "2.5.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
-      "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.5.0",
-        "@opentelemetry/resources": "2.5.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
-      "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "2.5.0",
-        "@opentelemetry/resources": "2.5.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
-      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-cms": {
@@ -2259,7 +2131,6 @@
       "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.0"
       },
@@ -2315,7 +2186,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -3069,6 +2939,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3089,6 +2960,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3170,7 +3042,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/canvas-confetti": {
       "version": "1.9.0",
@@ -3286,7 +3159,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3297,7 +3169,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3322,7 +3193,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
       "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3400,7 +3270,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3918,24 +3787,6 @@
         "react": ">= 16.8.0"
       }
     },
-    "node_modules/@vercel/otel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/otel/-/otel-2.1.0.tgz",
-      "integrity": "sha512-Zwu2Cu4t46DzBnY1DQSTxZ4MBLVfYsOjnlWuZuLRWnmVPX+SNrVHbs3ssiJ6uvY1J1JJswor4zSn8mHYxzYeBA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <2.0.0",
-        "@opentelemetry/api-logs": ">=0.200.0 <0.300.0",
-        "@opentelemetry/instrumentation": ">=0.200.0 <0.300.0",
-        "@opentelemetry/resources": ">=2.0.0 <3.0.0",
-        "@opentelemetry/sdk-logs": ">=0.200.0 <0.300.0",
-        "@opentelemetry/sdk-metrics": ">=2.0.0 <3.0.0",
-        "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0"
-      }
-    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -4057,22 +3908,13 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -4118,6 +3960,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4495,7 +4338,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4724,18 +4566,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "license": "MIT"
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.1.1"
       },
@@ -4754,7 +4589,6 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5112,7 +4946,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -5431,7 +5266,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5633,7 +5467,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6532,18 +6365,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/import-in-the-middle": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.5.tgz",
-      "integrity": "sha512-0InH9/4oDCBRzWXhpOqusspLBrVfK1vPvbn9Wxl8DAQ8yyx5fWJRETICSwkiAMaYntjJAMBP1R4B6cQnEUYVEA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^2.2.0",
-        "module-details-from-path": "^1.0.4"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -7148,7 +6969,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7631,6 +7451,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8599,12 +8420,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9178,6 +8993,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9193,6 +9009,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9205,7 +9022,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
@@ -9295,7 +9113,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9305,7 +9122,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9516,19 +9332,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-in-the-middle": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
-      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {
@@ -10292,7 +10095,6 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
       "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -10323,8 +10125,7 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -10416,7 +10217,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10752,7 +10552,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11026,7 +10825,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11135,7 +10933,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11487,7 +11284,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -1117,7 +1117,9 @@ export function OfficeScreen({
     voiceId: voiceRepliesPreference.voiceId,
     speed: voiceRepliesPreference.speed,
   });
-  const showOnboardingWizard = showOnboarding || forceShowOnboarding;
+  const cityViewMode = true;
+  const showOnboardingWizard =
+    cityViewMode ? false : showOnboarding || forceShowOnboarding;
   const handleOpenOnboarding = useCallback(() => {
     resetOnboarding();
     setCompanyCreatedSignal(0);
@@ -4166,6 +4168,7 @@ export function OfficeScreen({
   }, [agentsLoaded, didAttemptGatewayConnect, shouldPromptForConnect, status]);
 
   const showGatewayLoadingOverlay =
+    !cityViewMode &&
     !agentsLoaded &&
     (!connectPromptReady ||
       (gatewayUrl.trim().length > 0 &&
@@ -4173,6 +4176,7 @@ export function OfficeScreen({
         ((!didAttemptGatewayConnect && showDelayedGatewayLoadingOverlay) ||
           (status === "connecting" && showDelayedGatewayLoadingOverlay))));
   const showGatewayConnectOverlay =
+    !cityViewMode &&
     connectPromptReady &&
     status === "disconnected" &&
     !agentsLoaded &&

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -148,6 +148,15 @@ import {
   markServerRoomMigrationApplied,
   saveFurniture,
 } from "@/features/retro-office/core/persistence";
+import {
+  createDistrictSimulationState,
+  DISTRICT_SIM_DEFAULT_DISTRICT_COUNT,
+  DISTRICT_SIM_DEFAULT_MAX_AGENTS,
+  getDistrictSimulationNeedEmoji,
+  reconcileDistrictSimulationAgents,
+  stepDistrictSimulation,
+  type DistrictSimulationState,
+} from "@/features/retro-office/core/districtSimulation";
 import type {
   FurnitureItem,
   JanitorActor,
@@ -2290,6 +2299,8 @@ function useAgentTick(
 
 const AWAY_THRESHOLD_MS = 15 * 60 * 1000;
 const COMPACT_AGENT_BADGE_LIMIT = 6;
+const DISTRICT_SIM_STEP_MINUTES = 10;
+const DISTRICT_SIM_STEP_INTERVAL_MS = 10_000;
 
 const estimatePhoneSpeechDurationMs = (
   text: string | null | undefined,
@@ -2308,6 +2319,18 @@ const getAgentInitials = (name: string | null | undefined): string => {
     .map((part) => part[0]?.toUpperCase() ?? "")
     .join("");
 };
+
+const formatDistrictSimTime = (minuteOfDay: number): string => {
+  const normalizedMinutes = ((minuteOfDay % 1440) + 1440) % 1440;
+  const hour = Math.floor(normalizedMinutes / 60)
+    .toString()
+    .padStart(2, "0");
+  const minute = (normalizedMinutes % 60).toString().padStart(2, "0");
+  return `${hour}:${minute}`;
+};
+
+const formatDistrictCurrency = (value: number): string =>
+  `$${Math.round(value).toLocaleString("en-US")}`;
 
 export function RetroOffice3D({
   agents,
@@ -2792,6 +2815,42 @@ export function RetroOffice3D({
   );
   const [githubImmersiveReady, setGithubImmersiveReady] = useState(false);
   const [qaImmersiveReady, setQaImmersiveReady] = useState(false);
+  const [districtSimulation, setDistrictSimulation] =
+    useState<DistrictSimulationState>(() =>
+      createDistrictSimulationState({
+        agents: agents
+          .filter((agent) => !isRemoteOfficeAgentId(agent.id))
+          .map((agent) => ({ id: agent.id, name: agent.name })),
+        districtCount: DISTRICT_SIM_DEFAULT_DISTRICT_COUNT,
+        maxAgents: DISTRICT_SIM_DEFAULT_MAX_AGENTS,
+        seedKey: storageNamespace,
+      }),
+    );
+
+  useEffect(() => {
+    const simulationAgents = agents
+      .filter((agent) => !isRemoteOfficeAgentId(agent.id))
+      .map((agent) => ({ id: agent.id, name: agent.name }));
+    setDistrictSimulation((previous) =>
+      reconcileDistrictSimulationAgents(previous, {
+        agents: simulationAgents,
+        districtCount: DISTRICT_SIM_DEFAULT_DISTRICT_COUNT,
+        maxAgents: DISTRICT_SIM_DEFAULT_MAX_AGENTS,
+        seedKey: storageNamespace,
+      }),
+    );
+  }, [agents, storageNamespace]);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setDistrictSimulation((previous) =>
+        stepDistrictSimulation(previous, { minutes: DISTRICT_SIM_STEP_MINUTES }),
+      );
+    }, DISTRICT_SIM_STEP_INTERVAL_MS);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, []);
 
   useEffect(() => {
     markAtmMigrationApplied(storageNamespace);
@@ -3169,6 +3228,70 @@ export function RetroOffice3D({
     0,
     agents.length - compactRosterAgents.length,
   );
+  const districtNeedEmojiByAgentId = useMemo(
+    () =>
+      districtSimulation.agents.reduce<Record<string, string>>((acc, agent) => {
+        const emoji = getDistrictSimulationNeedEmoji(agent.needs);
+        if (emoji) acc[agent.id] = emoji;
+        return acc;
+      }, {}),
+    [districtSimulation.agents],
+  );
+  const districtSimulationSummary = useMemo(() => {
+    const districts = Array.from(
+      { length: districtSimulation.districtCount },
+      (_, index) => ({
+        id: index,
+        population: 0,
+        working: 0,
+        socializing: 0,
+      }),
+    );
+    let totalWallet = 0;
+    let totalRooms = 0;
+    for (const agent of districtSimulation.agents) {
+      const district = districts[agent.districtId] ?? districts[0];
+      if (district) {
+        district.population += 1;
+        if (agent.activity === "work") district.working += 1;
+        if (agent.activity === "socialize") district.socializing += 1;
+      }
+      totalWallet += agent.wallet;
+      totalRooms += agent.roomsOwned;
+    }
+    const relationshipValues = Object.values(districtSimulation.relationships);
+    const averageRelationship =
+      relationshipValues.length === 0
+        ? 0
+        : relationshipValues.reduce((sum, value) => sum + value, 0) /
+          relationshipValues.length;
+    const criticalNeeds = districtSimulation.agents
+      .map((agent) => {
+        const lowestNeed = Math.min(
+          agent.needs.hunger,
+          agent.needs.energy,
+          agent.needs.social,
+          agent.needs.comfort,
+        );
+        return {
+          id: agent.id,
+          name: agent.name,
+          lowestNeed,
+          emoji: getDistrictSimulationNeedEmoji(agent.needs),
+        };
+      })
+      .filter((entry) => Boolean(entry.emoji))
+      .sort((left, right) => left.lowestNeed - right.lowestNeed)
+      .slice(0, 4);
+    return {
+      districts,
+      totalWallet,
+      totalRooms,
+      averageRelationship,
+      criticalNeeds,
+      simulatedAgents: districtSimulation.agents.length,
+    };
+  }, [districtSimulation]);
   const standupActive =
     standupMeeting?.phase === "gathering" ||
     standupMeeting?.phase === "in_progress";
@@ -5997,6 +6120,7 @@ export function RetroOffice3D({
                 const working = status?.working ?? agent.status === "working";
                 const isRemoteAgent = isRemoteOfficeAgentId(agent.id);
                 const mood = moodByAgentId[agent.id];
+                const simNeedEmoji = districtNeedEmojiByAgentId[agent.id];
                 const dotClass = isError
                   ? "bg-red-400"
                   : working
@@ -6032,6 +6156,10 @@ export function RetroOffice3D({
                         }}
                       >
                         {mood.emoji}
+                      </span>
+                    ) : simNeedEmoji ? (
+                      <span className="absolute -top-6 left-1/2 -translate-x-1/2 text-sm pointer-events-none">
+                        {simNeedEmoji}
                       </span>
                     ) : null}
                     <span>{getAgentInitials(agent.name)}</span>
@@ -6199,6 +6327,114 @@ export function RetroOffice3D({
             </div>
           ) : null}
         </div>
+      ) : null}
+
+      {!immersiveOverlayActive ? (
+        <aside className="absolute top-3 right-3 z-20 w-[min(92vw,320px)] rounded-2xl border border-cyan-900/25 bg-[#10171f]/94 p-3 shadow-xl backdrop-blur-sm">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-cyan-300/70">
+                City simulation
+              </div>
+              <div className="mt-1 text-sm font-semibold text-cyan-100">
+                Day {districtSimulation.day} ·{" "}
+                {formatDistrictSimTime(districtSimulation.minuteOfDay)}
+              </div>
+            </div>
+            <span className="rounded-full border border-cyan-700/30 bg-cyan-800/20 px-2 py-1 font-mono text-[10px] text-cyan-200/80">
+              Scope A
+            </span>
+          </div>
+
+          <div className="mt-3 grid grid-cols-3 gap-2">
+            <div className="rounded-lg border border-cyan-900/25 bg-black/20 px-2 py-1.5">
+              <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-cyan-400/65">
+                Agents
+              </div>
+              <div className="text-sm font-semibold text-white">
+                {districtSimulationSummary.simulatedAgents}
+              </div>
+            </div>
+            <div className="rounded-lg border border-cyan-900/25 bg-black/20 px-2 py-1.5">
+              <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-cyan-400/65">
+                Districts
+              </div>
+              <div className="text-sm font-semibold text-white">
+                {districtSimulation.districtCount}
+              </div>
+            </div>
+            <div className="rounded-lg border border-cyan-900/25 bg-black/20 px-2 py-1.5">
+              <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-cyan-400/65">
+                Housing
+              </div>
+              <div className="text-sm font-semibold text-white">
+                {districtSimulationSummary.totalRooms} rooms
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            <div className="rounded-lg border border-cyan-900/25 bg-black/20 px-2 py-1.5">
+              <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-cyan-400/65">
+                Economy
+              </div>
+              <div className="text-sm font-semibold text-white">
+                {formatDistrictCurrency(districtSimulationSummary.totalWallet)}
+              </div>
+            </div>
+            <div className="rounded-lg border border-cyan-900/25 bg-black/20 px-2 py-1.5">
+              <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-cyan-400/65">
+                Relations
+              </div>
+              <div className="text-sm font-semibold text-white">
+                {districtSimulationSummary.averageRelationship.toFixed(1)}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-3">
+            <div className="mb-1 font-mono text-[9px] uppercase tracking-[0.16em] text-cyan-400/70">
+              District population
+            </div>
+            <div className="grid grid-cols-2 gap-1.5">
+              {districtSimulationSummary.districts.map((district) => (
+                <div
+                  key={`district-${district.id}`}
+                  className="rounded-md border border-cyan-900/20 bg-black/15 px-2 py-1"
+                >
+                  <div className="flex items-center justify-between text-[10px] text-cyan-100">
+                    <span>D{district.id + 1}</span>
+                    <span>{district.population}</span>
+                  </div>
+                  <div className="font-mono text-[9px] text-cyan-400/70">
+                    W:{district.working} · S:{district.socializing}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {districtSimulationSummary.criticalNeeds.length > 0 ? (
+            <div className="mt-3">
+              <div className="mb-1 font-mono text-[9px] uppercase tracking-[0.16em] text-cyan-400/70">
+                Needs alerts
+              </div>
+              <div className="space-y-1">
+                {districtSimulationSummary.criticalNeeds.map((entry) => (
+                  <div
+                    key={`need-${entry.id}`}
+                    className="flex items-center justify-between rounded-md border border-cyan-900/20 bg-black/15 px-2 py-1 text-[10px]"
+                  >
+                    <span className="truncate text-cyan-100">{entry.name}</span>
+                    <span className="text-cyan-200">
+                      {entry.emoji} {entry.lowestNeed.toFixed(0)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </aside>
       ) : null}
 
       {/* Idea 1: Agent tooltip — shown when hovering an agent in the 3D scene. */}

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -3229,6 +3229,7 @@ export function RetroOffice3D({
     0,
     agents.length - compactRosterAgents.length,
   );
+  const sceneTitle = cityScapeMode ? "OpenClaw City" : officeTitle;
   const districtNeedEmojiByAgentId = useMemo(
     () =>
       districtSimulation.agents.reduce<Record<string, string>>((acc, agent) => {
@@ -5471,24 +5472,25 @@ export function RetroOffice3D({
             </Suspense>
 
             {/* Furniture models — each loads its GLB asynchronously. */}
-            <Suspense fallback={null}>
-              {!editMode ? (
-                <PrimitiveInstancedWallSegmentsModel items={wallItems} />
-              ) : null}
-              {!editMode ? (
-                <InstancedFurnitureItemsModel
-                  itemType="desk_cubicle"
-                  items={deskItems}
-                  onItemClick={handleDeskClick}
-                />
-              ) : null}
-              {!editMode ? (
-                <InstancedFurnitureItemsModel
-                  itemType="chair"
-                  items={chairItems}
-                />
-              ) : null}
-              {furniture.map((item) =>
+            {!cityScapeMode ? (
+              <Suspense fallback={null}>
+                {!editMode ? (
+                  <PrimitiveInstancedWallSegmentsModel items={wallItems} />
+                ) : null}
+                {!editMode ? (
+                  <InstancedFurnitureItemsModel
+                    itemType="desk_cubicle"
+                    items={deskItems}
+                    onItemClick={handleDeskClick}
+                  />
+                ) : null}
+                {!editMode ? (
+                  <InstancedFurnitureItemsModel
+                    itemType="chair"
+                    items={chairItems}
+                  />
+                ) : null}
+                {furniture.map((item) =>
                 item.type === "wall" ? (
                   editMode ? (
                     <PrimitiveWallSegmentModel
@@ -5893,66 +5895,69 @@ export function RetroOffice3D({
                     onClick={handleDeskClick}
                   />
                 ),
-              )}
-            </Suspense>
+                )}
+              </Suspense>
+            ) : null}
 
-            {remoteLayoutFurniture.length > 0 ? (
+            {!cityScapeMode && remoteLayoutFurniture.length > 0 ? (
               <ReadOnlyFurnitureClone furniture={remoteLayoutFurniture} />
             ) : null}
 
             {/* Removed standalone Jukebox as it's now in the furniture loop */}
 
             {/* Agents — purely imperative, driven by renderAgentsRef inside useFrame. */}
-            {sceneAgents.map((agent) => {
-              const isJanitor = "role" in agent && agent.role === "janitor";
-              return (
-                <AgentObjectModel
-                  key={agent.id}
-                  agentId={agent.id}
-                  name={agent.name}
-                  subtitle={"subtitle" in agent ? agent.subtitle ?? null : null}
-                  status={agent.status}
-                  color={agentColorMap.get(agent.id) ?? "#888"}
-                  appearance={
-                    "avatarProfile" in agent
-                      ? (agent.avatarProfile ?? null)
-                      : null
-                  }
-                  agentsRef={renderAgentsRef}
-                  agentLookupRef={renderAgentLookupRef}
-                  onHover={isJanitor ? undefined : handleAgentHover}
-                  onUnhover={isJanitor ? undefined : handleAgentUnhover}
-                  onClick={isJanitor ? undefined : handleAgentClick}
-                  onContextMenu={isJanitor ? undefined : handleAgentContextMenu}
-                  showSpeech={
-                    isJanitor
-                      ? false
-                      : standupMeeting?.phase === "in_progress"
-                        ? Boolean(standupSpeechTextByAgentId[agent.id])
-                        : speechAgentIds.has(agent.id) ||
-                          Boolean(streamingTextByAgentId[agent.id])
-                  }
-                  speechText={
-                    isJanitor
-                      ? null
-                      : standupMeeting?.phase === "in_progress"
-                        ? (standupSpeechTextByAgentId[agent.id] ?? null)
-                        : (speechTextByAgentId[agent.id] ??
-                            streamingTextByAgentId[agent.id] ??
-                            null)
-                  }
-                  suppressSpeechBubble={
-                    suppressSceneSpeechBubbles &&
-                    standupMeeting?.currentSpeakerAgentId !== agent.id
-                  }
-                />
-              );
-            })}
+            {!cityScapeMode
+              ? sceneAgents.map((agent) => {
+                  const isJanitor = "role" in agent && agent.role === "janitor";
+                  return (
+                    <AgentObjectModel
+                      key={agent.id}
+                      agentId={agent.id}
+                      name={agent.name}
+                      subtitle={"subtitle" in agent ? agent.subtitle ?? null : null}
+                      status={agent.status}
+                      color={agentColorMap.get(agent.id) ?? "#888"}
+                      appearance={
+                        "avatarProfile" in agent
+                          ? (agent.avatarProfile ?? null)
+                          : null
+                      }
+                      agentsRef={renderAgentsRef}
+                      agentLookupRef={renderAgentLookupRef}
+                      onHover={isJanitor ? undefined : handleAgentHover}
+                      onUnhover={isJanitor ? undefined : handleAgentUnhover}
+                      onClick={isJanitor ? undefined : handleAgentClick}
+                      onContextMenu={isJanitor ? undefined : handleAgentContextMenu}
+                      showSpeech={
+                        isJanitor
+                          ? false
+                          : standupMeeting?.phase === "in_progress"
+                            ? Boolean(standupSpeechTextByAgentId[agent.id])
+                            : speechAgentIds.has(agent.id) ||
+                              Boolean(streamingTextByAgentId[agent.id])
+                      }
+                      speechText={
+                        isJanitor
+                          ? null
+                          : standupMeeting?.phase === "in_progress"
+                            ? (standupSpeechTextByAgentId[agent.id] ?? null)
+                            : (speechTextByAgentId[agent.id] ??
+                                streamingTextByAgentId[agent.id] ??
+                                null)
+                      }
+                      suppressSpeechBubble={
+                        suppressSceneSpeechBubbles &&
+                        standupMeeting?.currentSpeakerAgentId !== agent.id
+                      }
+                    />
+                  );
+                })
+              : null}
 
-            <ScenePingPongBall agentsRef={renderAgentsRef} />
+            {!cityScapeMode ? <ScenePingPongBall agentsRef={renderAgentsRef} /> : null}
 
             {/* New Idea 5: Agent color trails while walking. */}
-            {trailMode ? (
+            {!cityScapeMode && trailMode ? (
               <AgentTrailSystem
                 agentsRef={renderAgentsRef}
                 colorMap={agentColorMap}
@@ -5960,7 +5965,7 @@ export function RetroOffice3D({
             ) : null}
 
             {/* New Idea 7: Heatmap overlay when heatmap mode is active. */}
-            {heatmapMode ? (
+            {!cityScapeMode && heatmapMode ? (
               <AgentHeatmapSystem
                 agentsRef={renderAgentsRef}
                 heatmapMode={heatmapMode}
@@ -6103,7 +6108,7 @@ export function RetroOffice3D({
           <div className="flex items-center gap-3">
             <div className="h-px w-12 bg-gradient-to-r from-transparent to-amber-500/40" />
             <span className="text-sm tracking-[0.3em] text-amber-300/80 font-bold uppercase">
-              {officeTitle}
+              {sceneTitle}
             </span>
             <div className="h-px w-12 bg-gradient-to-l from-transparent to-amber-500/40" />
           </div>
@@ -6111,7 +6116,7 @@ export function RetroOffice3D({
       ) : null}
 
       {/* Agent roster — compact top summary with overflow panel. */}
-      {!readOnly && !immersiveOverlayActive ? (
+      {!cityScapeMode && !readOnly && !immersiveOverlayActive ? (
         <div className="absolute top-10 left-1/2 z-20 -translate-x-1/2">
           <div className="flex items-center gap-2 rounded-full border border-amber-900/25 bg-[#1c1610]/92 px-2 py-2 shadow-lg backdrop-blur-sm">
             <div className="flex items-center -space-x-1.5">

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -2709,8 +2709,9 @@ export function RetroOffice3D({
       toWorld(LOCAL_OFFICE_CANVAS_WIDTH / 2, LOCAL_OFFICE_CANVAS_HEIGHT / 2),
     [],
   );
+  const cityScapeMode = true;
   const CAM_POS = useMemo<[number, number, number]>(() => {
-    if (remoteOfficeEnabled) return DISTRICT_CAMERA_POSITION;
+    if (cityScapeMode) return DISTRICT_CAMERA_POSITION;
     return [
       LOCAL_CAMERA_TARGET[0] +
         (DISTRICT_CAMERA_POSITION[0] - DISTRICT_CAMERA_TARGET[0]),
@@ -2719,11 +2720,11 @@ export function RetroOffice3D({
       LOCAL_CAMERA_TARGET[2] +
         (DISTRICT_CAMERA_POSITION[2] - DISTRICT_CAMERA_TARGET[2]),
     ];
-  }, [LOCAL_CAMERA_TARGET, remoteOfficeEnabled]);
-  const cameraTarget = remoteOfficeEnabled
+  }, [LOCAL_CAMERA_TARGET, cityScapeMode]);
+  const cameraTarget = cityScapeMode
     ? DISTRICT_CAMERA_TARGET
     : LOCAL_CAMERA_TARGET;
-  const cameraZoom = remoteOfficeEnabled ? DISTRICT_CAMERA_ZOOM : 56;
+  const cameraZoom = cityScapeMode ? DISTRICT_CAMERA_ZOOM : 56;
   const overviewPreset = useMemo(
     () => ({ pos: CAM_POS, target: cameraTarget, zoom: cameraZoom }),
     [CAM_POS, cameraTarget, cameraZoom]
@@ -2731,12 +2732,12 @@ export function RetroOffice3D({
   const canvasResetKey = useMemo(
     () =>
       [
-        remoteOfficeEnabled ? "remote" : "local",
+        cityScapeMode ? "remote" : "local",
         gatewayStatus ?? "unknown",
         String(agents.length),
         String(officeCenterSignal),
       ].join(":"),
-    [agents.length, gatewayStatus, officeCenterSignal, remoteOfficeEnabled],
+    [agents.length, cityScapeMode, gatewayStatus, officeCenterSignal],
   );
   // New Idea 7: heatmap mode.
   const [heatmapMode, setHeatmapMode] = useState(false);
@@ -5459,10 +5460,10 @@ export function RetroOffice3D({
             />
 
             {/* Floor + walls — always visible, no async loading. */}
-            <SceneFloorAndWalls showRemoteOffice={remoteOfficeEnabled} />
+            <SceneFloorAndWalls showRemoteOffice={cityScapeMode} />
 
             {/* Wall pictures — procedural, no async loading. */}
-            <SceneWallPictures showRemoteOffice={remoteOfficeEnabled} />
+            <SceneWallPictures showRemoteOffice={cityScapeMode} />
 
             {/* Environment lighting — async, wrapped in its own Suspense so floor stays visible. */}
             <Suspense fallback={null}>

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -2704,12 +2704,13 @@ export function RetroOffice3D({
     target: [number, number, number];
     zoom?: number;
   } | null>(null);
+  const [sceneMode, setSceneMode] = useState<"city" | "office">("city");
+  const cityScapeMode = sceneMode === "city";
   const LOCAL_CAMERA_TARGET = useMemo(
     () =>
       toWorld(LOCAL_OFFICE_CANVAS_WIDTH / 2, LOCAL_OFFICE_CANVAS_HEIGHT / 2),
     [],
   );
-  const cityScapeMode = true;
   const cityCameraTarget = LOCAL_CAMERA_TARGET;
   const CAM_POS = useMemo<[number, number, number]>(() => {
     const activeTarget = cityScapeMode ? cityCameraTarget : LOCAL_CAMERA_TARGET;
@@ -2728,6 +2729,12 @@ export function RetroOffice3D({
     () => ({ pos: CAM_POS, target: cameraTarget, zoom: cameraZoom }),
     [CAM_POS, cameraTarget, cameraZoom]
   );
+  const handleEnterOfficeFromCity = useCallback(() => {
+    setSceneMode("office");
+  }, []);
+  const handleReturnToCity = useCallback(() => {
+    setSceneMode("city");
+  }, []);
   const canvasResetKey = useMemo(
     () =>
       [
@@ -5460,7 +5467,10 @@ export function RetroOffice3D({
             />
 
             {/* Floor + walls — always visible, no async loading. */}
-            <SceneFloorAndWalls showRemoteOffice={cityScapeMode} />
+            <SceneFloorAndWalls
+              showRemoteOffice={cityScapeMode}
+              onEnterHeadquarters={handleEnterOfficeFromCity}
+            />
 
             {/* Wall pictures — procedural, no async loading. */}
             <SceneWallPictures showRemoteOffice={cityScapeMode} />
@@ -7371,6 +7381,17 @@ export function RetroOffice3D({
               </button>
             </>
           )}
+        </div>
+      ) : null}
+      {!immersiveOverlayActive && !cityScapeMode ? (
+        <div className="absolute top-3 left-3 z-20">
+          <button
+            type="button"
+            onClick={handleReturnToCity}
+            className="rounded-md border border-cyan-500/35 bg-[#071018]/92 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-cyan-100 transition-colors backdrop-blur-sm hover:border-cyan-300/55 hover:text-white"
+          >
+            Back to City
+          </button>
         </div>
       ) : null}
       {!readOnly && settingsModalOpen ? (

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -2320,6 +2320,92 @@ const getAgentInitials = (name: string | null | undefined): string => {
     .join("");
 };
 
+function MiniStoreInterior() {
+  return (
+    <group>
+      <mesh position={[0, -0.01, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[2.6, 2.1]} />
+        <meshStandardMaterial color="#e7dcc6" roughness={0.96} metalness={0.02} />
+      </mesh>
+      <mesh position={[0, 0.72, -1]} castShadow receiveShadow>
+        <boxGeometry args={[2.6, 1.44, 0.08]} />
+        <meshStandardMaterial color="#9a7b66" roughness={0.84} />
+      </mesh>
+      <mesh position={[-1.26, 0.72, 0]} castShadow receiveShadow>
+        <boxGeometry args={[0.08, 1.44, 2.02]} />
+        <meshStandardMaterial color="#9a7b66" roughness={0.84} />
+      </mesh>
+      <mesh position={[1.26, 0.72, 0]} castShadow receiveShadow>
+        <boxGeometry args={[0.08, 1.44, 2.02]} />
+        <meshStandardMaterial color="#9a7b66" roughness={0.84} />
+      </mesh>
+      <mesh position={[0, 1.45, 0]} castShadow receiveShadow>
+        <boxGeometry args={[2.6, 0.08, 2.1]} />
+        <meshStandardMaterial color="#6b4f3f" roughness={0.78} />
+      </mesh>
+      <mesh position={[0.45, 0.44, 0.74]} castShadow receiveShadow>
+        <boxGeometry args={[1.1, 0.5, 0.42]} />
+        <meshStandardMaterial color="#7c5a42" roughness={0.76} />
+      </mesh>
+      {[-0.7, 0, 0.7].map((x, index) => (
+        <group key={`store-shelf-${index}`} position={[x, 0, -0.42]}>
+          <mesh position={[0, 0.56, 0]} castShadow receiveShadow>
+            <boxGeometry args={[0.42, 0.95, 0.26]} />
+            <meshStandardMaterial color="#8b735b" roughness={0.84} />
+          </mesh>
+          <mesh position={[0, 0.95, 0.01]}>
+            <boxGeometry args={[0.32, 0.12, 0.16]} />
+            <meshStandardMaterial color={["#ef4444", "#22c55e", "#3b82f6"][index] ?? "#ef4444"} roughness={0.5} />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+function MiniHouseInterior() {
+  return (
+    <group>
+      <mesh position={[0, -0.01, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[2.4, 2.2]} />
+        <meshStandardMaterial color="#dac7ae" roughness={0.98} metalness={0.01} />
+      </mesh>
+      <mesh position={[0, 0.7, -1.06]} castShadow receiveShadow>
+        <boxGeometry args={[2.4, 1.4, 0.08]} />
+        <meshStandardMaterial color="#8f7366" roughness={0.86} />
+      </mesh>
+      <mesh position={[-1.16, 0.7, 0]} castShadow receiveShadow>
+        <boxGeometry args={[0.08, 1.4, 2.12]} />
+        <meshStandardMaterial color="#8f7366" roughness={0.86} />
+      </mesh>
+      <mesh position={[1.16, 0.7, 0]} castShadow receiveShadow>
+        <boxGeometry args={[0.08, 1.4, 2.12]} />
+        <meshStandardMaterial color="#8f7366" roughness={0.86} />
+      </mesh>
+      <mesh position={[0, 1.42, 0]} castShadow receiveShadow>
+        <boxGeometry args={[2.4, 0.08, 2.2]} />
+        <meshStandardMaterial color="#5f4b40" roughness={0.82} />
+      </mesh>
+      <mesh position={[-0.48, 0.22, -0.36]} castShadow receiveShadow>
+        <boxGeometry args={[0.9, 0.22, 1.1]} />
+        <meshStandardMaterial color="#7c5b8e" roughness={0.78} />
+      </mesh>
+      <mesh position={[-0.62, 0.42, -0.66]}>
+        <boxGeometry args={[0.52, 0.16, 0.42]} />
+        <meshStandardMaterial color="#f8fafc" roughness={0.94} />
+      </mesh>
+      <mesh position={[0.54, 0.22, 0.46]} castShadow receiveShadow>
+        <boxGeometry args={[0.78, 0.28, 0.54]} />
+        <meshStandardMaterial color="#6d4c41" roughness={0.8} />
+      </mesh>
+      <mesh position={[0.02, 0.15, 0.74]} castShadow receiveShadow>
+        <boxGeometry args={[0.46, 0.18, 0.46]} />
+        <meshStandardMaterial color="#d7b98f" roughness={0.86} />
+      </mesh>
+    </group>
+  );
+}
+
 const formatDistrictSimTime = (minuteOfDay: number): string => {
   const normalizedMinutes = ((minuteOfDay % 1440) + 1440) % 1440;
   const hour = Math.floor(normalizedMinutes / 60)
@@ -2704,7 +2790,9 @@ export function RetroOffice3D({
     target: [number, number, number];
     zoom?: number;
   } | null>(null);
-  const [sceneMode, setSceneMode] = useState<"city" | "office">("city");
+  const [sceneMode, setSceneMode] = useState<"city" | "office" | "store" | "house">(
+    "city",
+  );
   const cityScapeMode = sceneMode === "city";
   const LOCAL_CAMERA_TARGET = useMemo(
     () =>
@@ -2712,8 +2800,41 @@ export function RetroOffice3D({
     [],
   );
   const cityCameraTarget = LOCAL_CAMERA_TARGET;
+  const officeInteriorAnchor = useMemo<[number, number, number]>(
+    () => [LOCAL_CAMERA_TARGET[0], 0, LOCAL_CAMERA_TARGET[2] + 0.59],
+    [LOCAL_CAMERA_TARGET],
+  );
+  const storeInteriorAnchor = useMemo<[number, number, number]>(
+    () => [LOCAL_CAMERA_TARGET[0] - 4.72, 0, LOCAL_CAMERA_TARGET[2] - 3.54],
+    [LOCAL_CAMERA_TARGET],
+  );
+  const houseInteriorAnchor = useMemo<[number, number, number]>(
+    () => [LOCAL_CAMERA_TARGET[0] + 3.54, 0, LOCAL_CAMERA_TARGET[2] + 2.36],
+    [LOCAL_CAMERA_TARGET],
+  );
+  const activeInteriorAnchor = useMemo<[number, number, number]>(() => {
+    if (sceneMode === "office") return officeInteriorAnchor;
+    if (sceneMode === "store") return storeInteriorAnchor;
+    if (sceneMode === "house") return houseInteriorAnchor;
+    return LOCAL_CAMERA_TARGET;
+  }, [
+    LOCAL_CAMERA_TARGET,
+    houseInteriorAnchor,
+    officeInteriorAnchor,
+    sceneMode,
+    storeInteriorAnchor,
+  ]);
   const CAM_POS = useMemo<[number, number, number]>(() => {
-    const activeTarget = cityScapeMode ? cityCameraTarget : LOCAL_CAMERA_TARGET;
+    const activeTarget = cityScapeMode ? cityCameraTarget : activeInteriorAnchor;
+    if (sceneMode === "office") {
+      return [activeTarget[0] + 2.9, activeTarget[1] + 4.4, activeTarget[2] + 4.2];
+    }
+    if (sceneMode === "store") {
+      return [activeTarget[0] + 1.9, activeTarget[1] + 2.8, activeTarget[2] + 2.7];
+    }
+    if (sceneMode === "house") {
+      return [activeTarget[0] + 1.8, activeTarget[1] + 2.6, activeTarget[2] + 2.5];
+    }
     return [
       activeTarget[0] +
         (DISTRICT_CAMERA_POSITION[0] - DISTRICT_CAMERA_TARGET[0]),
@@ -2722,15 +2843,22 @@ export function RetroOffice3D({
       activeTarget[2] +
         (DISTRICT_CAMERA_POSITION[2] - DISTRICT_CAMERA_TARGET[2]),
     ];
-  }, [LOCAL_CAMERA_TARGET, cityCameraTarget, cityScapeMode]);
-  const cameraTarget = cityScapeMode ? cityCameraTarget : LOCAL_CAMERA_TARGET;
-  const cameraZoom = cityScapeMode ? 44 : 56;
+  }, [activeInteriorAnchor, cityCameraTarget, cityScapeMode, sceneMode]);
+  const cameraTarget = cityScapeMode ? cityCameraTarget : activeInteriorAnchor;
+  const cameraZoom =
+    sceneMode === "city" ? 44 : sceneMode === "office" ? 108 : sceneMode === "store" ? 124 : 132;
   const overviewPreset = useMemo(
     () => ({ pos: CAM_POS, target: cameraTarget, zoom: cameraZoom }),
     [CAM_POS, cameraTarget, cameraZoom]
   );
   const handleEnterOfficeFromCity = useCallback(() => {
     setSceneMode("office");
+  }, []);
+  const handleEnterStoreFromCity = useCallback(() => {
+    setSceneMode("store");
+  }, []);
+  const handleEnterHouseFromCity = useCallback(() => {
+    setSceneMode("house");
   }, []);
   const handleReturnToCity = useCallback(() => {
     setSceneMode("city");
@@ -3225,7 +3353,14 @@ export function RetroOffice3D({
     0,
     agents.length - compactRosterAgents.length,
   );
-  const sceneTitle = cityScapeMode ? "OpenClaw City" : officeTitle;
+  const sceneTitle =
+    sceneMode === "city"
+      ? "OpenClaw City"
+      : sceneMode === "office"
+        ? officeTitle
+        : sceneMode === "store"
+          ? "Corner Store"
+          : "Townhouse";
   const districtNeedEmojiByAgentId = useMemo(
     () =>
       districtSimulation.agents.reduce<Record<string, string>>((acc, agent) => {
@@ -5456,15 +5591,24 @@ export function RetroOffice3D({
             />
 
             {/* Keep both worlds mounted; only toggle visibility to avoid renderer churn. */}
-            <group visible={cityScapeMode}>
+            <group visible>
               <SceneFloorAndWalls
                 showRemoteOffice
                 onEnterHeadquarters={handleEnterOfficeFromCity}
+                onEnterStore={handleEnterStoreFromCity}
+                onEnterHouse={handleEnterHouseFromCity}
+                activeSceneMode={sceneMode}
               />
             </group>
-            <group visible={!cityScapeMode}>
-              <SceneFloorAndWalls showRemoteOffice={false} />
-              <SceneWallPictures showRemoteOffice={false} />
+            <group
+              visible={sceneMode === "office"}
+              position={officeInteriorAnchor}
+              scale={0.16}
+            >
+              <group position={[-LOCAL_CAMERA_TARGET[0], 0, -LOCAL_CAMERA_TARGET[2]]}>
+                <SceneFloorAndWalls showRemoteOffice={false} />
+                <SceneWallPictures showRemoteOffice={false} />
+              </group>
             </group>
 
             {/* Environment lighting — async, wrapped in its own Suspense so floor stays visible. */}
@@ -5473,25 +5617,30 @@ export function RetroOffice3D({
             </Suspense>
 
             {/* Furniture models — mounted persistently, hidden in city view. */}
-            <group visible={!cityScapeMode}>
-              <Suspense fallback={null}>
-                {!editMode ? (
-                  <PrimitiveInstancedWallSegmentsModel items={wallItems} />
-                ) : null}
-                {!editMode ? (
-                  <InstancedFurnitureItemsModel
-                    itemType="desk_cubicle"
-                    items={deskItems}
-                    onItemClick={handleDeskClick}
-                  />
-                ) : null}
-                {!editMode ? (
-                  <InstancedFurnitureItemsModel
-                    itemType="chair"
-                    items={chairItems}
-                  />
-                ) : null}
-                {furniture.map((item) =>
+            <group
+              visible={sceneMode === "office"}
+              position={officeInteriorAnchor}
+              scale={0.16}
+            >
+              <group position={[-LOCAL_CAMERA_TARGET[0], 0, -LOCAL_CAMERA_TARGET[2]]}>
+                <Suspense fallback={null}>
+                  {!editMode ? (
+                    <PrimitiveInstancedWallSegmentsModel items={wallItems} />
+                  ) : null}
+                  {!editMode ? (
+                    <InstancedFurnitureItemsModel
+                      itemType="desk_cubicle"
+                      items={deskItems}
+                      onItemClick={handleDeskClick}
+                    />
+                  ) : null}
+                  {!editMode ? (
+                    <InstancedFurnitureItemsModel
+                      itemType="chair"
+                      items={chairItems}
+                    />
+                  ) : null}
+                  {furniture.map((item) =>
                 item.type === "wall" ? (
                   editMode ? (
                     <PrimitiveWallSegmentModel
@@ -5896,128 +6045,137 @@ export function RetroOffice3D({
                     onClick={handleDeskClick}
                   />
                 ),
-                )}
-              </Suspense>
+                  )}
+                </Suspense>
 
-              {remoteLayoutFurniture.length > 0 ? (
-                <ReadOnlyFurnitureClone furniture={remoteLayoutFurniture} />
-              ) : null}
+                {remoteLayoutFurniture.length > 0 ? (
+                  <ReadOnlyFurnitureClone furniture={remoteLayoutFurniture} />
+                ) : null}
 
-              {/* Removed standalone Jukebox as it's now in the furniture loop */}
+                {/* Removed standalone Jukebox as it's now in the furniture loop */}
 
-              {/* Agents — purely imperative, driven by renderAgentsRef inside useFrame. */}
-              {sceneAgents.map((agent) => {
-                  const isJanitor = "role" in agent && agent.role === "janitor";
-                  return (
-                    <AgentObjectModel
-                      key={agent.id}
-                      agentId={agent.id}
-                      name={agent.name}
-                      subtitle={"subtitle" in agent ? agent.subtitle ?? null : null}
-                      status={agent.status}
-                      color={agentColorMap.get(agent.id) ?? "#888"}
-                      appearance={
-                        "avatarProfile" in agent
-                          ? (agent.avatarProfile ?? null)
-                          : null
-                      }
-                      agentsRef={renderAgentsRef}
-                      agentLookupRef={renderAgentLookupRef}
-                      onHover={isJanitor ? undefined : handleAgentHover}
-                      onUnhover={isJanitor ? undefined : handleAgentUnhover}
-                      onClick={isJanitor ? undefined : handleAgentClick}
-                      onContextMenu={isJanitor ? undefined : handleAgentContextMenu}
-                      showSpeech={
-                        isJanitor
-                          ? false
-                          : standupMeeting?.phase === "in_progress"
-                            ? Boolean(standupSpeechTextByAgentId[agent.id])
-                            : speechAgentIds.has(agent.id) ||
-                              Boolean(streamingTextByAgentId[agent.id])
-                      }
-                      speechText={
-                        isJanitor
-                          ? null
-                          : standupMeeting?.phase === "in_progress"
-                            ? (standupSpeechTextByAgentId[agent.id] ?? null)
-                            : (speechTextByAgentId[agent.id] ??
-                                streamingTextByAgentId[agent.id] ??
-                                null)
-                      }
-                      suppressSpeechBubble={
-                        suppressSceneSpeechBubbles &&
-                        standupMeeting?.currentSpeakerAgentId !== agent.id
-                      }
-                    />
-                  );
-                })}
+                {/* Agents — purely imperative, driven by renderAgentsRef inside useFrame. */}
+                {sceneAgents.map((agent) => {
+                    const isJanitor = "role" in agent && agent.role === "janitor";
+                    return (
+                      <AgentObjectModel
+                        key={agent.id}
+                        agentId={agent.id}
+                        name={agent.name}
+                        subtitle={"subtitle" in agent ? agent.subtitle ?? null : null}
+                        status={agent.status}
+                        color={agentColorMap.get(agent.id) ?? "#888"}
+                        appearance={
+                          "avatarProfile" in agent
+                            ? (agent.avatarProfile ?? null)
+                            : null
+                        }
+                        agentsRef={renderAgentsRef}
+                        agentLookupRef={renderAgentLookupRef}
+                        onHover={isJanitor ? undefined : handleAgentHover}
+                        onUnhover={isJanitor ? undefined : handleAgentUnhover}
+                        onClick={isJanitor ? undefined : handleAgentClick}
+                        onContextMenu={isJanitor ? undefined : handleAgentContextMenu}
+                        showSpeech={
+                          isJanitor
+                            ? false
+                            : standupMeeting?.phase === "in_progress"
+                              ? Boolean(standupSpeechTextByAgentId[agent.id])
+                              : speechAgentIds.has(agent.id) ||
+                                Boolean(streamingTextByAgentId[agent.id])
+                        }
+                        speechText={
+                          isJanitor
+                            ? null
+                            : standupMeeting?.phase === "in_progress"
+                              ? (standupSpeechTextByAgentId[agent.id] ?? null)
+                              : (speechTextByAgentId[agent.id] ??
+                                  streamingTextByAgentId[agent.id] ??
+                                  null)
+                        }
+                        suppressSpeechBubble={
+                          suppressSceneSpeechBubbles &&
+                          standupMeeting?.currentSpeakerAgentId !== agent.id
+                        }
+                      />
+                    );
+                  })}
 
-              <ScenePingPongBall agentsRef={renderAgentsRef} />
+                <ScenePingPongBall agentsRef={renderAgentsRef} />
 
-              {/* New Idea 5: Agent color trails while walking. */}
-              {trailMode ? (
-                <AgentTrailSystem
-                  agentsRef={renderAgentsRef}
-                  colorMap={agentColorMap}
-                />
-              ) : null}
+                {/* New Idea 5: Agent color trails while walking. */}
+                {trailMode ? (
+                  <AgentTrailSystem
+                    agentsRef={renderAgentsRef}
+                    colorMap={agentColorMap}
+                  />
+                ) : null}
 
-              {/* New Idea 7: Heatmap overlay when heatmap mode is active. */}
-              {heatmapMode ? (
-                <AgentHeatmapSystem
-                  agentsRef={renderAgentsRef}
-                  heatmapMode={heatmapMode}
-                  heatGridRef={heatGridRef}
-                />
-              ) : null}
+                {/* New Idea 7: Heatmap overlay when heatmap mode is active. */}
+                {heatmapMode ? (
+                  <AgentHeatmapSystem
+                    agentsRef={renderAgentsRef}
+                    heatmapMode={heatmapMode}
+                    heatGridRef={heatGridRef}
+                  />
+                ) : null}
 
-              {/* Placement ghost. */}
-              {editMode &&
+                {/* Placement ghost. */}
+                {editMode &&
+                  drag.kind === "placing" &&
+                  drag.itemType !== "wall" &&
+                  ghostPos && (
+                    <Suspense fallback={null}>
+                      <FurniturePlacementGhost
+                        itemType={drag.itemType}
+                        position={ghostPos}
+                      />
+                    </Suspense>
+                  )}
+                {editMode &&
                 drag.kind === "placing" &&
-                drag.itemType !== "wall" &&
-                ghostPos && (
-                  <Suspense fallback={null}>
-                    <FurniturePlacementGhost
-                      itemType={drag.itemType}
-                      position={ghostPos}
-                    />
-                  </Suspense>
-                )}
-              {editMode &&
-              drag.kind === "placing" &&
-              drag.itemType === "wall" &&
-              wallGhostItem ? (
-                <PrimitiveWallSegmentModel
-                  item={wallGhostItem}
-                  isSelected={false}
-                  isHovered={false}
-                  editMode={false}
-                  onPointerDown={() => {}}
-                  onPointerOver={() => {}}
-                  onPointerOut={() => {}}
-                />
-              ) : null}
-              {editMode &&
-              drag.kind === "placing" &&
-              drag.itemType === "door" &&
-              ghostPos ? (
-                <PrimitiveDoorModel
-                  item={{
-                    _uid: "__door_ghost__",
-                    type: "door",
-                    x: worldToCanvas(ghostPos[0], ghostPos[2]).cx,
-                    y: worldToCanvas(ghostPos[0], ghostPos[2]).cy,
-                    w: DOOR_LENGTH,
-                    h: DOOR_THICKNESS,
-                  }}
-                  isSelected={false}
-                  isHovered={false}
-                  editMode={false}
-                  onPointerDown={() => {}}
-                  onPointerOver={() => {}}
-                  onPointerOut={() => {}}
-                />
-              ) : null}
+                drag.itemType === "wall" &&
+                wallGhostItem ? (
+                  <PrimitiveWallSegmentModel
+                    item={wallGhostItem}
+                    isSelected={false}
+                    isHovered={false}
+                    editMode={false}
+                    onPointerDown={() => {}}
+                    onPointerOver={() => {}}
+                    onPointerOut={() => {}}
+                  />
+                ) : null}
+                {editMode &&
+                drag.kind === "placing" &&
+                drag.itemType === "door" &&
+                ghostPos ? (
+                  <PrimitiveDoorModel
+                    item={{
+                      _uid: "__door_ghost__",
+                      type: "door",
+                      x: worldToCanvas(ghostPos[0], ghostPos[2]).cx,
+                      y: worldToCanvas(ghostPos[0], ghostPos[2]).cy,
+                      w: DOOR_LENGTH,
+                      h: DOOR_THICKNESS,
+                    }}
+                    isSelected={false}
+                    isHovered={false}
+                    editMode={false}
+                    onPointerDown={() => {}}
+                    onPointerOver={() => {}}
+                    onPointerOut={() => {}}
+                  />
+                ) : null}
+              </group>
+            </group>
+
+            <group visible={sceneMode === "store"} position={storeInteriorAnchor}>
+              <MiniStoreInterior />
+            </group>
+
+            <group visible={sceneMode === "house"} position={houseInteriorAnchor}>
+              <MiniHouseInterior />
             </group>
 
             {/* Floor raycaster for edit-mode interaction. */}
@@ -6115,7 +6273,7 @@ export function RetroOffice3D({
       ) : null}
 
       {/* Agent roster — compact top summary with overflow panel. */}
-      {!cityScapeMode && !readOnly && !immersiveOverlayActive ? (
+      {sceneMode === "office" && !readOnly && !immersiveOverlayActive ? (
         <div className="absolute top-10 left-1/2 z-20 -translate-x-1/2">
           <div className="flex items-center gap-2 rounded-full border border-amber-900/25 bg-[#1c1610]/92 px-2 py-2 shadow-lg backdrop-blur-sm">
             <div className="flex items-center -space-x-1.5">
@@ -7281,10 +7439,34 @@ export function RetroOffice3D({
               Enter office
             </div>
           </button>
+          <button
+            type="button"
+            onClick={handleEnterStoreFromCity}
+            className="rounded-xl border border-fuchsia-400/30 bg-[#1b0a1b]/92 px-4 py-2 text-left shadow-lg backdrop-blur-sm transition-colors hover:border-fuchsia-300/50 hover:bg-[#251027]"
+          >
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-fuchsia-300/80">
+              Corner Store
+            </div>
+            <div className="mt-1 text-sm font-semibold text-white">
+              Enter store
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={handleEnterHouseFromCity}
+            className="rounded-xl border border-violet-400/30 bg-[#140d24]/92 px-4 py-2 text-left shadow-lg backdrop-blur-sm transition-colors hover:border-violet-300/50 hover:bg-[#1b1230]"
+          >
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-violet-300/80">
+              Townhouse
+            </div>
+            <div className="mt-1 text-sm font-semibold text-white">
+              Enter house
+            </div>
+          </button>
         </div>
       ) : null}
 
-      {!readOnly && !immersiveOverlayActive && !cityScapeMode ? (
+      {!readOnly && !immersiveOverlayActive && sceneMode !== "city" ? (
         <div className="absolute top-14 left-3 z-20 flex flex-col items-start gap-2">
           <button
             type="button"
@@ -7405,17 +7587,6 @@ export function RetroOffice3D({
               </button>
             </>
           )}
-        </div>
-      ) : null}
-      {!immersiveOverlayActive && !cityScapeMode ? (
-        <div className="absolute top-3 left-3 z-20">
-          <button
-            type="button"
-            onClick={handleReturnToCity}
-            className="rounded-md border border-cyan-500/35 bg-[#071018]/92 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-cyan-100 transition-colors backdrop-blur-sm hover:border-cyan-300/55 hover:text-white"
-          >
-            Back to City
-          </button>
         </div>
       ) : null}
       {!readOnly && settingsModalOpen ? (

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -2710,21 +2710,20 @@ export function RetroOffice3D({
     [],
   );
   const cityScapeMode = true;
+  const cityCameraTarget = LOCAL_CAMERA_TARGET;
   const CAM_POS = useMemo<[number, number, number]>(() => {
-    if (cityScapeMode) return DISTRICT_CAMERA_POSITION;
+    const activeTarget = cityScapeMode ? cityCameraTarget : LOCAL_CAMERA_TARGET;
     return [
-      LOCAL_CAMERA_TARGET[0] +
+      activeTarget[0] +
         (DISTRICT_CAMERA_POSITION[0] - DISTRICT_CAMERA_TARGET[0]),
-      LOCAL_CAMERA_TARGET[1] +
+      activeTarget[1] +
         (DISTRICT_CAMERA_POSITION[1] - DISTRICT_CAMERA_TARGET[1]),
-      LOCAL_CAMERA_TARGET[2] +
+      activeTarget[2] +
         (DISTRICT_CAMERA_POSITION[2] - DISTRICT_CAMERA_TARGET[2]),
     ];
-  }, [LOCAL_CAMERA_TARGET, cityScapeMode]);
-  const cameraTarget = cityScapeMode
-    ? DISTRICT_CAMERA_TARGET
-    : LOCAL_CAMERA_TARGET;
-  const cameraZoom = cityScapeMode ? DISTRICT_CAMERA_ZOOM : 56;
+  }, [LOCAL_CAMERA_TARGET, cityCameraTarget, cityScapeMode]);
+  const cameraTarget = cityScapeMode ? cityCameraTarget : LOCAL_CAMERA_TARGET;
+  const cameraZoom = cityScapeMode ? 44 : 56;
   const overviewPreset = useMemo(
     () => ({ pos: CAM_POS, target: cameraTarget, zoom: cameraZoom }),
     [CAM_POS, cameraTarget, cameraZoom]

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -2735,16 +2735,6 @@ export function RetroOffice3D({
   const handleReturnToCity = useCallback(() => {
     setSceneMode("city");
   }, []);
-  const canvasResetKey = useMemo(
-    () =>
-      [
-        cityScapeMode ? "remote" : "local",
-        gatewayStatus ?? "unknown",
-        String(agents.length),
-        String(officeCenterSignal),
-      ].join(":"),
-    [agents.length, cityScapeMode, gatewayStatus, officeCenterSignal],
-  );
   // New Idea 7: heatmap mode.
   const [heatmapMode, setHeatmapMode] = useState(false);
   const [trailMode, setTrailMode] = useState(false);
@@ -5385,7 +5375,6 @@ export function RetroOffice3D({
         */}
         {!immersiveOverlayActive ? (
           <Canvas
-            key={canvasResetKey}
             orthographic
             dpr={[0.85, 1.5]}
             camera={{
@@ -5466,22 +5455,25 @@ export function RetroOffice3D({
               color="#7090ff"
             />
 
-            {/* Floor + walls — always visible, no async loading. */}
-            <SceneFloorAndWalls
-              showRemoteOffice={cityScapeMode}
-              onEnterHeadquarters={handleEnterOfficeFromCity}
-            />
-
-            {/* Wall pictures — procedural, no async loading. */}
-            <SceneWallPictures showRemoteOffice={cityScapeMode} />
+            {/* Keep both worlds mounted; only toggle visibility to avoid renderer churn. */}
+            <group visible={cityScapeMode}>
+              <SceneFloorAndWalls
+                showRemoteOffice
+                onEnterHeadquarters={handleEnterOfficeFromCity}
+              />
+            </group>
+            <group visible={!cityScapeMode}>
+              <SceneFloorAndWalls showRemoteOffice={false} />
+              <SceneWallPictures showRemoteOffice={false} />
+            </group>
 
             {/* Environment lighting — async, wrapped in its own Suspense so floor stays visible. */}
             <Suspense fallback={null}>
               <Environment preset="city" />
             </Suspense>
 
-            {/* Furniture models — each loads its GLB asynchronously. */}
-            {!cityScapeMode ? (
+            {/* Furniture models — mounted persistently, hidden in city view. */}
+            <group visible={!cityScapeMode}>
               <Suspense fallback={null}>
                 {!editMode ? (
                   <PrimitiveInstancedWallSegmentsModel items={wallItems} />
@@ -5906,17 +5898,15 @@ export function RetroOffice3D({
                 ),
                 )}
               </Suspense>
-            ) : null}
 
-            {!cityScapeMode && remoteLayoutFurniture.length > 0 ? (
-              <ReadOnlyFurnitureClone furniture={remoteLayoutFurniture} />
-            ) : null}
+              {remoteLayoutFurniture.length > 0 ? (
+                <ReadOnlyFurnitureClone furniture={remoteLayoutFurniture} />
+              ) : null}
 
-            {/* Removed standalone Jukebox as it's now in the furniture loop */}
+              {/* Removed standalone Jukebox as it's now in the furniture loop */}
 
-            {/* Agents — purely imperative, driven by renderAgentsRef inside useFrame. */}
-            {!cityScapeMode
-              ? sceneAgents.map((agent) => {
+              {/* Agents — purely imperative, driven by renderAgentsRef inside useFrame. */}
+              {sceneAgents.map((agent) => {
                   const isJanitor = "role" in agent && agent.role === "janitor";
                   return (
                     <AgentObjectModel
@@ -5960,75 +5950,75 @@ export function RetroOffice3D({
                       }
                     />
                   );
-                })
-              : null}
+                })}
 
-            {!cityScapeMode ? <ScenePingPongBall agentsRef={renderAgentsRef} /> : null}
+              <ScenePingPongBall agentsRef={renderAgentsRef} />
 
-            {/* New Idea 5: Agent color trails while walking. */}
-            {!cityScapeMode && trailMode ? (
-              <AgentTrailSystem
-                agentsRef={renderAgentsRef}
-                colorMap={agentColorMap}
-              />
-            ) : null}
+              {/* New Idea 5: Agent color trails while walking. */}
+              {trailMode ? (
+                <AgentTrailSystem
+                  agentsRef={renderAgentsRef}
+                  colorMap={agentColorMap}
+                />
+              ) : null}
 
-            {/* New Idea 7: Heatmap overlay when heatmap mode is active. */}
-            {!cityScapeMode && heatmapMode ? (
-              <AgentHeatmapSystem
-                agentsRef={renderAgentsRef}
-                heatmapMode={heatmapMode}
-                heatGridRef={heatGridRef}
-              />
-            ) : null}
+              {/* New Idea 7: Heatmap overlay when heatmap mode is active. */}
+              {heatmapMode ? (
+                <AgentHeatmapSystem
+                  agentsRef={renderAgentsRef}
+                  heatmapMode={heatmapMode}
+                  heatGridRef={heatGridRef}
+                />
+              ) : null}
 
-            {/* Placement ghost. */}
-            {editMode &&
+              {/* Placement ghost. */}
+              {editMode &&
+                drag.kind === "placing" &&
+                drag.itemType !== "wall" &&
+                ghostPos && (
+                  <Suspense fallback={null}>
+                    <FurniturePlacementGhost
+                      itemType={drag.itemType}
+                      position={ghostPos}
+                    />
+                  </Suspense>
+                )}
+              {editMode &&
               drag.kind === "placing" &&
-              drag.itemType !== "wall" &&
-              ghostPos && (
-                <Suspense fallback={null}>
-                  <FurniturePlacementGhost
-                    itemType={drag.itemType}
-                    position={ghostPos}
-                  />
-                </Suspense>
-              )}
-            {editMode &&
-            drag.kind === "placing" &&
-            drag.itemType === "wall" &&
-            wallGhostItem ? (
-              <PrimitiveWallSegmentModel
-                item={wallGhostItem}
-                isSelected={false}
-                isHovered={false}
-                editMode={false}
-                onPointerDown={() => {}}
-                onPointerOver={() => {}}
-                onPointerOut={() => {}}
-              />
-            ) : null}
-            {editMode &&
-            drag.kind === "placing" &&
-            drag.itemType === "door" &&
-            ghostPos ? (
-              <PrimitiveDoorModel
-                item={{
-                  _uid: "__door_ghost__",
-                  type: "door",
-                  x: worldToCanvas(ghostPos[0], ghostPos[2]).cx,
-                  y: worldToCanvas(ghostPos[0], ghostPos[2]).cy,
-                  w: DOOR_LENGTH,
-                  h: DOOR_THICKNESS,
-                }}
-                isSelected={false}
-                isHovered={false}
-                editMode={false}
-                onPointerDown={() => {}}
-                onPointerOver={() => {}}
-                onPointerOut={() => {}}
-              />
-            ) : null}
+              drag.itemType === "wall" &&
+              wallGhostItem ? (
+                <PrimitiveWallSegmentModel
+                  item={wallGhostItem}
+                  isSelected={false}
+                  isHovered={false}
+                  editMode={false}
+                  onPointerDown={() => {}}
+                  onPointerOver={() => {}}
+                  onPointerOut={() => {}}
+                />
+              ) : null}
+              {editMode &&
+              drag.kind === "placing" &&
+              drag.itemType === "door" &&
+              ghostPos ? (
+                <PrimitiveDoorModel
+                  item={{
+                    _uid: "__door_ghost__",
+                    type: "door",
+                    x: worldToCanvas(ghostPos[0], ghostPos[2]).cx,
+                    y: worldToCanvas(ghostPos[0], ghostPos[2]).cy,
+                    w: DOOR_LENGTH,
+                    h: DOOR_THICKNESS,
+                  }}
+                  isSelected={false}
+                  isHovered={false}
+                  editMode={false}
+                  onPointerDown={() => {}}
+                  onPointerOver={() => {}}
+                  onPointerOut={() => {}}
+                />
+              ) : null}
+            </group>
 
             {/* Floor raycaster for edit-mode interaction. */}
             <SceneFloorRaycaster
@@ -7276,6 +7266,40 @@ export function RetroOffice3D({
           </div>
         </div>
       )}
+
+      {!readOnly && !immersiveOverlayActive && cityScapeMode ? (
+        <div className="absolute top-14 left-3 z-20 flex flex-col items-start gap-2">
+          <button
+            type="button"
+            onClick={handleEnterOfficeFromCity}
+            className="rounded-xl border border-emerald-400/30 bg-[#071b12]/92 px-4 py-2 text-left shadow-lg backdrop-blur-sm transition-colors hover:border-emerald-300/50 hover:bg-[#0b2418]"
+          >
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-300/80">
+              Headquarters
+            </div>
+            <div className="mt-1 text-sm font-semibold text-white">
+              Enter office
+            </div>
+          </button>
+        </div>
+      ) : null}
+
+      {!readOnly && !immersiveOverlayActive && !cityScapeMode ? (
+        <div className="absolute top-14 left-3 z-20 flex flex-col items-start gap-2">
+          <button
+            type="button"
+            onClick={handleReturnToCity}
+            className="rounded-xl border border-cyan-400/30 bg-[#09131b]/92 px-4 py-2 text-left shadow-lg backdrop-blur-sm transition-colors hover:border-cyan-300/50 hover:bg-[#0d1c26]"
+          >
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-cyan-300/80">
+              City View
+            </div>
+            <div className="mt-1 text-sm font-semibold text-white">
+              Back to City
+            </div>
+          </button>
+        </div>
+      ) : null}
 
       {/* Toolbar — top right. */}
       {!readOnly && !immersiveOverlayActive ? (

--- a/src/features/retro-office/core/districtSimulation.ts
+++ b/src/features/retro-office/core/districtSimulation.ts
@@ -1,0 +1,389 @@
+import type { OfficeAgent } from "@/features/retro-office/core/types";
+
+export const DISTRICT_SIM_DEFAULT_DISTRICT_COUNT = 10;
+export const DISTRICT_SIM_DEFAULT_MAX_AGENTS = 10;
+
+export type DistrictSimulationNeeds = {
+  hunger: number;
+  energy: number;
+  social: number;
+  comfort: number;
+};
+
+export type DistrictSimulationActivity =
+  | "work"
+  | "sleep"
+  | "socialize"
+  | "eat"
+  | "idle";
+
+export type DistrictSimulationAgent = {
+  id: string;
+  name: string;
+  districtId: number;
+  homeDistrictId: number;
+  workDistrictId: number;
+  roomsOwned: number;
+  wallet: number;
+  needs: DistrictSimulationNeeds;
+  activity: DistrictSimulationActivity;
+  workStartHour: number;
+  workEndHour: number;
+  lastRentDay: number;
+};
+
+export type DistrictSimulationState = {
+  day: number;
+  minuteOfDay: number;
+  districtCount: number;
+  maxAgents: number;
+  agents: DistrictSimulationAgent[];
+  relationships: Record<string, number>;
+  seed: number;
+};
+
+type DistrictSimulationSeed = Pick<OfficeAgent, "id" | "name">;
+
+type DistrictSimulationCreateInput = {
+  agents: DistrictSimulationSeed[];
+  districtCount?: number;
+  maxAgents?: number;
+  seedKey?: string;
+};
+
+type DistrictSimulationReconcileInput = {
+  agents: DistrictSimulationSeed[];
+  districtCount?: number;
+  maxAgents?: number;
+  seedKey?: string;
+};
+
+type DistrictSimulationStepInput = {
+  minutes?: number;
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+const clampNeed = (value: number) => clamp(value, 0, 100);
+
+const normalizeDistrictCount = (districtCount?: number) =>
+  Math.max(1, Math.floor(districtCount ?? DISTRICT_SIM_DEFAULT_DISTRICT_COUNT));
+
+const normalizeMaxAgents = (maxAgents?: number) =>
+  Math.max(1, Math.floor(maxAgents ?? DISTRICT_SIM_DEFAULT_MAX_AGENTS));
+
+const hashSeed = (value: string): number => {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0);
+};
+
+const relationshipKey = (leftId: string, rightId: string) =>
+  leftId < rightId ? `${leftId}::${rightId}` : `${rightId}::${leftId}`;
+
+const withRelationshipPairs = (
+  relationships: Record<string, number>,
+  agentIds: string[],
+): Record<string, number> => {
+  const next: Record<string, number> = {};
+  const validAgentIds = new Set(agentIds);
+  for (const [key, value] of Object.entries(relationships)) {
+    const [leftId, rightId] = key.split("::");
+    if (!leftId || !rightId) continue;
+    if (!validAgentIds.has(leftId) || !validAgentIds.has(rightId)) continue;
+    next[key] = value;
+  }
+  for (let i = 0; i < agentIds.length; i += 1) {
+    for (let j = i + 1; j < agentIds.length; j += 1) {
+      const leftId = agentIds[i];
+      const rightId = agentIds[j];
+      if (!leftId || !rightId) continue;
+      const key = relationshipKey(leftId, rightId);
+      if (next[key] === undefined) next[key] = 0;
+    }
+  }
+  return next;
+};
+
+const seedAgent = (
+  agent: DistrictSimulationSeed,
+  districtCount: number,
+  seed: number,
+): DistrictSimulationAgent => {
+  const localSeed = hashSeed(`${seed}:${agent.id}:${agent.name}`);
+  const homeDistrictId = localSeed % districtCount;
+  const workDistrictId = (homeDistrictId + 1 + (localSeed % 3)) % districtCount;
+  const workStartHour = 8 + (localSeed % 2);
+  const workEndHour = workStartHour + 8;
+  const roomsOwned = 1 + (localSeed % 3);
+  const wallet = 320 + (localSeed % 220);
+  const needs: DistrictSimulationNeeds = {
+    hunger: 65 + (localSeed % 30),
+    energy: 60 + ((localSeed >> 3) % 30),
+    social: 55 + ((localSeed >> 5) % 35),
+    comfort: 58 + ((localSeed >> 7) % 30),
+  };
+  return {
+    id: agent.id,
+    name: agent.name,
+    districtId: homeDistrictId,
+    homeDistrictId,
+    workDistrictId,
+    roomsOwned,
+    wallet,
+    needs: {
+      hunger: clampNeed(needs.hunger),
+      energy: clampNeed(needs.energy),
+      social: clampNeed(needs.social),
+      comfort: clampNeed(needs.comfort),
+    },
+    activity: "idle",
+    workStartHour,
+    workEndHour,
+    lastRentDay: 0,
+  };
+};
+
+const resolveActivity = (
+  agent: DistrictSimulationAgent,
+  hourOfDay: number,
+): DistrictSimulationActivity => {
+  const inWorkHours =
+    hourOfDay >= agent.workStartHour && hourOfDay < agent.workEndHour;
+  if (agent.needs.energy < 22) return "sleep";
+  if (agent.needs.hunger < 35) return "eat";
+  if (inWorkHours && agent.needs.energy > 30 && agent.needs.hunger > 30) return "work";
+  if (agent.needs.social < 45) return "socialize";
+  if (agent.needs.comfort < 35) return "idle";
+  return inWorkHours ? "work" : "idle";
+};
+
+const applyNeedDelta = (
+  needs: DistrictSimulationNeeds,
+  activity: DistrictSimulationActivity,
+  minutes: number,
+): DistrictSimulationNeeds => {
+  if (activity === "work") {
+    return {
+      hunger: clampNeed(needs.hunger - minutes * 0.35),
+      energy: clampNeed(needs.energy - minutes * 0.42),
+      social: clampNeed(needs.social - minutes * 0.2),
+      comfort: clampNeed(needs.comfort - minutes * 0.16),
+    };
+  }
+  if (activity === "sleep") {
+    return {
+      hunger: clampNeed(needs.hunger - minutes * 0.18),
+      energy: clampNeed(needs.energy + minutes * 0.9),
+      social: clampNeed(needs.social - minutes * 0.05),
+      comfort: clampNeed(needs.comfort + minutes * 0.24),
+    };
+  }
+  if (activity === "eat") {
+    return {
+      hunger: clampNeed(needs.hunger + minutes * 1.08),
+      energy: clampNeed(needs.energy + minutes * 0.12),
+      social: clampNeed(needs.social + minutes * 0.06),
+      comfort: clampNeed(needs.comfort + minutes * 0.08),
+    };
+  }
+  if (activity === "socialize") {
+    return {
+      hunger: clampNeed(needs.hunger - minutes * 0.14),
+      energy: clampNeed(needs.energy - minutes * 0.16),
+      social: clampNeed(needs.social + minutes * 0.82),
+      comfort: clampNeed(needs.comfort + minutes * 0.12),
+    };
+  }
+  return {
+    hunger: clampNeed(needs.hunger - minutes * 0.08),
+    energy: clampNeed(needs.energy + minutes * 0.06),
+    social: clampNeed(needs.social - minutes * 0.04),
+    comfort: clampNeed(needs.comfort + minutes * 0.2),
+  };
+};
+
+const applyWalletDelta = (
+  agent: DistrictSimulationAgent,
+  activity: DistrictSimulationActivity,
+  minutes: number,
+): number => {
+  let wallet = agent.wallet;
+  if (activity === "work") wallet += minutes * 1.75;
+  if (activity === "eat") wallet -= minutes * 0.34;
+  if (activity === "socialize") wallet -= minutes * 0.12;
+  return wallet;
+};
+
+const applyRentCharge = (
+  agent: DistrictSimulationAgent,
+  nextDay: number,
+): DistrictSimulationAgent => {
+  if (nextDay <= agent.lastRentDay) return agent;
+  const dayDelta = nextDay - agent.lastRentDay;
+  const rentCost = dayDelta * agent.roomsOwned * 38;
+  return {
+    ...agent,
+    wallet: agent.wallet - rentCost,
+    lastRentDay: nextDay,
+  };
+};
+
+export const createDistrictSimulationState = ({
+  agents,
+  districtCount,
+  maxAgents,
+  seedKey = "default",
+}: DistrictSimulationCreateInput): DistrictSimulationState => {
+  const resolvedDistrictCount = normalizeDistrictCount(districtCount);
+  const resolvedMaxAgents = normalizeMaxAgents(maxAgents);
+  const seed = hashSeed(`${seedKey}:${resolvedDistrictCount}:${resolvedMaxAgents}`);
+  const seededAgents = agents
+    .slice(0, resolvedMaxAgents)
+    .map((agent) => seedAgent(agent, resolvedDistrictCount, seed));
+  const relationships = withRelationshipPairs(
+    {},
+    seededAgents.map((agent) => agent.id),
+  );
+  return {
+    day: 1,
+    minuteOfDay: 9 * 60,
+    districtCount: resolvedDistrictCount,
+    maxAgents: resolvedMaxAgents,
+    agents: seededAgents,
+    relationships,
+    seed,
+  };
+};
+
+export const reconcileDistrictSimulationAgents = (
+  state: DistrictSimulationState,
+  {
+    agents,
+    districtCount,
+    maxAgents,
+    seedKey = "default",
+  }: DistrictSimulationReconcileInput,
+): DistrictSimulationState => {
+  const resolvedDistrictCount = normalizeDistrictCount(districtCount);
+  const resolvedMaxAgents = normalizeMaxAgents(maxAgents);
+  const shouldReseed =
+    resolvedDistrictCount !== state.districtCount ||
+    resolvedMaxAgents !== state.maxAgents ||
+    hashSeed(`${seedKey}:${resolvedDistrictCount}:${resolvedMaxAgents}`) !== state.seed;
+  if (shouldReseed) {
+    return createDistrictSimulationState({
+      agents,
+      districtCount: resolvedDistrictCount,
+      maxAgents: resolvedMaxAgents,
+      seedKey,
+    });
+  }
+
+  const nextSeeds = agents.slice(0, resolvedMaxAgents);
+  const existingById = new Map(state.agents.map((agent) => [agent.id, agent]));
+  const nextAgents = nextSeeds.map((seedAgentEntry) => {
+    const existing = existingById.get(seedAgentEntry.id);
+    if (existing) return existing;
+    return seedAgent(seedAgentEntry, state.districtCount, state.seed);
+  });
+
+  const relationships = withRelationshipPairs(
+    state.relationships,
+    nextAgents.map((agent) => agent.id),
+  );
+  return {
+    ...state,
+    agents: nextAgents,
+    relationships,
+  };
+};
+
+export const stepDistrictSimulation = (
+  state: DistrictSimulationState,
+  { minutes = 10 }: DistrictSimulationStepInput = {},
+): DistrictSimulationState => {
+  const resolvedMinutes = clamp(Math.floor(minutes), 1, 240);
+  const totalMinutes = state.minuteOfDay + resolvedMinutes;
+  const dayDelta = Math.floor(totalMinutes / (24 * 60));
+  const nextDay = state.day + dayDelta;
+  const minuteOfDay = totalMinutes % (24 * 60);
+  const hourOfDay = minuteOfDay / 60;
+
+  const steppedAgents = state.agents.map((agent) => {
+    const withRent = dayDelta > 0 ? applyRentCharge(agent, nextDay) : agent;
+    const activity = resolveActivity(withRent, hourOfDay);
+    const districtId =
+      activity === "work"
+        ? withRent.workDistrictId
+        : activity === "socialize"
+          ? (withRent.homeDistrictId + 2) % state.districtCount
+          : withRent.homeDistrictId;
+    const needs = applyNeedDelta(withRent.needs, activity, resolvedMinutes);
+    let wallet = applyWalletDelta(withRent, activity, resolvedMinutes);
+    if (wallet < 0) {
+      needs.comfort = clampNeed(needs.comfort - resolvedMinutes * 0.28);
+    }
+    wallet = Number(wallet.toFixed(2));
+    return {
+      ...withRent,
+      districtId,
+      activity,
+      wallet,
+      needs,
+    };
+  });
+
+  const relationships = { ...state.relationships };
+  for (let i = 0; i < steppedAgents.length; i += 1) {
+    for (let j = i + 1; j < steppedAgents.length; j += 1) {
+      const left = steppedAgents[i];
+      const right = steppedAgents[j];
+      if (!left || !right) continue;
+      const key = relationshipKey(left.id, right.id);
+      const currentScore = relationships[key] ?? 0;
+      const sameDistrict = left.districtId === right.districtId;
+      const socialBoost =
+        left.activity === "socialize" || right.activity === "socialize";
+      const delta = sameDistrict
+        ? socialBoost
+          ? resolvedMinutes * 0.28
+          : resolvedMinutes * 0.08
+        : -resolvedMinutes * 0.05;
+      relationships[key] = Number(clamp(currentScore + delta, -100, 100).toFixed(2));
+    }
+  }
+
+  return {
+    ...state,
+    day: nextDay,
+    minuteOfDay,
+    agents: steppedAgents,
+    relationships,
+  };
+};
+
+export const getDistrictSimulationRelationship = (
+  state: DistrictSimulationState,
+  leftId: string,
+  rightId: string,
+): number => state.relationships[relationshipKey(leftId, rightId)] ?? 0;
+
+export const getDistrictSimulationNeedEmoji = (
+  needs: DistrictSimulationNeeds,
+): string | null => {
+  const entries = Object.entries(needs) as Array<
+    [keyof DistrictSimulationNeeds, number]
+  >;
+  entries.sort((left, right) => left[1] - right[1]);
+  const [lowestNeed, value] = entries[0] ?? ["comfort", 100];
+  if (value >= 55) return null;
+  if (lowestNeed === "hunger") return "🍔";
+  if (lowestNeed === "energy") return "😴";
+  if (lowestNeed === "social") return "💬";
+  return "🛋️";
+};

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -593,11 +593,11 @@ export const FloorAndWalls = memo(function FloorAndWalls({
       ) : null}
 
       {[
-        { x: 120, y: -95, width: 1.7, depth: 1.55, height: 2.35, body: "#374151", accent: "#111827", window: "#c4b5fd" },
-        { x: 430, y: -110, width: 1.58, depth: 1.42, height: 2.1, body: "#4b5563", accent: "#1f2937", window: "#bfdbfe" },
-        { x: 880, y: -120, width: 2.2, depth: 1.8, height: 3.25, body: "#334155", accent: "#0f172a", window: "#fde68a" },
-        { x: 1340, y: -108, width: 1.62, depth: 1.48, height: 2.2, body: "#475569", accent: "#1e293b", window: "#93c5fd" },
-        { x: 1670, y: -92, width: 1.74, depth: 1.52, height: 2.55, body: "#3f3f46", accent: "#18181b", window: "#e9d5ff" },
+        { x: 120, y: -35, width: 1.7, depth: 1.55, height: 2.35, body: "#374151", accent: "#111827", window: "#c4b5fd" },
+        { x: 430, y: -46, width: 1.58, depth: 1.42, height: 2.1, body: "#4b5563", accent: "#1f2937", window: "#bfdbfe" },
+        { x: 880, y: -54, width: 2.2, depth: 1.8, height: 3.25, body: "#334155", accent: "#0f172a", window: "#fde68a" },
+        { x: 1340, y: -42, width: 1.62, depth: 1.48, height: 2.2, body: "#475569", accent: "#1e293b", window: "#93c5fd" },
+        { x: 1670, y: -28, width: 1.74, depth: 1.52, height: 2.55, body: "#3f3f46", accent: "#18181b", window: "#e9d5ff" },
       ].map((tower) => {
         const [wx, , wz] = toWorld(tower.x, tower.y);
         return (
@@ -615,10 +615,10 @@ export const FloorAndWalls = memo(function FloorAndWalls({
       })}
 
       {[
-        { x: 260, y: LOCAL_OFFICE_CANVAS_HEIGHT + 40, width: 1.35, depth: 0.98, height: 1.05, body: "#e5c9a8", roof: "#7b5e57", door: "#5d4037", window: "#fef3c7" },
-        { x: 540, y: LOCAL_OFFICE_CANVAS_HEIGHT + 46, width: 1.42, depth: 1.02, height: 1.12, body: "#c4d7b2", roof: "#5f7a61", door: "#39503d", window: "#dcfce7" },
-        { x: 1320, y: LOCAL_OFFICE_CANVAS_HEIGHT + 44, width: 1.4, depth: 1, height: 1.1, body: "#cdb4db", roof: "#6b4f85", door: "#433255", window: "#e9d5ff" },
-        { x: 1580, y: LOCAL_OFFICE_CANVAS_HEIGHT + 40, width: 1.32, depth: 0.96, height: 1.04, body: "#c6d8ef", roof: "#4b5d73", door: "#314152", window: "#dbeafe" },
+        { x: 260, y: LOCAL_OFFICE_CANVAS_HEIGHT + 18, width: 1.35, depth: 0.98, height: 1.05, body: "#e5c9a8", roof: "#7b5e57", door: "#5d4037", window: "#fef3c7" },
+        { x: 540, y: LOCAL_OFFICE_CANVAS_HEIGHT + 20, width: 1.42, depth: 1.02, height: 1.12, body: "#c4d7b2", roof: "#5f7a61", door: "#39503d", window: "#dcfce7" },
+        { x: 1320, y: LOCAL_OFFICE_CANVAS_HEIGHT + 20, width: 1.4, depth: 1, height: 1.1, body: "#cdb4db", roof: "#6b4f85", door: "#433255", window: "#e9d5ff" },
+        { x: 1580, y: LOCAL_OFFICE_CANVAS_HEIGHT + 18, width: 1.32, depth: 0.96, height: 1.04, body: "#c6d8ef", roof: "#4b5d73", door: "#314152", window: "#dbeafe" },
       ].map((house) => {
         const [wx, , wz] = toWorld(house.x, house.y);
         return (
@@ -633,6 +633,82 @@ export const FloorAndWalls = memo(function FloorAndWalls({
             roofColor={house.roof}
             doorColor={house.door}
             windowColor={house.window}
+          />
+        );
+      })}
+
+      {[
+        { x: 220, y: 22, width: 1.55, depth: 0.82, height: 1.08, body: "#7c2d12", awning: "#fb7185", trim: "#fecdd3", window: "#fff7c2" },
+        { x: 520, y: 26, width: 1.7, depth: 0.86, height: 1.14, body: "#334155", awning: "#38bdf8", trim: "#dbeafe", window: "#bfdbfe" },
+        { x: 1280, y: 24, width: 1.62, depth: 0.84, height: 1.1, body: "#3f3f46", awning: "#22c55e", trim: "#dcfce7", window: "#d1fae5" },
+        { x: 1560, y: 20, width: 1.5, depth: 0.8, height: 1.04, body: "#6d4c41", awning: "#f59e0b", trim: "#fde68a", window: "#fef3c7" },
+      ].map((store) => {
+        const [wx, , wz] = toWorld(store.x, store.y);
+        return (
+          <StorefrontBlock
+            key={`north-storefront-${store.x}-${store.y}`}
+            position={[wx, 0, wz]}
+            width={store.width}
+            depth={store.depth}
+            height={store.height}
+            bodyColor={store.body}
+            awningColor={store.awning}
+            trimColor={store.trim}
+            windowColor={store.window}
+          />
+        );
+      })}
+
+      {([
+        { kind: "tower", x: 54, z: -6.2, width: 1.4, depth: 1.28, height: 2.2, body: "#334155", accent: "#0f172a", window: "#93c5fd" },
+        { kind: "store", x: 48, z: -2.6, width: 1.18, depth: 0.76, height: 1.02, body: "#7c2d12", awning: "#f97316", trim: "#fde68a", window: "#fef3c7" },
+        { kind: "house", x: 47.8, z: 2.8, width: 1.02, depth: 0.96, height: 0.98, body: "#d8c3a5", roof: "#8d6e63", door: "#5d4037", window: "#fff7c2" },
+        { kind: "tower", x: -6.4, z: -6.25, width: 1.32, depth: 1.24, height: 2.06, body: "#475569", accent: "#1e293b", window: "#c4b5fd" },
+        { kind: "store", x: -2.2, z: -6.05, width: 1.08, depth: 0.8, height: 1.0, body: "#374151", awning: "#38bdf8", trim: "#dbeafe", window: "#bfdbfe" },
+        { kind: "house", x: 2.4, z: -6.15, width: 1.0, depth: 0.94, height: 0.94, body: "#c4d7b2", roof: "#5f7a61", door: "#39503d", window: "#dcfce7" },
+      ] as const).map((building) => {
+        if (building.kind === "store") {
+          return (
+            <StorefrontBlock
+              key={`perimeter-store-${building.x}-${building.z}`}
+              position={[building.x, 0, building.z]}
+              rotationY={building.x > 0 ? -Math.PI / 2 : Math.PI / 2}
+              width={building.width}
+              depth={building.depth}
+              height={building.height}
+              bodyColor={building.body}
+              awningColor={building.awning}
+              trimColor={building.trim}
+              windowColor={building.window}
+            />
+          );
+        }
+        if (building.kind === "house") {
+          return (
+            <TownhouseBlock
+              key={`perimeter-house-${building.x}-${building.z}`}
+              position={[building.x, 0, building.z]}
+              rotationY={building.z < 0 ? Math.PI : -Math.PI / 2}
+              width={building.width}
+              depth={building.depth}
+              height={building.height}
+              bodyColor={building.body}
+              roofColor={building.roof}
+              doorColor={building.door}
+              windowColor={building.window}
+            />
+          );
+        }
+        return (
+          <TowerBlock
+            key={`perimeter-tower-${building.x}-${building.z}`}
+            position={[building.x, 0, building.z]}
+            width={building.width}
+            depth={building.depth}
+            height={building.height}
+            bodyColor={building.body}
+            accentColor={building.accent}
+            windowColor={building.window}
           />
         );
       })}

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -335,6 +335,77 @@ function TownhouseBlock({
   );
 }
 
+function StreetTree({
+  position,
+  canopyColor = "#3f9142",
+}: {
+  position: [number, number, number];
+  canopyColor?: string;
+}) {
+  return (
+    <group position={position}>
+      <mesh position={[0, 0.22, 0]} castShadow>
+        <cylinderGeometry args={[0.045, 0.055, 0.44, 10]} />
+        <meshStandardMaterial color="#6d4c41" roughness={0.82} metalness={0.08} />
+      </mesh>
+      <mesh position={[0, 0.6, 0]} castShadow>
+        <sphereGeometry args={[0.18, 12, 12]} />
+        <meshStandardMaterial color={canopyColor} roughness={0.9} metalness={0.02} />
+      </mesh>
+      <mesh position={[0.11, 0.54, 0.05]} castShadow>
+        <sphereGeometry args={[0.12, 10, 10]} />
+        <meshStandardMaterial color={canopyColor} roughness={0.9} metalness={0.02} />
+      </mesh>
+      <mesh position={[-0.1, 0.55, -0.06]} castShadow>
+        <sphereGeometry args={[0.11, 10, 10]} />
+        <meshStandardMaterial color={canopyColor} roughness={0.9} metalness={0.02} />
+      </mesh>
+    </group>
+  );
+}
+
+function CompactCar({
+  position,
+  rotationY = 0,
+  bodyColor,
+}: {
+  position: [number, number, number];
+  rotationY?: number;
+  bodyColor: string;
+}) {
+  return (
+    <group position={position} rotation={[0, rotationY, 0]}>
+      <mesh position={[0, 0.12, 0]} castShadow receiveShadow>
+        <boxGeometry args={[0.4, 0.14, 0.22]} />
+        <meshStandardMaterial color={bodyColor} roughness={0.52} metalness={0.28} />
+      </mesh>
+      <mesh position={[0.02, 0.2, 0]} castShadow>
+        <boxGeometry args={[0.24, 0.11, 0.2]} />
+        <meshStandardMaterial color={bodyColor} roughness={0.48} metalness={0.34} />
+      </mesh>
+      <mesh position={[0.07, 0.21, 0.112]}>
+        <planeGeometry args={[0.12, 0.07]} />
+        <meshBasicMaterial color="#c8e6ff" />
+      </mesh>
+      <mesh position={[0.07, 0.21, -0.112]} rotation={[0, Math.PI, 0]}>
+        <planeGeometry args={[0.12, 0.07]} />
+        <meshBasicMaterial color="#c8e6ff" />
+      </mesh>
+      {[
+        [-0.14, 0.05, 0.11],
+        [0.14, 0.05, 0.11],
+        [-0.14, 0.05, -0.11],
+        [0.14, 0.05, -0.11],
+      ].map(([x, y, z], index) => (
+        <mesh key={`car-wheel-${index}`} position={[x, y, z]} rotation={[Math.PI / 2, 0, 0]} castShadow>
+          <cylinderGeometry args={[0.04, 0.04, 0.03, 10]} />
+          <meshStandardMaterial color="#121212" roughness={0.86} metalness={0.08} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
 export const FloorAndWalls = memo(function FloorAndWalls({
   showRemoteOffice = true,
 }: {
@@ -379,6 +450,16 @@ export const FloorAndWalls = memo(function FloorAndWalls({
   const localSouthWallZ = localOfficeCenterZ + localOfficeHeight / 2;
   const localWestWallX = localOfficeCenterX - localOfficeWidth / 2;
   const localEastWallX = localOfficeCenterX + localOfficeWidth / 2;
+  const cityRoadOffset = 1.04;
+  const cityRoadWidth = 0.8;
+  const cityRoadSpanX = localOfficeWidth + 4.6;
+  const cityRoadSpanZ = localOfficeHeight + 4.6;
+  const northRoadZ = localNorthWallZ - cityRoadOffset;
+  const southRoadZ = localSouthWallZ + cityRoadOffset;
+  const westRoadX = localWestWallX - cityRoadOffset;
+  const eastRoadX = localEastWallX + cityRoadOffset;
+  const parkDepth = 1.95;
+  const parkWidth = 2.2;
   const groundCenterX = showRemoteOffice ? districtCenterX : localOfficeCenterX;
   const groundCenterZ = showRemoteOffice ? districtCenterZ : localOfficeCenterZ;
   const groundWidth = showRemoteOffice ? districtWidth : localOfficeWidth;
@@ -712,6 +793,108 @@ export const FloorAndWalls = memo(function FloorAndWalls({
           />
         );
       })}
+
+      <mesh position={[localOfficeCenterX, 0.003, northRoadZ]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[cityRoadSpanX, cityRoadWidth]} />
+        <meshStandardMaterial color="#4b5563" roughness={0.95} metalness={0.06} />
+      </mesh>
+      <mesh position={[localOfficeCenterX, 0.003, southRoadZ]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[cityRoadSpanX, cityRoadWidth]} />
+        <meshStandardMaterial color="#4b5563" roughness={0.95} metalness={0.06} />
+      </mesh>
+      <mesh position={[westRoadX, 0.003, localOfficeCenterZ]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[cityRoadWidth, cityRoadSpanZ]} />
+        <meshStandardMaterial color="#4b5563" roughness={0.95} metalness={0.06} />
+      </mesh>
+      <mesh position={[eastRoadX, 0.003, localOfficeCenterZ]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[cityRoadWidth, cityRoadSpanZ]} />
+        <meshStandardMaterial color="#4b5563" roughness={0.95} metalness={0.06} />
+      </mesh>
+
+      {Array.from({ length: 12 }).map((_, index) => {
+        const x = localOfficeCenterX - cityRoadSpanX / 2 + 0.55 + index * 0.78;
+        return (
+          <group key={`north-lane-dashes-${index}`}>
+            <mesh position={[x, 0.008, northRoadZ]} rotation={[-Math.PI / 2, 0, 0]}>
+              <planeGeometry args={[0.34, 0.045]} />
+              <meshBasicMaterial color="#f8fafc" transparent opacity={0.85} />
+            </mesh>
+            <mesh position={[x, 0.008, southRoadZ]} rotation={[-Math.PI / 2, 0, 0]}>
+              <planeGeometry args={[0.34, 0.045]} />
+              <meshBasicMaterial color="#f8fafc" transparent opacity={0.85} />
+            </mesh>
+          </group>
+        );
+      })}
+
+      {Array.from({ length: 10 }).map((_, index) => {
+        const z = localOfficeCenterZ - cityRoadSpanZ / 2 + 0.58 + index * 0.84;
+        return (
+          <group key={`side-lane-dashes-${index}`}>
+            <mesh position={[westRoadX, 0.008, z]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+              <planeGeometry args={[0.34, 0.045]} />
+              <meshBasicMaterial color="#f8fafc" transparent opacity={0.85} />
+            </mesh>
+            <mesh position={[eastRoadX, 0.008, z]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+              <planeGeometry args={[0.34, 0.045]} />
+              <meshBasicMaterial color="#f8fafc" transparent opacity={0.85} />
+            </mesh>
+          </group>
+        );
+      })}
+
+      {[
+        [westRoadX - 0.75, 0, northRoadZ - 0.72],
+        [eastRoadX + 0.75, 0, northRoadZ - 0.72],
+        [westRoadX - 0.75, 0, southRoadZ + 0.72],
+        [eastRoadX + 0.75, 0, southRoadZ + 0.72],
+      ].map(([x, y, z], index) => (
+        <group key={`park-plot-${index}`} position={[x, y, z]}>
+          <mesh position={[0, 0.002, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+            <planeGeometry args={[parkWidth, parkDepth]} />
+            <meshStandardMaterial color="#4b7f41" roughness={0.98} metalness={0.01} />
+          </mesh>
+          <mesh position={[0, 0.03, 0]} castShadow receiveShadow>
+            <boxGeometry args={[parkWidth + 0.1, 0.06, parkDepth + 0.1]} />
+            <meshStandardMaterial color="#3f2f1f" roughness={0.9} metalness={0.08} />
+          </mesh>
+        </group>
+      ))}
+
+      {[
+        [westRoadX - 1.18, 0, northRoadZ - 0.95],
+        [westRoadX - 0.22, 0, northRoadZ - 0.4],
+        [eastRoadX + 0.22, 0, northRoadZ - 0.48],
+        [eastRoadX + 1.14, 0, northRoadZ - 0.93],
+        [westRoadX - 1.12, 0, southRoadZ + 0.95],
+        [westRoadX - 0.22, 0, southRoadZ + 0.44],
+        [eastRoadX + 0.24, 0, southRoadZ + 0.46],
+        [eastRoadX + 1.15, 0, southRoadZ + 0.9],
+      ].map(([x, y, z], index) => (
+        <StreetTree
+          key={`street-tree-${index}`}
+          position={[x, y, z]}
+          canopyColor={index % 2 === 0 ? "#3f9142" : "#4ea34a"}
+        />
+      ))}
+
+      {[
+        [localOfficeCenterX - 2.2, 0, northRoadZ + 0.05, 0, "#e53935"],
+        [localOfficeCenterX + 1.1, 0, northRoadZ - 0.06, 0, "#1d4ed8"],
+        [localOfficeCenterX - 1.4, 0, southRoadZ + 0.08, Math.PI, "#f59e0b"],
+        [localOfficeCenterX + 2.35, 0, southRoadZ - 0.05, Math.PI, "#16a34a"],
+        [westRoadX + 0.02, 0, localOfficeCenterZ - 1.7, -Math.PI / 2, "#8b5cf6"],
+        [westRoadX - 0.03, 0, localOfficeCenterZ + 1.6, -Math.PI / 2, "#ef4444"],
+        [eastRoadX - 0.02, 0, localOfficeCenterZ - 1.2, Math.PI / 2, "#0284c7"],
+        [eastRoadX + 0.03, 0, localOfficeCenterZ + 1.95, Math.PI / 2, "#f97316"],
+      ].map(([x, y, z, rotationY, bodyColor], index) => (
+        <CompactCar
+          key={`city-car-${index}`}
+          position={[x as number, y as number, z as number]}
+          rotationY={rotationY as number}
+          bodyColor={bodyColor as string}
+        />
+      ))}
 
       {gymZoneFloorWidth > 0 && roomZoneFloorHeight > 0 ? (
         <>

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -555,6 +555,248 @@ function CityTrafficLayer({
   );
 }
 
+function FactoryBlock({
+  position,
+  width,
+  depth,
+  height,
+  bodyColor,
+  roofColor,
+  chimneyColor,
+}: {
+  position: [number, number, number];
+  width: number;
+  depth: number;
+  height: number;
+  bodyColor: string;
+  roofColor: string;
+  chimneyColor: string;
+}) {
+  return (
+    <group position={position}>
+      <mesh position={[0, height / 2, 0]} castShadow receiveShadow>
+        <boxGeometry args={[width, height, depth]} />
+        <meshStandardMaterial color={bodyColor} roughness={0.86} metalness={0.08} />
+      </mesh>
+      <mesh position={[0, height + 0.03, 0]} castShadow>
+        <boxGeometry args={[width * 0.92, 0.06, depth * 0.92]} />
+        <meshStandardMaterial color={roofColor} roughness={0.78} metalness={0.12} />
+      </mesh>
+      {[-width * 0.22, 0, width * 0.22].map((offsetX, index) => (
+        <mesh key={`factory-chimney-${index}`} position={[offsetX, height + 0.18, -depth * 0.18]} castShadow>
+          <cylinderGeometry args={[0.06, 0.07, 0.34 + index * 0.07, 10]} />
+          <meshStandardMaterial color={chimneyColor} roughness={0.72} metalness={0.18} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function RoadTile({
+  position,
+  size,
+  mask,
+}: {
+  position: [number, number, number];
+  size: number;
+  mask: RoadMask;
+}) {
+  const roadWidth = size * 0.72;
+  const laneWidth = size * 0.06;
+  return (
+    <group position={position}>
+      <mesh position={[0, 0.001, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[size, size]} />
+        <meshStandardMaterial color="#5c8f47" roughness={0.98} metalness={0.01} />
+      </mesh>
+      <mesh position={[0, 0.004, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[roadWidth, roadWidth]} />
+        <meshStandardMaterial color="#3f4650" roughness={0.95} metalness={0.08} />
+      </mesh>
+      {mask.north || mask.south ? (
+        <mesh position={[0, 0.005, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[laneWidth, size * 0.88]} />
+          <meshBasicMaterial color="#f8fafc" transparent opacity={0.95} />
+        </mesh>
+      ) : null}
+      {mask.east || mask.west ? (
+        <mesh position={[0, 0.005, 0]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+          <planeGeometry args={[laneWidth, size * 0.88]} />
+          <meshBasicMaterial color="#f8fafc" transparent opacity={0.95} />
+        </mesh>
+      ) : null}
+      {mask.north ? (
+        <mesh position={[0, 0.0045, -size * 0.36]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[roadWidth, size * 0.3]} />
+          <meshStandardMaterial color="#3f4650" roughness={0.95} metalness={0.08} />
+        </mesh>
+      ) : null}
+      {mask.south ? (
+        <mesh position={[0, 0.0045, size * 0.36]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[roadWidth, size * 0.3]} />
+          <meshStandardMaterial color="#3f4650" roughness={0.95} metalness={0.08} />
+        </mesh>
+      ) : null}
+      {mask.west ? (
+        <mesh position={[-size * 0.36, 0.0045, 0]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+          <planeGeometry args={[roadWidth, size * 0.3]} />
+          <meshStandardMaterial color="#3f4650" roughness={0.95} metalness={0.08} />
+        </mesh>
+      ) : null}
+      {mask.east ? (
+        <mesh position={[size * 0.36, 0.0045, 0]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}>
+          <planeGeometry args={[roadWidth, size * 0.3]} />
+          <meshStandardMaterial color="#3f4650" roughness={0.95} metalness={0.08} />
+        </mesh>
+      ) : null}
+    </group>
+  );
+}
+
+function FullCityScene({ centerX, centerZ }: { centerX: number; centerZ: number }) {
+  const cityGrid = useMemo(() => buildCityGrid(), []);
+  const baseOffsetX = centerX - ((CITY_GRID_COLUMNS - 1) * CITY_GRID_CELL_SIZE) / 2;
+  const baseOffsetZ = centerZ - ((CITY_GRID_ROWS - 1) * CITY_GRID_CELL_SIZE) / 2;
+  const cityWidth = CITY_GRID_COLUMNS * CITY_GRID_CELL_SIZE;
+  const cityDepth = CITY_GRID_ROWS * CITY_GRID_CELL_SIZE;
+  const hqPosition: [number, number, number] = [centerX, 0, centerZ + CITY_GRID_CELL_SIZE * 0.5];
+  const trafficNorthZ = baseOffsetZ + 2 * CITY_GRID_CELL_SIZE;
+  const trafficSouthZ = baseOffsetZ + 5 * CITY_GRID_CELL_SIZE;
+  const trafficWestX = baseOffsetX + 2 * CITY_GRID_CELL_SIZE;
+  const trafficEastX = baseOffsetX + 7 * CITY_GRID_CELL_SIZE;
+  return (
+    <group>
+      <mesh position={[centerX, -0.02, centerZ]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[cityWidth + 3.2, cityDepth + 3.2]} />
+        <meshStandardMaterial color="#66a04a" roughness={0.99} metalness={0.01} />
+      </mesh>
+      {cityGrid.map((cell) => {
+        const x = baseOffsetX + cell.gx * CITY_GRID_CELL_SIZE;
+        const z = baseOffsetZ + cell.gz * CITY_GRID_CELL_SIZE;
+        if (cell.road) {
+          return (
+            <RoadTile
+              key={`full-city-road-${cell.gx}-${cell.gz}`}
+              position={[x, 0, z]}
+              size={CITY_GRID_CELL_SIZE}
+              mask={cell.mask}
+            />
+          );
+        }
+        const lotPosition: [number, number, number] = [x, 0, z];
+        if ((cell.gx + cell.gz) % 7 === 0) {
+          return (
+            <group key={`full-city-park-${cell.gx}-${cell.gz}`} position={lotPosition}>
+              <mesh position={[0, 0.001, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+                <planeGeometry args={[CITY_GRID_CELL_SIZE * 0.9, CITY_GRID_CELL_SIZE * 0.9]} />
+                <meshStandardMaterial color="#5d994a" roughness={0.98} metalness={0.01} />
+              </mesh>
+              <StreetTree position={[-0.24, 0, -0.18]} canopyColor="#3f9142" />
+              <StreetTree position={[0.18, 0, 0.12]} canopyColor="#4ea34a" />
+            </group>
+          );
+        }
+        if (cell.zone === "residential") {
+          return (
+            <TownhouseBlock
+              key={`full-city-res-${cell.gx}-${cell.gz}`}
+              position={lotPosition}
+              rotationY={(cell.gx + cell.gz) % 2 === 0 ? 0 : Math.PI / 2}
+              width={0.72}
+              depth={0.72}
+              height={0.78 + ((cell.gx + cell.gz) % 3) * 0.12}
+              bodyColor={["#d8c3a5", "#cbb6d9", "#c6d8ef", "#c4d7b2"][(cell.gx + cell.gz) % 4] ?? "#d8c3a5"}
+              roofColor={["#8d6e63", "#6b4f85", "#4b5d73", "#5f7a61"][(cell.gx + cell.gz) % 4] ?? "#8d6e63"}
+              doorColor="#473225"
+              windowColor="#f8f3c2"
+            />
+          );
+        }
+        if (cell.zone === "commercial") {
+          const isTower = cell.gz <= 1 && cell.gx % 3 === 0;
+          return isTower ? (
+            <TowerBlock
+              key={`full-city-com-tower-${cell.gx}-${cell.gz}`}
+              position={lotPosition}
+              width={0.84}
+              depth={0.84}
+              height={2.5 + (cell.gx % 2) * 0.9}
+              bodyColor="#e5e7eb"
+              accentColor="#9ca3af"
+              windowColor="#111827"
+            />
+          ) : (
+            <StorefrontBlock
+              key={`full-city-com-store-${cell.gx}-${cell.gz}`}
+              position={lotPosition}
+              rotationY={cell.gz % 2 === 0 ? 0 : Math.PI / 2}
+              width={0.86}
+              depth={0.74}
+              height={0.9 + (cell.gx % 3) * 0.12}
+              bodyColor={["#facc15", "#d6b48a", "#f3f4f6", "#f59e0b"][(cell.gx + cell.gz) % 4] ?? "#d6b48a"}
+              awningColor={["#ef4444", "#2563eb", "#22c55e", "#8b5cf6"][(cell.gx + cell.gz) % 4] ?? "#ef4444"}
+              trimColor="#f8fafc"
+              windowColor="#dbeafe"
+            />
+          );
+        }
+        return (
+          <FactoryBlock
+            key={`full-city-ind-${cell.gx}-${cell.gz}`}
+            position={lotPosition}
+            width={0.92}
+            depth={0.84}
+            height={0.72 + (cell.gx % 2) * 0.14}
+            bodyColor="#8b5e3c"
+            roofColor="#3f3f46"
+            chimneyColor="#9ca3af"
+          />
+        );
+      })}
+      <group position={hqPosition}>
+        <TowerBlock
+          position={[-0.52, 0, -0.26]}
+          width={0.9}
+          depth={0.9}
+          height={3.6}
+          bodyColor="#f3f4f6"
+          accentColor="#9ca3af"
+          windowColor="#0f172a"
+        />
+        <TowerBlock
+          position={[0.56, 0, 0.24]}
+          width={0.9}
+          depth={0.9}
+          height={3.1}
+          bodyColor="#f3f4f6"
+          accentColor="#9ca3af"
+          windowColor="#0f172a"
+        />
+        <StorefrontBlock
+          position={[0, 0, 0.92]}
+          width={1.3}
+          depth={0.78}
+          height={0.95}
+          bodyColor="#334155"
+          awningColor="#22c55e"
+          trimColor="#dcfce7"
+          windowColor="#bfdbfe"
+        />
+      </group>
+      <CityTrafficLayer
+        cityRoadSpanX={CITY_GRID_CELL_SIZE * CITY_GRID_COLUMNS * 0.82}
+        cityRoadSpanZ={CITY_GRID_CELL_SIZE * CITY_GRID_ROWS * 0.82}
+        localOfficeCenterX={centerX}
+        localOfficeCenterZ={centerZ}
+        northRoadZ={trafficNorthZ}
+        southRoadZ={trafficSouthZ}
+        westRoadX={trafficWestX}
+        eastRoadX={trafficEastX}
+      />
+    </group>
+  );
+}
+
 type ZoneKind = "residential" | "commercial" | "industrial";
 type RoadMask = {
   north: boolean;
@@ -675,6 +917,10 @@ export const FloorAndWalls = memo(function FloorAndWalls({
   const groundCenterZ = showRemoteOffice ? districtCenterZ : localOfficeCenterZ;
   const groundWidth = showRemoteOffice ? districtWidth : localOfficeWidth;
   const groundHeight = showRemoteOffice ? districtHeight : localOfficeHeight;
+
+  if (showRemoteOffice) {
+    return <FullCityScene centerX={localOfficeCenterX} centerZ={localOfficeCenterZ} />;
+  }
 
   return (
     <group>
@@ -1433,6 +1679,7 @@ export const WallPictures = memo(function WallPictures({
 }: {
   showRemoteOffice?: boolean;
 }) {
+  if (showRemoteOffice) return null;
   const localWidth = LOCAL_OFFICE_CANVAS_WIDTH * SCALE;
   const localHeight = LOCAL_OFFICE_CANVAS_HEIGHT * SCALE;
   const [localCenterX, , localCenterZ] = toWorld(

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo, useRef, type ReactNode } from "react";
+import { memo, useMemo, useRef, useState, type ReactNode } from "react";
 import { useFrame } from "@react-three/fiber";
 import type * as THREE from "three";
 import {
@@ -653,8 +653,17 @@ function RoadTile({
   );
 }
 
-function FullCityScene({ centerX, centerZ }: { centerX: number; centerZ: number }) {
+function FullCityScene({
+  centerX,
+  centerZ,
+  onEnterHeadquarters,
+}: {
+  centerX: number;
+  centerZ: number;
+  onEnterHeadquarters?: () => void;
+}) {
   const cityGrid = useMemo(() => buildCityGrid(), []);
+  const [hqHovered, setHqHovered] = useState(false);
   const baseOffsetX = centerX - ((CITY_GRID_COLUMNS - 1) * CITY_GRID_CELL_SIZE) / 2;
   const baseOffsetZ = centerZ - ((CITY_GRID_ROWS - 1) * CITY_GRID_CELL_SIZE) / 2;
   const cityWidth = CITY_GRID_COLUMNS * CITY_GRID_CELL_SIZE;
@@ -753,7 +762,29 @@ function FullCityScene({ centerX, centerZ }: { centerX: number; centerZ: number 
           />
         );
       })}
-      <group position={hqPosition}>
+      <group
+        position={hqPosition}
+        onPointerOver={(event) => {
+          event.stopPropagation();
+          setHqHovered(true);
+        }}
+        onPointerOut={(event) => {
+          event.stopPropagation();
+          setHqHovered(false);
+        }}
+        onClick={(event) => {
+          event.stopPropagation();
+          onEnterHeadquarters?.();
+        }}
+      >
+        <mesh position={[0, 0.01, 0.18]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[3.2, 2.8]} />
+          <meshBasicMaterial
+            color={hqHovered ? "#fde68a" : "#bbf7d0"}
+            transparent
+            opacity={hqHovered ? 0.24 : 0.14}
+          />
+        </mesh>
         <TowerBlock
           position={[-0.52, 0, -0.26]}
           width={0.9}
@@ -782,6 +813,22 @@ function FullCityScene({ centerX, centerZ }: { centerX: number; centerZ: number 
           trimColor="#dcfce7"
           windowColor="#bfdbfe"
         />
+        <mesh position={[0, 0.02, -1.02]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[1.85, 0.34]} />
+          <meshBasicMaterial
+            color={hqHovered ? "#fef08a" : "#e0f2fe"}
+            transparent
+            opacity={0.92}
+          />
+        </mesh>
+        <mesh position={[0, 0.03, -1.02]}>
+          <planeGeometry args={[1.7, 0.18]} />
+          <meshBasicMaterial color="#0f172a" transparent opacity={0.98} />
+        </mesh>
+        <mesh position={[0, 0.04, -1.02]}>
+          <planeGeometry args={[1.58, 0.12]} />
+          <meshBasicMaterial color={hqHovered ? "#fef08a" : "#f8fafc"} transparent opacity={1} />
+        </mesh>
       </group>
       <CityTrafficLayer
         cityRoadSpanX={CITY_GRID_CELL_SIZE * CITY_GRID_COLUMNS * 0.82}
@@ -861,8 +908,10 @@ const buildCityGrid = (): CityGridCell[] => {
 
 export const FloorAndWalls = memo(function FloorAndWalls({
   showRemoteOffice = true,
+  onEnterHeadquarters,
 }: {
   showRemoteOffice?: boolean;
+  onEnterHeadquarters?: () => void;
 }) {
   const districtWidth = CANVAS_W * SCALE;
   const districtHeight = CANVAS_H * SCALE;
@@ -919,7 +968,13 @@ export const FloorAndWalls = memo(function FloorAndWalls({
   const groundHeight = showRemoteOffice ? districtHeight : localOfficeHeight;
 
   if (showRemoteOffice) {
-    return <FullCityScene centerX={localOfficeCenterX} centerZ={localOfficeCenterZ} />;
+    return (
+      <FullCityScene
+        centerX={localOfficeCenterX}
+        centerZ={localOfficeCenterZ}
+        onEnterHeadquarters={onEnterHeadquarters}
+      />
+    );
   }
 
   return (

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { memo, type ReactNode } from "react";
+import { memo, useMemo, useRef, type ReactNode } from "react";
+import { useFrame } from "@react-three/fiber";
+import type * as THREE from "three";
 import {
   CANVAS_H,
   CANVAS_W,
@@ -368,13 +370,15 @@ function CompactCar({
   position,
   rotationY = 0,
   bodyColor,
+  scale = 1,
 }: {
   position: [number, number, number];
   rotationY?: number;
   bodyColor: string;
+  scale?: number;
 }) {
   return (
-    <group position={position} rotation={[0, rotationY, 0]}>
+    <group position={position} rotation={[0, rotationY, 0]} scale={[scale, scale, scale]}>
       <mesh position={[0, 0.12, 0]} castShadow receiveShadow>
         <boxGeometry args={[0.4, 0.14, 0.22]} />
         <meshStandardMaterial color={bodyColor} roughness={0.52} metalness={0.28} />
@@ -405,6 +409,213 @@ function CompactCar({
     </group>
   );
 }
+
+function MovingCompactCar({
+  route,
+  speed = 0.16,
+  phase = 0,
+  bodyColor,
+}: {
+  route: Array<[number, number, number]>;
+  speed?: number;
+  phase?: number;
+  bodyColor: string;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+  const segmentLengths = useMemo(() => {
+    if (route.length < 2) return [];
+    const lengths: number[] = [];
+    for (let index = 0; index < route.length - 1; index += 1) {
+      const [x1, , z1] = route[index] ?? [0, 0, 0];
+      const [x2, , z2] = route[index + 1] ?? [0, 0, 0];
+      lengths.push(Math.hypot(x2 - x1, z2 - z1));
+    }
+    return lengths;
+  }, [route]);
+  const totalLength = useMemo(
+    () => segmentLengths.reduce((sum, value) => sum + value, 0),
+    [segmentLengths],
+  );
+  useFrame((state) => {
+    if (!groupRef.current) return;
+    if (route.length < 2 || totalLength <= 0) return;
+    const elapsed = state.clock.getElapsedTime();
+    const startDistance =
+      (((elapsed + phase) * speed) % totalLength + totalLength) % totalLength;
+    let remaining = startDistance;
+    let segmentIndex = 0;
+    while (
+      segmentIndex < segmentLengths.length - 1 &&
+      remaining > (segmentLengths[segmentIndex] ?? 0)
+    ) {
+      remaining -= segmentLengths[segmentIndex] ?? 0;
+      segmentIndex += 1;
+    }
+    const currentLength = Math.max(0.0001, segmentLengths[segmentIndex] ?? 0.0001);
+    const t = remaining / currentLength;
+    const start = route[segmentIndex] ?? route[0];
+    const end = route[segmentIndex + 1] ?? route[route.length - 1];
+    const x = (start?.[0] ?? 0) + ((end?.[0] ?? 0) - (start?.[0] ?? 0)) * t;
+    const z = (start?.[2] ?? 0) + ((end?.[2] ?? 0) - (start?.[2] ?? 0)) * t;
+    const heading = Math.atan2(
+      (end?.[2] ?? 0) - (start?.[2] ?? 0),
+      (end?.[0] ?? 0) - (start?.[0] ?? 0),
+    );
+    groupRef.current.position.set(x, 0, z);
+    groupRef.current.rotation.set(0, -heading, 0);
+  });
+  if (route.length < 2 || totalLength <= 0) return null;
+  return (
+    <group ref={groupRef}>
+      <CompactCar position={[0, 0, 0]} rotationY={0} bodyColor={bodyColor} />
+    </group>
+  );
+}
+
+function CityTrafficLayer({
+  cityRoadSpanX,
+  cityRoadSpanZ,
+  localOfficeCenterX,
+  localOfficeCenterZ,
+  northRoadZ,
+  southRoadZ,
+  westRoadX,
+  eastRoadX,
+}: {
+  cityRoadSpanX: number;
+  cityRoadSpanZ: number;
+  localOfficeCenterX: number;
+  localOfficeCenterZ: number;
+  northRoadZ: number;
+  southRoadZ: number;
+  westRoadX: number;
+  eastRoadX: number;
+}) {
+  const outerLoopRoute = useMemo(
+    () =>
+      [
+        [localOfficeCenterX - cityRoadSpanX * 0.45, 0, northRoadZ],
+        [localOfficeCenterX + cityRoadSpanX * 0.45, 0, northRoadZ],
+        [eastRoadX, 0, localOfficeCenterZ + cityRoadSpanZ * 0.45],
+        [localOfficeCenterX - cityRoadSpanX * 0.45, 0, southRoadZ],
+        [westRoadX, 0, localOfficeCenterZ - cityRoadSpanZ * 0.45],
+        [localOfficeCenterX - cityRoadSpanX * 0.45, 0, northRoadZ],
+      ] as Array<[number, number, number]>,
+    [
+      cityRoadSpanX,
+      cityRoadSpanZ,
+      eastRoadX,
+      localOfficeCenterX,
+      localOfficeCenterZ,
+      northRoadZ,
+      southRoadZ,
+      westRoadX,
+    ],
+  );
+  const crossLoopRoute = useMemo(
+    () =>
+      [
+        [westRoadX, 0, localOfficeCenterZ - cityRoadSpanZ * 0.35],
+        [localOfficeCenterX + cityRoadSpanX * 0.35, 0, northRoadZ],
+        [eastRoadX, 0, localOfficeCenterZ + cityRoadSpanZ * 0.28],
+        [localOfficeCenterX - cityRoadSpanX * 0.35, 0, southRoadZ],
+        [westRoadX, 0, localOfficeCenterZ - cityRoadSpanZ * 0.35],
+      ] as Array<[number, number, number]>,
+    [
+      cityRoadSpanX,
+      cityRoadSpanZ,
+      eastRoadX,
+      localOfficeCenterX,
+      localOfficeCenterZ,
+      northRoadZ,
+      southRoadZ,
+      westRoadX,
+    ],
+  );
+
+  return (
+    <>
+      {[
+        { route: outerLoopRoute, speed: 0.2, phase: 0.0, color: "#e53935" },
+        { route: outerLoopRoute, speed: 0.2, phase: 2.4, color: "#1d4ed8" },
+        { route: outerLoopRoute, speed: 0.2, phase: 4.7, color: "#f59e0b" },
+        { route: outerLoopRoute, speed: 0.2, phase: 7.1, color: "#16a34a" },
+        { route: crossLoopRoute, speed: 0.16, phase: 1.2, color: "#8b5cf6" },
+        { route: crossLoopRoute, speed: 0.16, phase: 3.6, color: "#0284c7" },
+      ].map((traffic, index) => (
+        <MovingCompactCar
+          key={`moving-traffic-${index}`}
+          route={traffic.route}
+          speed={traffic.speed}
+          phase={traffic.phase}
+          bodyColor={traffic.color}
+        />
+      ))}
+    </>
+  );
+}
+
+type ZoneKind = "residential" | "commercial" | "industrial";
+type RoadMask = {
+  north: boolean;
+  south: boolean;
+  east: boolean;
+  west: boolean;
+};
+
+type CityGridCell = {
+  gx: number;
+  gz: number;
+  zone: ZoneKind;
+  road: boolean;
+  mask: RoadMask;
+};
+
+const CITY_GRID_COLUMNS = 10;
+const CITY_GRID_ROWS = 8;
+const CITY_GRID_CELL_SIZE = 1.18;
+
+const classifyZone = (gx: number, gz: number): ZoneKind => {
+  if (gz <= 1) return "commercial";
+  if (gz >= CITY_GRID_ROWS - 2) return "industrial";
+  return gx % 2 === 0 ? "residential" : "commercial";
+};
+
+const isRoadCell = (gx: number, gz: number): boolean => {
+  if (gz === 2 || gz === 5) return true;
+  if (gx === 2 || gx === 7) return true;
+  if ((gx === 5 && gz >= 1 && gz <= 6) || (gz === 4 && gx >= 1 && gx <= 8)) return true;
+  return false;
+};
+
+const buildCityGrid = (): CityGridCell[] => {
+  const cells: CityGridCell[] = [];
+  const roads = new Set<string>();
+  for (let gz = 0; gz < CITY_GRID_ROWS; gz += 1) {
+    for (let gx = 0; gx < CITY_GRID_COLUMNS; gx += 1) {
+      if (isRoadCell(gx, gz)) roads.add(`${gx}:${gz}`);
+    }
+  }
+  for (let gz = 0; gz < CITY_GRID_ROWS; gz += 1) {
+    for (let gx = 0; gx < CITY_GRID_COLUMNS; gx += 1) {
+      const road = roads.has(`${gx}:${gz}`);
+      const mask: RoadMask = {
+        north: roads.has(`${gx}:${gz - 1}`),
+        south: roads.has(`${gx}:${gz + 1}`),
+        east: roads.has(`${gx + 1}:${gz}`),
+        west: roads.has(`${gx - 1}:${gz}`),
+      };
+      cells.push({
+        gx,
+        gz,
+        zone: classifyZone(gx, gz),
+        road,
+        mask,
+      });
+    }
+  }
+  return cells;
+};
 
 export const FloorAndWalls = memo(function FloorAndWalls({
   showRemoteOffice = true,

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -167,6 +167,174 @@ function OfficeFlagPole({
   );
 }
 
+function TowerBlock({
+  position,
+  width,
+  depth,
+  height,
+  bodyColor,
+  accentColor,
+  windowColor,
+}: {
+  position: [number, number, number];
+  width: number;
+  depth: number;
+  height: number;
+  bodyColor: string;
+  accentColor: string;
+  windowColor: string;
+}) {
+  return (
+    <group position={position}>
+      <mesh position={[0, height / 2, 0]} castShadow receiveShadow>
+        <boxGeometry args={[width, height, depth]} />
+        <meshStandardMaterial color={bodyColor} roughness={0.88} metalness={0.08} />
+      </mesh>
+      <mesh position={[0, height + 0.14, 0]} castShadow>
+        <boxGeometry args={[width * 0.76, 0.28, depth * 0.76]} />
+        <meshStandardMaterial color={accentColor} roughness={0.74} metalness={0.2} />
+      </mesh>
+      {Array.from({ length: 4 }).map((_, row) =>
+        Array.from({ length: 3 }).map((__, column) => (
+          <mesh
+            key={`tower-window-${row}-${column}`}
+            position={[
+              -width * 0.24 + column * (width * 0.24),
+              0.4 + row * (height * 0.18),
+              depth / 2 + 0.01,
+            ]}
+          >
+            <planeGeometry args={[width * 0.13, height * 0.08]} />
+            <meshBasicMaterial color={windowColor} />
+          </mesh>
+        )),
+      )}
+      {Array.from({ length: 4 }).map((_, row) =>
+        Array.from({ length: 2 }).map((__, column) => (
+          <mesh
+            key={`tower-side-window-${row}-${column}`}
+            position={[
+              width / 2 + 0.01,
+              0.4 + row * (height * 0.18),
+              -depth * 0.16 + column * (depth * 0.32),
+            ]}
+            rotation={[0, -Math.PI / 2, 0]}
+          >
+            <planeGeometry args={[depth * 0.16, height * 0.08]} />
+            <meshBasicMaterial color={windowColor} />
+          </mesh>
+        )),
+      )}
+    </group>
+  );
+}
+
+function StorefrontBlock({
+  position,
+  rotationY = 0,
+  width,
+  depth,
+  height,
+  bodyColor,
+  awningColor,
+  trimColor,
+  windowColor,
+}: {
+  position: [number, number, number];
+  rotationY?: number;
+  width: number;
+  depth: number;
+  height: number;
+  bodyColor: string;
+  awningColor: string;
+  trimColor: string;
+  windowColor: string;
+}) {
+  return (
+    <group position={position} rotation={[0, rotationY, 0]}>
+      <mesh position={[0, height / 2, 0]} castShadow receiveShadow>
+        <boxGeometry args={[width, height, depth]} />
+        <meshStandardMaterial color={bodyColor} roughness={0.86} metalness={0.08} />
+      </mesh>
+      <mesh position={[0, height + 0.08, 0]} castShadow>
+        <boxGeometry args={[width + 0.08, 0.16, depth + 0.08]} />
+        <meshStandardMaterial color={trimColor} roughness={0.72} metalness={0.16} />
+      </mesh>
+      <mesh position={[0, height * 0.58, depth / 2 + 0.13]} castShadow>
+        <boxGeometry args={[width * 0.94, 0.12, 0.28]} />
+        <meshStandardMaterial color={awningColor} roughness={0.7} metalness={0.04} />
+      </mesh>
+      <mesh position={[0, height * 0.78, depth / 2 + 0.02]}>
+        <planeGeometry args={[width * 0.66, height * 0.16]} />
+        <meshBasicMaterial color={trimColor} />
+      </mesh>
+      <mesh position={[-width * 0.2, height * 0.34, depth / 2 + 0.01]}>
+        <planeGeometry args={[width * 0.22, height * 0.36]} />
+        <meshBasicMaterial color={windowColor} />
+      </mesh>
+      <mesh position={[width * 0.2, height * 0.34, depth / 2 + 0.01]}>
+        <planeGeometry args={[width * 0.22, height * 0.36]} />
+        <meshBasicMaterial color={windowColor} />
+      </mesh>
+      <mesh position={[0, height * 0.18, depth / 2 + 0.015]}>
+        <planeGeometry args={[width * 0.16, height * 0.28]} />
+        <meshBasicMaterial color="#2a1c12" />
+      </mesh>
+    </group>
+  );
+}
+
+function TownhouseBlock({
+  position,
+  rotationY = 0,
+  width,
+  depth,
+  height,
+  bodyColor,
+  roofColor,
+  doorColor,
+  windowColor,
+}: {
+  position: [number, number, number];
+  rotationY?: number;
+  width: number;
+  depth: number;
+  height: number;
+  bodyColor: string;
+  roofColor: string;
+  doorColor: string;
+  windowColor: string;
+}) {
+  return (
+    <group position={position} rotation={[0, rotationY, 0]}>
+      <mesh position={[0, height / 2, 0]} castShadow receiveShadow>
+        <boxGeometry args={[width, height, depth]} />
+        <meshStandardMaterial color={bodyColor} roughness={0.9} metalness={0.05} />
+      </mesh>
+      <mesh position={[0, height + width * 0.14, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+        <coneGeometry args={[width * 0.72, width * 0.54, 4]} />
+        <meshStandardMaterial color={roofColor} roughness={0.78} metalness={0.08} />
+      </mesh>
+      <mesh position={[0, height * 0.18, depth / 2 + 0.015]}>
+        <planeGeometry args={[width * 0.18, height * 0.28]} />
+        <meshBasicMaterial color={doorColor} />
+      </mesh>
+      {[-width * 0.22, width * 0.22].map((offsetX, index) => (
+        <mesh key={`townhouse-window-lower-${index}`} position={[offsetX, height * 0.32, depth / 2 + 0.01]}>
+          <planeGeometry args={[width * 0.16, height * 0.16]} />
+          <meshBasicMaterial color={windowColor} />
+        </mesh>
+      ))}
+      {[-width * 0.22, width * 0.22].map((offsetX, index) => (
+        <mesh key={`townhouse-window-upper-${index}`} position={[offsetX, height * 0.62, depth / 2 + 0.01]}>
+          <planeGeometry args={[width * 0.16, height * 0.16]} />
+          <meshBasicMaterial color={windowColor} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
 export const FloorAndWalls = memo(function FloorAndWalls({
   showRemoteOffice = true,
 }: {
@@ -354,8 +522,120 @@ export const FloorAndWalls = memo(function FloorAndWalls({
               </mesh>
             );
           })}
+
+          {[
+            { x: 110, y: 740, width: 1.9, depth: 0.95, height: 1.35, body: "#6d4c41", awning: "#d97706", trim: "#fbbf24", window: "#fde68a" },
+            { x: 420, y: 740, width: 2.2, depth: 1.05, height: 1.48, body: "#455a64", awning: "#0ea5e9", trim: "#dbeafe", window: "#bfdbfe" },
+            { x: 790, y: 740, width: 2.05, depth: 1, height: 1.4, body: "#7c2d12", awning: "#fb7185", trim: "#fecdd3", window: "#fef3c7" },
+            { x: 1130, y: 740, width: 2.15, depth: 1.02, height: 1.44, body: "#1f2937", awning: "#22c55e", trim: "#dcfce7", window: "#d1fae5" },
+            { x: 1490, y: 740, width: 1.95, depth: 0.96, height: 1.36, body: "#374151", awning: "#8b5cf6", trim: "#ddd6fe", window: "#c4b5fd" },
+          ].map((store) => {
+            const [wx, , wz] = toWorld(store.x, store.y);
+            return (
+              <StorefrontBlock
+                key={`storefront-${store.x}-${store.y}`}
+                position={[wx, 0, wz]}
+                width={store.width}
+                depth={store.depth}
+                height={store.height}
+                bodyColor={store.body}
+                awningColor={store.awning}
+                trimColor={store.trim}
+                windowColor={store.window}
+              />
+            );
+          })}
+
+          {[
+            { x: 180, y: 960, width: 1.45, depth: 1.08, height: 1.18, body: "#d6b48a", roof: "#8d6e63", door: "#5b3a29", window: "#fff7c2" },
+            { x: 470, y: 958, width: 1.58, depth: 1.12, height: 1.22, body: "#c4d7b2", roof: "#546e7a", door: "#2f3e46", window: "#dbeafe" },
+            { x: 790, y: 962, width: 1.5, depth: 1.06, height: 1.2, body: "#d7ccc8", roof: "#6d4c41", door: "#4e342e", window: "#fef3c7" },
+            { x: 1110, y: 958, width: 1.54, depth: 1.08, height: 1.24, body: "#cbb6d9", roof: "#5b4375", door: "#35263f", window: "#e9d5ff" },
+            { x: 1430, y: 962, width: 1.48, depth: 1.04, height: 1.18, body: "#b7d3c6", roof: "#355c4d", door: "#254237", window: "#dcfce7" },
+          ].map((house) => {
+            const [wx, , wz] = toWorld(house.x, house.y);
+            return (
+              <TownhouseBlock
+                key={`townhouse-${house.x}-${house.y}`}
+                position={[wx, 0, wz]}
+                rotationY={Math.PI}
+                width={house.width}
+                depth={house.depth}
+                height={house.height}
+                bodyColor={house.body}
+                roofColor={house.roof}
+                doorColor={house.door}
+                windowColor={house.window}
+              />
+            );
+          })}
+
+          {[
+            { x: 35, y: 865, width: 1.8, depth: 1.7, height: 2.7, body: "#334155", accent: "#0f172a", window: "#93c5fd" },
+            { x: 1745, y: 865, width: 1.95, depth: 1.78, height: 3.1, body: "#1f2937", accent: "#111827", window: "#fef08a" },
+            { x: 1680, y: 1080, width: 1.65, depth: 1.52, height: 2.45, body: "#475569", accent: "#1e293b", window: "#bfdbfe" },
+          ].map((tower) => {
+            const [wx, , wz] = toWorld(tower.x, tower.y);
+            return (
+              <TowerBlock
+                key={`tower-${tower.x}-${tower.y}`}
+                position={[wx, 0, wz]}
+                width={tower.width}
+                depth={tower.depth}
+                height={tower.height}
+                bodyColor={tower.body}
+                accentColor={tower.accent}
+                windowColor={tower.window}
+              />
+            );
+          })}
         </>
       ) : null}
+
+      {[
+        { x: 120, y: -95, width: 1.7, depth: 1.55, height: 2.35, body: "#374151", accent: "#111827", window: "#c4b5fd" },
+        { x: 430, y: -110, width: 1.58, depth: 1.42, height: 2.1, body: "#4b5563", accent: "#1f2937", window: "#bfdbfe" },
+        { x: 880, y: -120, width: 2.2, depth: 1.8, height: 3.25, body: "#334155", accent: "#0f172a", window: "#fde68a" },
+        { x: 1340, y: -108, width: 1.62, depth: 1.48, height: 2.2, body: "#475569", accent: "#1e293b", window: "#93c5fd" },
+        { x: 1670, y: -92, width: 1.74, depth: 1.52, height: 2.55, body: "#3f3f46", accent: "#18181b", window: "#e9d5ff" },
+      ].map((tower) => {
+        const [wx, , wz] = toWorld(tower.x, tower.y);
+        return (
+          <TowerBlock
+            key={`skyline-tower-${tower.x}-${tower.y}`}
+            position={[wx, 0, wz]}
+            width={tower.width}
+            depth={tower.depth}
+            height={tower.height}
+            bodyColor={tower.body}
+            accentColor={tower.accent}
+            windowColor={tower.window}
+          />
+        );
+      })}
+
+      {[
+        { x: 260, y: LOCAL_OFFICE_CANVAS_HEIGHT + 40, width: 1.35, depth: 0.98, height: 1.05, body: "#e5c9a8", roof: "#7b5e57", door: "#5d4037", window: "#fef3c7" },
+        { x: 540, y: LOCAL_OFFICE_CANVAS_HEIGHT + 46, width: 1.42, depth: 1.02, height: 1.12, body: "#c4d7b2", roof: "#5f7a61", door: "#39503d", window: "#dcfce7" },
+        { x: 1320, y: LOCAL_OFFICE_CANVAS_HEIGHT + 44, width: 1.4, depth: 1, height: 1.1, body: "#cdb4db", roof: "#6b4f85", door: "#433255", window: "#e9d5ff" },
+        { x: 1580, y: LOCAL_OFFICE_CANVAS_HEIGHT + 40, width: 1.32, depth: 0.96, height: 1.04, body: "#c6d8ef", roof: "#4b5d73", door: "#314152", window: "#dbeafe" },
+      ].map((house) => {
+        const [wx, , wz] = toWorld(house.x, house.y);
+        return (
+          <TownhouseBlock
+            key={`perimeter-townhouse-${house.x}-${house.y}`}
+            position={[wx, 0, wz]}
+            rotationY={Math.PI}
+            width={house.width}
+            depth={house.depth}
+            height={house.height}
+            bodyColor={house.body}
+            roofColor={house.roof}
+            doorColor={house.door}
+            windowColor={house.window}
+          />
+        );
+      })}
 
       {gymZoneFloorWidth > 0 && roomZoneFloorHeight > 0 ? (
         <>

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Billboard, Text } from "@react-three/drei";
 import { memo, useMemo, useRef, useState, type ReactNode } from "react";
 import { useFrame } from "@react-three/fiber";
 import type * as THREE from "three";
@@ -592,6 +593,65 @@ function FactoryBlock({
   );
 }
 
+function LotCutawayBase({
+  position,
+  width,
+  depth,
+  tone = "grass",
+}: {
+  position: [number, number, number];
+  width: number;
+  depth: number;
+  tone?: "grass" | "shop" | "home";
+}) {
+  const surfaceColor =
+    tone === "shop" ? "#d7d1c0" : tone === "home" ? "#cdddb7" : "#9ec27e";
+  const borderColor =
+    tone === "shop" ? "#6b7280" : tone === "home" ? "#8d6e63" : "#5d4037";
+  return (
+    <group position={position}>
+      <mesh position={[0, -0.01, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[width, depth]} />
+        <meshStandardMaterial color={surfaceColor} roughness={0.98} metalness={0.01} />
+      </mesh>
+      <mesh position={[0, 0.02, 0]} receiveShadow>
+        <boxGeometry args={[width + 0.08, 0.04, depth + 0.08]} />
+        <meshStandardMaterial color={borderColor} roughness={0.88} metalness={0.06} />
+      </mesh>
+    </group>
+  );
+}
+
+function BuildingBillboardLabel({
+  position,
+  text,
+  color = "#f8fafc",
+  background = "#111827",
+}: {
+  position: [number, number, number];
+  text: string;
+  color?: string;
+  background?: string;
+}) {
+  return (
+    <Billboard position={position} follow lockX={false} lockY={false} lockZ={false}>
+      <mesh position={[0, 0, -0.01]}>
+        <planeGeometry args={[1.7, 0.32]} />
+        <meshBasicMaterial color={background} transparent opacity={0.9} />
+      </mesh>
+      <Text
+        fontSize={0.14}
+        color={color}
+        anchorX="center"
+        anchorY="middle"
+        maxWidth={1.5}
+      >
+        {text}
+      </Text>
+    </Billboard>
+  );
+}
+
 function RoadTile({
   position,
   size,
@@ -657,10 +717,16 @@ function FullCityScene({
   centerX,
   centerZ,
   onEnterHeadquarters,
+  onEnterStore,
+  onEnterHouse,
+  activeSceneMode = "city",
 }: {
   centerX: number;
   centerZ: number;
   onEnterHeadquarters?: () => void;
+  onEnterStore?: () => void;
+  onEnterHouse?: () => void;
+  activeSceneMode?: "city" | "office" | "store" | "house";
 }) {
   const cityGrid = useMemo(() => buildCityGrid(), []);
   const [hqHovered, setHqHovered] = useState(false);
@@ -669,10 +735,22 @@ function FullCityScene({
   const cityWidth = CITY_GRID_COLUMNS * CITY_GRID_CELL_SIZE;
   const cityDepth = CITY_GRID_ROWS * CITY_GRID_CELL_SIZE;
   const hqPosition: [number, number, number] = [centerX, 0, centerZ + CITY_GRID_CELL_SIZE * 0.5];
+  const storeAnchor: [number, number, number] = [
+    baseOffsetX + 1 * CITY_GRID_CELL_SIZE,
+    0,
+    baseOffsetZ + 1 * CITY_GRID_CELL_SIZE,
+  ];
+  const houseAnchor: [number, number, number] = [
+    baseOffsetX + 8 * CITY_GRID_CELL_SIZE,
+    0,
+    baseOffsetZ + 6 * CITY_GRID_CELL_SIZE,
+  ];
   const trafficNorthZ = baseOffsetZ + 2 * CITY_GRID_CELL_SIZE;
   const trafficSouthZ = baseOffsetZ + 5 * CITY_GRID_CELL_SIZE;
   const trafficWestX = baseOffsetX + 2 * CITY_GRID_CELL_SIZE;
   const trafficEastX = baseOffsetX + 7 * CITY_GRID_CELL_SIZE;
+  const storeLotActive = activeSceneMode === "store";
+  const houseLotActive = activeSceneMode === "house";
   return (
     <group>
       <mesh position={[centerX, -0.02, centerZ]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
@@ -682,6 +760,8 @@ function FullCityScene({
       {cityGrid.map((cell) => {
         const x = baseOffsetX + cell.gx * CITY_GRID_CELL_SIZE;
         const z = baseOffsetZ + cell.gz * CITY_GRID_CELL_SIZE;
+        const isStoreLot = cell.gx === 1 && cell.gz === 1;
+        const isHouseLot = cell.gx === 8 && cell.gz === 6;
         if (cell.road) {
           return (
             <RoadTile
@@ -693,6 +773,34 @@ function FullCityScene({
           );
         }
         const lotPosition: [number, number, number] = [x, 0, z];
+        if (isStoreLot && storeLotActive) {
+          return (
+            <group key="full-city-store-cutaway" position={lotPosition}>
+              <LotCutawayBase
+                position={[0, 0, 0]}
+                width={CITY_GRID_CELL_SIZE * 0.96}
+                depth={CITY_GRID_CELL_SIZE * 0.96}
+                tone="shop"
+              />
+              <StreetTree position={[-0.34, 0, -0.28]} canopyColor="#4ea34a" />
+              <StreetTree position={[0.28, 0, 0.22]} canopyColor="#3f9142" />
+            </group>
+          );
+        }
+        if (isHouseLot && houseLotActive) {
+          return (
+            <group key="full-city-house-cutaway" position={lotPosition}>
+              <LotCutawayBase
+                position={[0, 0, 0]}
+                width={CITY_GRID_CELL_SIZE * 0.98}
+                depth={CITY_GRID_CELL_SIZE * 0.98}
+                tone="home"
+              />
+              <StreetTree position={[-0.28, 0, -0.26]} canopyColor="#4ea34a" />
+              <StreetTree position={[0.24, 0, 0.18]} canopyColor="#5aa05c" />
+            </group>
+          );
+        }
         if ((cell.gx + cell.gz) % 7 === 0) {
           return (
             <group key={`full-city-park-${cell.gx}-${cell.gz}`} position={lotPosition}>
@@ -724,16 +832,25 @@ function FullCityScene({
         if (cell.zone === "commercial") {
           const isTower = cell.gz <= 1 && cell.gx % 3 === 0;
           return isTower ? (
-            <TowerBlock
-              key={`full-city-com-tower-${cell.gx}-${cell.gz}`}
-              position={lotPosition}
-              width={0.84}
-              depth={0.84}
-              height={2.5 + (cell.gx % 2) * 0.9}
-              bodyColor="#e5e7eb"
-              accentColor="#9ca3af"
-              windowColor="#111827"
-            />
+            <group key={`full-city-com-tower-${cell.gx}-${cell.gz}`}>
+              <TowerBlock
+                position={lotPosition}
+                width={0.84}
+                depth={0.84}
+                height={2.5 + (cell.gx % 2) * 0.9}
+                bodyColor="#e5e7eb"
+                accentColor="#9ca3af"
+                windowColor="#111827"
+              />
+              {cell.gz === 0 && cell.gx === 6 ? (
+                <BuildingBillboardLabel
+                  position={[x, 3.7, z]}
+                  text="JIRA"
+                  color="#fde68a"
+                  background="#1f2937"
+                />
+              ) : null}
+            </group>
           ) : (
             <StorefrontBlock
               key={`full-city-com-store-${cell.gx}-${cell.gz}`}
@@ -762,72 +879,129 @@ function FullCityScene({
           />
         );
       })}
+      {activeSceneMode !== "office" ? (
+        <group
+          position={hqPosition}
+          onPointerOver={(event) => {
+            event.stopPropagation();
+            setHqHovered(true);
+          }}
+          onPointerOut={(event) => {
+            event.stopPropagation();
+            setHqHovered(false);
+          }}
+          onClick={(event) => {
+            event.stopPropagation();
+            onEnterHeadquarters?.();
+          }}
+        >
+          <mesh position={[0, 0.01, 0.18]} rotation={[-Math.PI / 2, 0, 0]}>
+            <planeGeometry args={[3.2, 2.8]} />
+            <meshBasicMaterial
+              color={hqHovered ? "#fde68a" : "#bbf7d0"}
+              transparent
+              opacity={hqHovered ? 0.24 : 0.14}
+            />
+          </mesh>
+          <TowerBlock
+            position={[-0.52, 0, -0.26]}
+            width={0.9}
+            depth={0.9}
+            height={3.6}
+            bodyColor="#f3f4f6"
+            accentColor="#9ca3af"
+            windowColor="#0f172a"
+          />
+          <TowerBlock
+            position={[0.56, 0, 0.24]}
+            width={0.9}
+            depth={0.9}
+            height={3.1}
+            bodyColor="#f3f4f6"
+            accentColor="#9ca3af"
+            windowColor="#0f172a"
+          />
+          <StorefrontBlock
+            position={[0, 0, 0.92]}
+            width={1.3}
+            depth={0.78}
+            height={0.95}
+            bodyColor="#334155"
+            awningColor="#22c55e"
+            trimColor="#dcfce7"
+            windowColor="#bfdbfe"
+          />
+          <mesh position={[0, 0.02, -1.02]} rotation={[-Math.PI / 2, 0, 0]}>
+            <planeGeometry args={[1.85, 0.34]} />
+            <meshBasicMaterial
+              color={hqHovered ? "#fef08a" : "#e0f2fe"}
+              transparent
+              opacity={0.92}
+            />
+          </mesh>
+          <mesh position={[0, 0.03, -1.02]}>
+            <planeGeometry args={[1.7, 0.18]} />
+            <meshBasicMaterial color="#0f172a" transparent opacity={0.98} />
+          </mesh>
+          <mesh position={[0, 0.04, -1.02]}>
+            <planeGeometry args={[1.58, 0.12]} />
+            <meshBasicMaterial
+              color={hqHovered ? "#fef08a" : "#f8fafc"}
+              transparent
+              opacity={1}
+            />
+          </mesh>
+        </group>
+      ) : (
+        <group position={hqPosition}>
+          <LotCutawayBase
+            position={[0, 0, 0.1]}
+            width={3.25}
+            depth={2.85}
+            tone="grass"
+          />
+          {[
+            [-1.42, 0, -1.12],
+            [1.46, 0, -1.14],
+            [-1.44, 0, 1.18],
+            [1.46, 0, 1.18],
+          ].map(([x, y, z], index) => (
+            <StreetTree
+              key={`hq-lot-tree-${index}`}
+              position={[x, y, z]}
+              canopyColor={index % 2 === 0 ? "#3f9142" : "#4ea34a"}
+            />
+          ))}
+          <BuildingBillboardLabel
+            position={[0, 0.55, -1.34]}
+            text="HEADQUARTERS"
+            color="#fef08a"
+            background="#0f172a"
+          />
+        </group>
+      )}
       <group
-        position={hqPosition}
-        onPointerOver={(event) => {
-          event.stopPropagation();
-          setHqHovered(true);
-        }}
-        onPointerOut={(event) => {
-          event.stopPropagation();
-          setHqHovered(false);
-        }}
+        position={storeAnchor}
         onClick={(event) => {
           event.stopPropagation();
-          onEnterHeadquarters?.();
+          onEnterStore?.();
         }}
       >
-        <mesh position={[0, 0.01, 0.18]} rotation={[-Math.PI / 2, 0, 0]}>
-          <planeGeometry args={[3.2, 2.8]} />
-          <meshBasicMaterial
-            color={hqHovered ? "#fde68a" : "#bbf7d0"}
-            transparent
-            opacity={hqHovered ? 0.24 : 0.14}
-          />
+        <mesh position={[0, 0.01, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[1.22, 1.02]} />
+          <meshBasicMaterial color="#fef3c7" transparent opacity={0.12} />
         </mesh>
-        <TowerBlock
-          position={[-0.52, 0, -0.26]}
-          width={0.9}
-          depth={0.9}
-          height={3.6}
-          bodyColor="#f3f4f6"
-          accentColor="#9ca3af"
-          windowColor="#0f172a"
-        />
-        <TowerBlock
-          position={[0.56, 0, 0.24]}
-          width={0.9}
-          depth={0.9}
-          height={3.1}
-          bodyColor="#f3f4f6"
-          accentColor="#9ca3af"
-          windowColor="#0f172a"
-        />
-        <StorefrontBlock
-          position={[0, 0, 0.92]}
-          width={1.3}
-          depth={0.78}
-          height={0.95}
-          bodyColor="#334155"
-          awningColor="#22c55e"
-          trimColor="#dcfce7"
-          windowColor="#bfdbfe"
-        />
-        <mesh position={[0, 0.02, -1.02]} rotation={[-Math.PI / 2, 0, 0]}>
-          <planeGeometry args={[1.85, 0.34]} />
-          <meshBasicMaterial
-            color={hqHovered ? "#fef08a" : "#e0f2fe"}
-            transparent
-            opacity={0.92}
-          />
-        </mesh>
-        <mesh position={[0, 0.03, -1.02]}>
-          <planeGeometry args={[1.7, 0.18]} />
-          <meshBasicMaterial color="#0f172a" transparent opacity={0.98} />
-        </mesh>
-        <mesh position={[0, 0.04, -1.02]}>
-          <planeGeometry args={[1.58, 0.12]} />
-          <meshBasicMaterial color={hqHovered ? "#fef08a" : "#f8fafc"} transparent opacity={1} />
+      </group>
+      <group
+        position={houseAnchor}
+        onClick={(event) => {
+          event.stopPropagation();
+          onEnterHouse?.();
+        }}
+      >
+        <mesh position={[0, 0.01, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[1.12, 1.12]} />
+          <meshBasicMaterial color="#e9d5ff" transparent opacity={0.12} />
         </mesh>
       </group>
       <CityTrafficLayer
@@ -909,9 +1083,15 @@ const buildCityGrid = (): CityGridCell[] => {
 export const FloorAndWalls = memo(function FloorAndWalls({
   showRemoteOffice = true,
   onEnterHeadquarters,
+  activeSceneMode = "city",
+  onEnterStore,
+  onEnterHouse,
 }: {
   showRemoteOffice?: boolean;
   onEnterHeadquarters?: () => void;
+  activeSceneMode?: "city" | "office" | "store" | "house";
+  onEnterStore?: () => void;
+  onEnterHouse?: () => void;
 }) {
   const districtWidth = CANVAS_W * SCALE;
   const districtHeight = CANVAS_H * SCALE;
@@ -973,6 +1153,9 @@ export const FloorAndWalls = memo(function FloorAndWalls({
         centerX={localOfficeCenterX}
         centerZ={localOfficeCenterZ}
         onEnterHeadquarters={onEnterHeadquarters}
+        onEnterStore={onEnterStore}
+        onEnterHouse={onEnterHouse}
+        activeSceneMode={activeSceneMode}
       />
     );
   }

--- a/tests/unit/districtSimulation.test.ts
+++ b/tests/unit/districtSimulation.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDistrictSimulationState,
+  DISTRICT_SIM_DEFAULT_DISTRICT_COUNT,
+  DISTRICT_SIM_DEFAULT_MAX_AGENTS,
+  getDistrictSimulationNeedEmoji,
+  getDistrictSimulationRelationship,
+  reconcileDistrictSimulationAgents,
+  stepDistrictSimulation,
+} from "@/features/retro-office/core/districtSimulation";
+
+const makeAgents = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `agent-${index + 1}`,
+    name: `Agent ${index + 1}`,
+  }));
+
+describe("districtSimulation", () => {
+  it("creates deterministic state with scope defaults", () => {
+    const agents = makeAgents(20);
+    const state = createDistrictSimulationState({
+      agents,
+      seedKey: "scope-a",
+    });
+    expect(state.districtCount).toBe(DISTRICT_SIM_DEFAULT_DISTRICT_COUNT);
+    expect(state.maxAgents).toBe(DISTRICT_SIM_DEFAULT_MAX_AGENTS);
+    expect(state.agents.length).toBe(10);
+    expect(state.minuteOfDay).toBe(9 * 60);
+    for (const agent of state.agents) {
+      expect(agent.homeDistrictId).toBeGreaterThanOrEqual(0);
+      expect(agent.homeDistrictId).toBeLessThan(10);
+      expect(agent.workDistrictId).toBeGreaterThanOrEqual(0);
+      expect(agent.workDistrictId).toBeLessThan(10);
+      expect(agent.roomsOwned).toBeGreaterThanOrEqual(1);
+      expect(agent.roomsOwned).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("steps needs, activity, and wallet through schedule-driven simulation", () => {
+    const state = createDistrictSimulationState({
+      agents: makeAgents(3),
+      districtCount: 10,
+      maxAgents: 10,
+      seedKey: "scope-a-schedule",
+    });
+    const firstBefore = state.agents[0];
+    expect(firstBefore).toBeTruthy();
+    const stepped = stepDistrictSimulation(state, { minutes: 60 });
+    const firstAfter = stepped.agents[0];
+    expect(firstAfter).toBeTruthy();
+    expect(stepped.minuteOfDay).toBe((9 * 60 + 60) % (24 * 60));
+    expect(firstAfter.activity).toMatch(/work|sleep|socialize|eat|idle/);
+    expect(firstAfter.needs.hunger).toBeGreaterThanOrEqual(0);
+    expect(firstAfter.needs.hunger).toBeLessThanOrEqual(100);
+    expect(firstAfter.needs.energy).toBeGreaterThanOrEqual(0);
+    expect(firstAfter.needs.energy).toBeLessThanOrEqual(100);
+    expect(firstAfter.needs.social).toBeGreaterThanOrEqual(0);
+    expect(firstAfter.needs.social).toBeLessThanOrEqual(100);
+    expect(firstAfter.needs.comfort).toBeGreaterThanOrEqual(0);
+    expect(firstAfter.needs.comfort).toBeLessThanOrEqual(100);
+    if (firstAfter.activity === "work") {
+      expect(firstAfter.wallet).toBeGreaterThan(firstBefore.wallet);
+    }
+  });
+
+  it("charges rent on day rollover based on rooms owned", () => {
+    const state = createDistrictSimulationState({
+      agents: makeAgents(2),
+      districtCount: 10,
+      maxAgents: 10,
+      seedKey: "scope-a-rent",
+    });
+    const before = state.agents[0];
+    expect(before).toBeTruthy();
+    const stepped = stepDistrictSimulation(
+      {
+        ...state,
+        minuteOfDay: 23 * 60 + 50,
+      },
+      { minutes: 20 },
+    );
+    const after = stepped.agents[0];
+    expect(stepped.day).toBe(2);
+    expect(after.lastRentDay).toBe(2);
+    expect(after.wallet).toBeLessThan(before.wallet);
+  });
+
+  it("updates relationship score by co-location and social activity", () => {
+    const state = createDistrictSimulationState({
+      agents: makeAgents(2),
+      districtCount: 10,
+      maxAgents: 10,
+      seedKey: "scope-a-relationships",
+    });
+    const leftId = state.agents[0]?.id ?? "";
+    const rightId = state.agents[1]?.id ?? "";
+    expect(leftId).not.toBe("");
+    expect(rightId).not.toBe("");
+    const beforeScore = getDistrictSimulationRelationship(state, leftId, rightId);
+    const stepped = stepDistrictSimulation(state, { minutes: 45 });
+    const afterScore = getDistrictSimulationRelationship(stepped, leftId, rightId);
+    expect(afterScore).not.toBe(beforeScore);
+    expect(afterScore).toBeGreaterThanOrEqual(-100);
+    expect(afterScore).toBeLessThanOrEqual(100);
+  });
+
+  it("reconciles agents while keeping relationship graph consistent", () => {
+    const initial = createDistrictSimulationState({
+      agents: makeAgents(4),
+      districtCount: 10,
+      maxAgents: 10,
+      seedKey: "scope-a-reconcile",
+    });
+    const reconciled = reconcileDistrictSimulationAgents(initial, {
+      agents: [
+        { id: "agent-1", name: "Agent 1" },
+        { id: "agent-3", name: "Agent 3" },
+        { id: "agent-5", name: "Agent 5" },
+      ],
+      districtCount: 10,
+      maxAgents: 10,
+      seedKey: "scope-a-reconcile",
+    });
+    expect(reconciled.agents.map((agent) => agent.id)).toEqual([
+      "agent-1",
+      "agent-3",
+      "agent-5",
+    ]);
+    expect(
+      getDistrictSimulationRelationship(reconciled, "agent-1", "agent-3"),
+    ).toBeTypeOf("number");
+    expect(
+      getDistrictSimulationRelationship(reconciled, "agent-1", "agent-5"),
+    ).toBeTypeOf("number");
+    expect(
+      getDistrictSimulationRelationship(reconciled, "agent-3", "agent-5"),
+    ).toBeTypeOf("number");
+  });
+
+  it("maps lowest critical need to HUD emoji", () => {
+    expect(
+      getDistrictSimulationNeedEmoji({
+        hunger: 20,
+        energy: 70,
+        social: 70,
+        comfort: 70,
+      }),
+    ).toBe("🍔");
+    expect(
+      getDistrictSimulationNeedEmoji({
+        hunger: 80,
+        energy: 20,
+        social: 70,
+        comfort: 70,
+      }),
+    ).toBe("😴");
+    expect(
+      getDistrictSimulationNeedEmoji({
+        hunger: 80,
+        energy: 80,
+        social: 20,
+        comfort: 70,
+      }),
+    ).toBe("💬");
+    expect(
+      getDistrictSimulationNeedEmoji({
+        hunger: 80,
+        energy: 80,
+        social: 70,
+        comfort: 20,
+      }),
+    ).toBe("🛋️");
+    expect(
+      getDistrictSimulationNeedEmoji({
+        hunger: 90,
+        energy: 90,
+        social: 90,
+        comfort: 90,
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add deterministic district simulation engine for Scope A foundations
- model 10-district neighborhood simulation with 10-agent cap defaults
- include housing (rooms/rent), schedules, needs, relationships, and economy updates per tick
- add unit tests to validate deterministic creation/reconcile/step behavior and need emoji mapping
- wire simulation into `RetroOffice3D` with a visible city HUD panel that shows day/time, district population, economy/relations, housing, and needs alerts
- shift the scene from office-first to city-first rendering using a full tile-grid city layout
- add SimCity-inspired roads, intersections, mixed zoning, greenery, and animated traffic
- suppress office/onboarding blockers in city mode so the city view is exposed cleanly by default
- add Phase 1 HQ interaction: click HQ from the city to enter the office interior, with a Back to City control

## Walkthrough
[full_city_browser_render_demo.mp4](https://cursor.com/agents/bc-48fb2ab6-02f2-45d1-94b5-1fd5706fd0ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffull_city_browser_render_demo.mp4)
[full city latest clean screenshot](https://cursor.com/agents/bc-48fb2ab6-02f2-45d1-94b5-1fd5706fd0ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffull_city_no_overlays.png)

## Testing
- npm run typecheck

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48fb2ab6-02f2-45d1-94b5-1fd5706fd0ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48fb2ab6-02f2-45d1-94b5-1fd5706fd0ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

