### PR TITLE
Improve mobile responsiveness across office UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -304,6 +304,7 @@
 @layer base {
   html {
     font-size: 112%;
+    min-height: 100%;
   }
 
   * {
@@ -314,6 +315,7 @@
   body {
     @apply bg-background text-foreground;
     min-height: 100vh;
+    min-height: 100dvh;
     margin: 0;
     letter-spacing: var(--tracking-normal);
     font-family: var(--font-sans), sans-serif;
@@ -401,6 +403,39 @@ summary,
 
 .dark *::-webkit-scrollbar-thumb:hover {
   background: color-mix(in oklch, var(--foreground) 46%, var(--border));
+}
+
+.safe-top {
+  padding-top: max(0.75rem, env(safe-area-inset-top));
+}
+
+.safe-bottom {
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+}
+
+.safe-left {
+  padding-left: max(0.75rem, env(safe-area-inset-left));
+}
+
+.safe-right {
+  padding-right: max(0.75rem, env(safe-area-inset-right));
+}
+
+.safe-x {
+  padding-left: max(0.75rem, env(safe-area-inset-left));
+  padding-right: max(0.75rem, env(safe-area-inset-right));
+}
+
+.safe-y {
+  padding-top: max(0.75rem, env(safe-area-inset-top));
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+}
+
+.safe-inset {
+  padding-top: max(0.75rem, env(safe-area-inset-top));
+  padding-right: max(0.75rem, env(safe-area-inset-right));
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+  padding-left: max(0.75rem, env(safe-area-inset-left));
 }
 
 textarea {
@@ -1328,6 +1363,23 @@ textarea:focus::-webkit-scrollbar {
   outline: none !important;
   outline-offset: 0 !important;
   box-shadow: none !important;
+}
+
+.safe-area-pad {
+  padding-top: max(0.75rem, env(safe-area-inset-top));
+  padding-right: max(0.75rem, env(safe-area-inset-right));
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+  padding-left: max(0.75rem, env(safe-area-inset-left));
+}
+
+.safe-area-pad-x {
+  padding-right: max(0.75rem, env(safe-area-inset-right));
+  padding-left: max(0.75rem, env(safe-area-inset-left));
+}
+
+.safe-area-pad-y {
+  padding-top: max(0.75rem, env(safe-area-inset-top));
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
 }
 
 @keyframes fadeUp {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,16 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Bebas_Neue, IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Claw3D",
   description: "Focused operator studio for the OpenClaw gateway.",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 const display = Bebas_Neue({
@@ -41,7 +47,9 @@ export default function RootLayout({
         />
       </head>
       <body className={`${display.variable} ${sans.variable} ${mono.variable} antialiased`}>
-        <main className="h-screen w-screen overflow-hidden bg-background">{children}</main>
+        <main className="h-dvh min-h-dvh w-full max-w-full overflow-hidden bg-background">
+          {children}
+        </main>
       </body>
     </html>
   );

--- a/src/app/office/builder/page.tsx
+++ b/src/app/office/builder/page.tsx
@@ -14,7 +14,7 @@ export default function OfficeBuilderPage() {
   });
   const map = normalizeOfficeMap(getPublishedOfficeMap(WORKSPACE_ID), fallback);
   return (
-    <main className="relative h-screen w-screen overflow-hidden bg-background p-3">
+    <main className="relative h-dvh min-h-dvh w-full overflow-hidden bg-background p-2 safe-area-pad sm:p-3">
       <OfficeBuilderPanel initialMap={map} workspaceId={WORKSPACE_ID} officeId={OFFICE_ID} />
     </main>
   );

--- a/src/features/agents/components/GatewayConnectScreen.tsx
+++ b/src/features/agents/components/GatewayConnectScreen.tsx
@@ -215,7 +215,7 @@ export const GatewayConnectScreen = ({
   );
 
   return (
-    <div className="mx-auto flex min-h-0 w-full max-w-[820px] flex-1 flex-col gap-5">
+    <div className="mx-auto flex min-h-0 max-h-[calc(100dvh-max(1.5rem,calc(env(safe-area-inset-top)+env(safe-area-inset-bottom)+1.5rem)))] w-full max-w-[820px] flex-1 flex-col gap-4 overflow-y-auto pr-1 sm:gap-5">
       <div className="ui-card px-4 py-2">
         <div className="flex items-center gap-2">
           {status === "connecting" ? (
@@ -229,7 +229,7 @@ export const GatewayConnectScreen = ({
         </div>
       </div>
 
-      <div className="ui-card px-4 py-5 sm:px-6">
+      <div className="ui-card px-4 py-4 sm:px-6 sm:py-5">
         <div>
           <p className="font-mono text-[10px] font-medium tracking-[0.06em] text-muted-foreground">
             Remote gateway (recommended)
@@ -243,31 +243,31 @@ export const GatewayConnectScreen = ({
           <p className="mt-1 text-xs text-muted-foreground">
             Each backend keeps its own saved URL and token.
           </p>
-          <div className="mt-3 flex flex-wrap gap-2">
+          <div className="mt-3 grid grid-cols-1 gap-2 sm:flex sm:flex-wrap">
             <button
               type="button"
-              className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"
+              className="ui-btn-secondary w-full px-3 py-2 text-[11px] font-semibold tracking-[0.05em] sm:w-auto sm:py-1.5"
               onClick={useDemoPreset}
             >
               Demo backend
             </button>
             <button
               type="button"
-              className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"
+              className="ui-btn-secondary w-full px-3 py-2 text-[11px] font-semibold tracking-[0.05em] sm:w-auto sm:py-1.5"
               onClick={useHermesPreset}
             >
               Hermes backend
             </button>
             <button
               type="button"
-              className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"
+              className="ui-btn-secondary w-full px-3 py-2 text-[11px] font-semibold tracking-[0.05em] sm:w-auto sm:py-1.5"
               onClick={useCustomPreset}
             >
               Custom backend
             </button>
             <button
               type="button"
-              className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"
+              className="ui-btn-secondary w-full px-3 py-2 text-[11px] font-semibold tracking-[0.05em] sm:w-auto sm:py-1.5"
               onClick={useOpenClawPreset}
             >
               OpenClaw backend

--- a/src/features/agents/components/GatewayConnectScreen.tsx
+++ b/src/features/agents/components/GatewayConnectScreen.tsx
@@ -137,6 +137,72 @@ export const GatewayConnectScreen = ({
     </div>
   );
 
+  const compactLocalGuidance = (
+    <div className="space-y-2 sm:hidden">
+      <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+        <p className="text-xs font-medium text-foreground">Demo office</p>
+        <p className="mt-1 text-xs leading-snug text-muted-foreground">
+          Run <span className="font-mono text-foreground">{localDemoCommand}</span>, then choose{" "}
+          <span className="font-mono text-foreground">Demo backend</span> and connect.
+        </p>
+      </div>
+      <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+        <p className="text-xs font-medium text-foreground">Other local runtimes</p>
+        <p className="mt-1 text-xs leading-snug text-muted-foreground">
+          Hermes: <span className="font-mono text-foreground">npm run hermes-adapter</span>. Custom: point the URL at your orchestrator, for example{" "}
+          <span className="font-mono text-foreground">http://localhost:7770</span>.
+        </p>
+      </div>
+      <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+        <p className="text-xs font-medium text-foreground">Opening Claw3D remotely</p>
+        <p className="mt-1 text-xs leading-snug text-muted-foreground">
+          Start Studio with <span className="font-mono text-foreground">HOST=0.0.0.0</span> and set{" "}
+          <span className="font-mono text-foreground">STUDIO_ACCESS_TOKEN</span>.
+        </p>
+      </div>
+    </div>
+  );
+
+  const expandedLocalGuidance = (
+    <div className="hidden space-y-3 sm:block">
+      <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+        <p className="text-xs font-medium text-foreground">Just want to see the office?</p>
+        <p className="mt-1 text-xs leading-snug text-muted-foreground">
+          Run <span className="font-mono text-foreground">{localDemoCommand}</span> to start a built-in mock gateway with demo agents.
+          Then choose <span className="font-mono text-foreground">Demo backend</span> and connect.
+        </p>
+      </div>
+      <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+        <p className="text-xs font-medium text-foreground">Using Hermes locally?</p>
+        <p className="mt-1 text-xs leading-snug text-muted-foreground">
+          Run <span className="font-mono text-foreground">npm run hermes-adapter</span>, then choose
+          <span className="font-mono text-foreground"> Hermes backend</span>. The default local URL is
+          <span className="font-mono text-foreground"> [REDACTED]</span>.
+        </p>
+      </div>
+      <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+        <p className="text-xs font-medium text-foreground">Using a custom runtime locally?</p>
+        <p className="mt-1 text-xs leading-snug text-muted-foreground">
+          Choose <span className="font-mono text-foreground">Custom backend</span> and point the URL
+          at your orchestrator or runtime boundary, for example
+          <span className="font-mono text-foreground"> http://localhost:7770</span>. Direct custom
+          runtime chat flows are not wired into Studio yet in this slice, but the provider seam and
+          metadata scaffold are now in place.
+        </p>
+      </div>
+      <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+        <p className="text-xs font-medium text-foreground">Opening Claw3D from another machine?</p>
+        <p className="mt-1 text-xs leading-snug text-muted-foreground">
+          Start Studio with <span className="font-mono text-foreground">HOST=0.0.0.0</span> (or a
+          specific LAN/Tailscale host) and set
+          <span className="font-mono text-foreground"> STUDIO_ACCESS_TOKEN</span> before exposing it
+          beyond localhost. Gateway settings are stored on the Studio host, but OpenClaw device approval
+          remains per browser/device.
+        </p>
+      </div>
+    </div>
+  );
+
   const remoteForm = (
     <div className="mt-2.5 flex flex-col gap-3">
       <label className="flex flex-col gap-1 text-[11px] font-medium text-foreground/90">
@@ -215,7 +281,7 @@ export const GatewayConnectScreen = ({
   );
 
   return (
-    <div className="mx-auto flex min-h-0 max-h-[calc(100dvh-max(1.5rem,calc(env(safe-area-inset-top)+env(safe-area-inset-bottom)+1.5rem)))] w-full max-w-[820px] flex-1 flex-col gap-4 overflow-y-auto pr-1 sm:gap-5">
+    <div className="mx-auto flex min-h-0 max-h-full w-full max-w-[820px] flex-1 flex-col gap-4 overflow-y-auto overscroll-contain pr-1 sm:gap-5">
       <div className="ui-card px-4 py-2">
         <div className="flex items-center gap-2">
           {status === "connecting" ? (
@@ -288,41 +354,9 @@ export const GatewayConnectScreen = ({
         </div>
         <div className="mt-3 space-y-3">
           {commandField}
-          <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
-            <p className="text-xs font-medium text-foreground">Just want to see the office?</p>
-            <p className="mt-1 text-xs leading-snug text-muted-foreground">
-              Run <span className="font-mono text-foreground">{localDemoCommand}</span> to start a built-in mock gateway with demo agents.
-              Then choose <span className="font-mono text-foreground">Demo backend</span> and connect.
-            </p>
-          </div>
-          <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
-            <p className="text-xs font-medium text-foreground">Using Hermes locally?</p>
-            <p className="mt-1 text-xs leading-snug text-muted-foreground">
-              Run <span className="font-mono text-foreground">npm run hermes-adapter</span>, then choose
-              <span className="font-mono text-foreground"> Hermes backend</span>. The default local URL is
-              <span className="font-mono text-foreground"> ws://localhost:18789</span>.
-            </p>
-          </div>
-          <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
-            <p className="text-xs font-medium text-foreground">Using a custom runtime locally?</p>
-            <p className="mt-1 text-xs leading-snug text-muted-foreground">
-              Choose <span className="font-mono text-foreground">Custom backend</span> and point the URL
-              at your orchestrator or runtime boundary, for example
-              <span className="font-mono text-foreground"> http://localhost:7770</span>. Direct custom
-              runtime chat flows are not wired into Studio yet in this slice, but the provider seam and
-              metadata scaffold are now in place.
-            </p>
-          </div>
-          <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
-            <p className="text-xs font-medium text-foreground">Opening Claw3D from another machine?</p>
-            <p className="mt-1 text-xs leading-snug text-muted-foreground">
-              Start Studio with <span className="font-mono text-foreground">HOST=0.0.0.0</span> (or a
-              specific LAN/Tailscale host) and set
-              <span className="font-mono text-foreground"> STUDIO_ACCESS_TOKEN</span> before exposing it
-              beyond localhost. Gateway settings are stored on the Studio host, but OpenClaw device approval
-              remains per browser/device.
-            </p>
-          </div>
+          {compactLocalGuidance}
+          {expandedLocalGuidance}
+
           {localGatewayDefaults ? (
             <div className="ui-input rounded-md px-3 py-3">
               <div className="space-y-2">

--- a/src/features/office/components/HQSidebar.tsx
+++ b/src/features/office/components/HQSidebar.tsx
@@ -65,16 +65,16 @@ export function HQSidebar({
   const boardLikeWidth = activeTab === "kanban";
 
   return (
-    <aside className="pointer-events-none fixed inset-y-0 right-0 z-20 flex justify-end">
-      <div className="pointer-events-auto mt-14 flex shrink-0 flex-col items-end gap-1.5">
+    <aside className="pointer-events-none fixed inset-y-0 right-0 z-20 flex justify-end safe-area-pad-y">
+      <div className="pointer-events-auto mt-14 mr-[max(0px,env(safe-area-inset-right))] flex shrink-0 flex-col items-end gap-1.5 md:mt-14">
         <button
           type="button"
           onClick={onToggle}
-          className="rounded-l-md border border-r-0 border-cyan-500/30 bg-[#06090d]/90 px-1.5 py-2.5 font-mono text-[10px] font-semibold tracking-[0.2em] text-cyan-300 shadow-xl backdrop-blur transition-colors hover:border-cyan-400/50 hover:text-cyan-100"
+          className="rounded-l-md border border-r-0 border-cyan-500/30 bg-[#06090d]/90 px-2 py-3 font-mono text-[10px] font-semibold tracking-[0.18em] text-cyan-300 shadow-xl backdrop-blur transition-colors hover:border-cyan-400/50 hover:text-cyan-100 md:px-1.5 md:py-2.5 md:tracking-[0.2em]"
           aria-expanded={open}
           aria-label={open ? "Collapse headquarters sidebar" : "Open headquarters sidebar"}
         >
-          <span className="block leading-none [writing-mode:vertical-rl]">
+          <span className="block leading-none md:[writing-mode:vertical-rl]">
             {open ? "COLLAPSE HQ" : "OPEN HQ"}
           </span>
         </button>
@@ -84,10 +84,10 @@ export function HQSidebar({
           onClick={() => {
             onOpenMarketplace();
           }}
-          className="rounded-l-md border border-r-0 border-fuchsia-500/25 bg-[#100611]/90 px-1.5 py-2.5 font-mono text-[10px] font-semibold tracking-[0.2em] text-fuchsia-300/80 shadow-xl backdrop-blur transition-colors hover:border-fuchsia-400/45 hover:text-fuchsia-100"
+          className="rounded-l-md border border-r-0 border-fuchsia-500/25 bg-[#100611]/90 px-2 py-3 font-mono text-[10px] font-semibold tracking-[0.18em] text-fuchsia-300/80 shadow-xl backdrop-blur transition-colors hover:border-fuchsia-400/45 hover:text-fuchsia-100 md:px-1.5 md:py-2.5 md:tracking-[0.2em]"
           aria-label="Open marketplace"
         >
-          <span className="block leading-none [writing-mode:vertical-rl]">
+          <span className="block leading-none md:[writing-mode:vertical-rl]">
             MARKETPLACE
           </span>
         </button>
@@ -100,7 +100,7 @@ export function HQSidebar({
               onToggle();
             }
           }}
-          className={`rounded-l-md border border-r-0 px-1.5 py-2.5 font-mono text-[10px] font-semibold tracking-[0.2em] shadow-xl backdrop-blur transition-colors ${
+          className={`rounded-l-md border border-r-0 px-2 py-3 font-mono text-[10px] font-semibold tracking-[0.18em] shadow-xl backdrop-blur transition-colors md:px-1.5 md:py-2.5 md:tracking-[0.2em] ${
             analyticsOnly
               ? "border-amber-400/50 bg-[#1a1206]/95 text-amber-200"
               : "border-amber-500/25 bg-[#120d06]/90 text-amber-300/80 hover:border-amber-400/45 hover:text-amber-100"
@@ -108,7 +108,7 @@ export function HQSidebar({
           aria-pressed={analyticsOnly}
           aria-label="Open analytics sidebar"
         >
-          <span className="block leading-none [writing-mode:vertical-rl]">
+          <span className="block leading-none md:[writing-mode:vertical-rl]">
             ANALYTICS
           </span>
         </button>
@@ -116,11 +116,13 @@ export function HQSidebar({
 
       {open ? (
         <div
-          className={`pointer-events-auto flex h-full flex-col border-l border-cyan-500/20 bg-black/85 shadow-2xl backdrop-blur ${
-            boardLikeWidth ? "w-[min(94vw,1180px)]" : "w-56"
+          className={`pointer-events-auto flex h-full max-h-full flex-col border-l border-cyan-500/20 bg-black/85 shadow-2xl backdrop-blur transition-[width] ${
+            boardLikeWidth
+              ? "w-[min(calc(100vw-max(0.75rem,env(safe-area-inset-left))-max(0.75rem,env(safe-area-inset-right))-2.75rem),1180px)] md:w-[min(94vw,1180px)]"
+              : "w-[min(calc(100vw-max(0.75rem,env(safe-area-inset-left))-max(0.75rem,env(safe-area-inset-right))-2.75rem),360px)] md:w-56"
           }`}
         >
-          <div className="border-b border-cyan-500/15 px-4 py-3">
+          <div className="border-b border-cyan-500/15 px-3 py-3 md:px-4">
             <div className="font-mono text-[10px] font-semibold tracking-[0.32em] text-cyan-300/80">
               {analyticsOnly ? "ANALYTICS" : "HEADQUARTERS"}
             </div>
@@ -162,7 +164,7 @@ export function HQSidebar({
             <div
               role="tablist"
               aria-label="Headquarters panels"
-              className="grid grid-cols-4 border-b border-cyan-500/15"
+              className="grid grid-cols-2 border-b border-cyan-500/15 sm:grid-cols-4"
             >
               {PRIMARY_TABS.map((tab) => {
                 const isActive = tab === activeTab;
@@ -176,7 +178,7 @@ export function HQSidebar({
                     aria-controls={`hq-panel-${tab}`}
                     id={`hq-tab-${tab}`}
                     onClick={() => onTabChange(tab)}
-                    className={`flex items-center justify-center gap-1 border-r border-cyan-500/10 px-2 py-2.5 font-mono text-[11px] uppercase tracking-[0.18em] transition-colors last:border-r-0 ${
+                    className={`flex min-h-11 items-center justify-center gap-1 border-r border-cyan-500/10 px-2 py-2.5 text-center font-mono text-[10px] uppercase tracking-[0.16em] transition-colors even:border-r-0 sm:text-[11px] sm:tracking-[0.18em] sm:even:border-r ${
                       isActive
                         ? "bg-cyan-500/10 text-cyan-100"
                         : "text-white/45 hover:bg-white/5 hover:text-white/80"

--- a/src/features/office/screens/KanbanImmersiveScreen.tsx
+++ b/src/features/office/screens/KanbanImmersiveScreen.tsx
@@ -84,17 +84,17 @@ export function KanbanImmersiveScreen({
       role="dialog"
       aria-modal="true"
       aria-label="Kanban Board"
-      className="fixed inset-0 z-50 flex items-center justify-center"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-3 py-3 safe-area-pad sm:px-6 sm:py-6"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="relative">
+      <div className="relative flex h-full w-full items-center justify-center">
         <button
           type="button"
           onClick={onClose}
           aria-label="Close Kanban Board"
-          className="absolute -right-5 -top-5 z-10 flex h-10 w-10 items-center justify-center rounded-full border border-amber-400/20 bg-[#0e0b07]/90 text-amber-200/70 backdrop-blur-sm transition-colors hover:border-amber-400/40 hover:text-white"
+          className="absolute right-2 top-2 z-10 flex h-11 w-11 items-center justify-center rounded-full border border-amber-400/20 bg-[#0e0b07]/90 text-amber-200/70 backdrop-blur-sm transition-colors hover:border-amber-400/40 hover:text-white sm:-right-5 sm:-top-5 sm:h-10 sm:w-10"
         >
           <X className="h-4 w-4" />
         </button>
@@ -102,7 +102,7 @@ export function KanbanImmersiveScreen({
         <div
           ref={dialogRef}
           tabIndex={-1}
-          className="flex h-[min(75vh,800px)] w-[min(80vw,1280px)] flex-col overflow-hidden rounded-2xl border border-amber-500/20 bg-[#0e0b07]/85 shadow-2xl outline-none backdrop-blur-md"
+          className="flex h-full max-h-[min(100%,860px)] w-full max-w-[1280px] flex-col overflow-hidden rounded-2xl border border-amber-500/20 bg-[#0e0b07]/85 shadow-2xl outline-none backdrop-blur-md sm:h-[min(82vh,860px)] sm:w-[min(94vw,1280px)]"
         >
           <div className="min-h-0 flex-1">
           <TaskBoardView

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -4217,7 +4217,7 @@ export function OfficeScreen({
       ) : null}
       {showGatewayConnectOverlay ? (
         <div className="pointer-events-auto absolute inset-0 z-50 flex items-start justify-center overflow-y-auto bg-[#120a05]/76 px-3 py-4 safe-area-pad sm:px-4 sm:py-10">
-          <div className="max-h-full w-full max-w-[860px] overflow-hidden rounded-2xl border border-amber-900/55 bg-[#120a05]/98 p-3 shadow-2xl sm:p-4">
+          <div className="w-full max-w-[860px] rounded-2xl border border-amber-900/55 bg-[#120a05]/98 p-3 shadow-2xl sm:p-4">
             <GatewayConnectScreen
               gatewayUrl={gatewayUrl}
               token={token}

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -4216,8 +4216,8 @@ export function OfficeScreen({
         </div>
       ) : null}
       {showGatewayConnectOverlay ? (
-        <div className="pointer-events-auto absolute inset-0 z-50 flex items-start justify-center bg-[#120a05]/76 px-4 py-10">
-          <div className="w-full max-w-[860px] rounded-2xl border border-amber-900/55 bg-[#120a05]/98 p-3 shadow-2xl">
+        <div className="pointer-events-auto absolute inset-0 z-50 flex items-start justify-center overflow-y-auto bg-[#120a05]/76 px-3 py-4 safe-area-pad sm:px-4 sm:py-10">
+          <div className="max-h-full w-full max-w-[860px] overflow-hidden rounded-2xl border border-amber-900/55 bg-[#120a05]/98 p-3 shadow-2xl sm:p-4">
             <GatewayConnectScreen
               gatewayUrl={gatewayUrl}
               token={token}
@@ -4470,16 +4470,16 @@ export function OfficeScreen({
       </section>
 
       {showEmptyFleetBanner ? (
-        <div className="pointer-events-none fixed left-1/2 top-16 z-40 w-full max-w-xl -translate-x-1/2 px-4">
+        <div className="pointer-events-none fixed left-1/2 top-[max(4rem,calc(env(safe-area-inset-top)+1rem))] z-40 w-full max-w-xl -translate-x-1/2 px-3 sm:px-4">
           <div className="pointer-events-auto rounded-lg border border-amber-400/35 bg-black/80 px-4 py-3 shadow-2xl backdrop-blur">
-            <div className="flex items-center justify-between gap-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-amber-200/80">
                   Office fleet status
                 </p>
                 <p className="mt-1 text-sm text-amber-50">{emptyFleetMessage}</p>
               </div>
-              <div className="flex shrink-0 items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2 sm:shrink-0 sm:justify-end">
                 <button
                   type="button"
                   className="ui-btn-secondary px-3 py-2 text-xs font-semibold tracking-[0.05em] text-foreground"
@@ -4650,10 +4650,10 @@ export function OfficeScreen({
       ) : null}
 
       {showOpenClawConsole ? (
-        <section className="pointer-events-auto fixed bottom-3 left-3 z-30 flex w-[520px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded border border-cyan-500/25 bg-black/78 shadow-2xl backdrop-blur">
-          <div className="flex items-center justify-between border-b border-cyan-500/15 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-cyan-200/80">
+        <section className="pointer-events-auto fixed bottom-[max(0.75rem,env(safe-area-inset-bottom))] left-[max(0.75rem,env(safe-area-inset-left))] z-30 flex w-[min(520px,calc(100vw-max(1.5rem,calc(env(safe-area-inset-left)+env(safe-area-inset-right)+1.5rem))))] max-w-[calc(100vw-max(1.5rem,calc(env(safe-area-inset-left)+env(safe-area-inset-right)+1.5rem)))] flex-col overflow-hidden rounded border border-cyan-500/25 bg-black/78 shadow-2xl backdrop-blur">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-cyan-500/15 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-cyan-200/80">
             <span>OpenClaw Event Console</span>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-end gap-2">
               <span className="text-[10px] text-cyan-100/45">
                 agents {state.agents.length} | events{" "}
                 {filteredOpenClawLogEntries.length}/{openClawLogEntries.length}
@@ -4697,7 +4697,7 @@ export function OfficeScreen({
             </div>
           </div>
           {!openClawConsoleCollapsed ? (
-            <div className="flex h-[320px] flex-col gap-3 overflow-y-auto bg-[#02090b]/96 px-3 py-2 font-mono text-[10px] leading-4">
+            <div className="flex h-[min(320px,42dvh)] flex-col gap-3 overflow-y-auto bg-[#02090b]/96 px-3 py-2 font-mono text-[10px] leading-4 sm:h-[320px]">
             <div className="rounded border border-cyan-500/10 bg-cyan-950/10 p-2">
               <div className="flex items-center gap-2">
                 <input
@@ -4862,16 +4862,15 @@ export function OfficeScreen({
       ) : null}
 
       <div
-        className={`fixed bottom-3 z-30 flex flex-col items-end gap-2 ${sidebarOpen ? "right-84" : "right-3"} ${
+        className={`fixed bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-30 flex flex-col items-end gap-2 ${sidebarOpen ? "right-[max(0.75rem,env(safe-area-inset-right))] md:right-84" : "right-[max(0.75rem,env(safe-area-inset-right))]"} ${
           debugEnabled ? "hidden" : ""
         }`}
       >
         {chatOpen && (
           <div
-            className="flex overflow-hidden rounded border border-white/10 bg-[#0e0a04] shadow-2xl"
-            style={{ width: 560, height: 520 }}
+            className="flex h-[min(75dvh,520px)] w-[min(560px,calc(100vw-max(1.5rem,calc(env(safe-area-inset-left)+env(safe-area-inset-right)+1.5rem))))] max-w-[calc(100vw-max(1.5rem,calc(env(safe-area-inset-left)+env(safe-area-inset-right)+1.5rem)))] flex-col overflow-hidden rounded border border-white/10 bg-[#0e0a04] shadow-2xl sm:h-[520px] md:flex-row"
           >
-            <div className="flex w-44 shrink-0 flex-col border-r border-white/10">
+            <div className="flex max-h-40 shrink-0 flex-col border-b border-white/10 md:max-h-none md:w-44 md:border-b-0 md:border-r">
               <div className="flex items-center justify-between border-b border-white/10 px-3 py-2">
                 <span className="font-mono text-[11px] font-semibold uppercase tracking-widest text-white/60">
                   Agents
@@ -4880,13 +4879,14 @@ export function OfficeScreen({
                   {chatRosterEntries.length}
                 </span>
               </div>
-              <div className="flex-1 overflow-y-auto">
+              <div className="flex-1 overflow-x-auto overflow-y-auto md:overflow-y-auto">
                 {chatRosterEntries.length === 0 ? (
                   <div className="px-3 py-4 font-mono text-[11px] text-white/30">
                     No agents.
                   </div>
                 ) : (
-                  chatRosterEntries.map((agent) => {
+                  <div className="flex min-w-max flex-row md:min-w-0 md:flex-col">
+                    {chatRosterEntries.map((agent) => {
                     const isSelected = agent.id === selectedChatAgentId;
                     const isRunning = agent.isRunning;
                     return (
@@ -4894,7 +4894,7 @@ export function OfficeScreen({
                         key={agent.id}
                         type="button"
                         onClick={() => handleOpenAgentChat(agent.id)}
-                        className={`flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors ${
+                        className={`flex min-w-40 items-center gap-2 px-3 py-2.5 text-left transition-colors md:w-full md:min-w-0 ${
                           isSelected
                             ? "bg-white/10 text-white"
                             : "text-white/50 hover:bg-white/5 hover:text-white/80"
@@ -4916,7 +4916,8 @@ export function OfficeScreen({
                         </span>
                       </button>
                     );
-                  })
+                  })}
+                  </div>
                 )}
               </div>
             </div>
@@ -5014,7 +5015,7 @@ export function OfficeScreen({
         <button
           type="button"
           onClick={() => setChatOpen((prev) => !prev)}
-          className="flex items-center gap-1.5 rounded border border-amber-700/50 bg-[#0e0a04]/90 px-3 py-1.5 font-mono text-[11px] font-medium tracking-wider text-amber-500/80 shadow-lg backdrop-blur transition-colors hover:border-amber-600/70 hover:text-amber-400"
+          className="flex min-h-11 items-center gap-1.5 rounded border border-amber-700/50 bg-[#0e0a04]/90 px-3 py-2 font-mono text-[11px] font-medium tracking-wider text-amber-500/80 shadow-lg backdrop-blur transition-colors hover:border-amber-600/70 hover:text-amber-400"
         >
           {chatOpen ? (
             <>
@@ -5036,9 +5037,9 @@ export function OfficeScreen({
       </div>
 
       {mainVoiceState !== "idle" || mainVoiceError ? (
-        <div className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center">
+        <div className="pointer-events-none fixed inset-x-0 bottom-[max(4.5rem,calc(env(safe-area-inset-bottom)+4rem))] z-40 flex justify-center px-3 sm:bottom-6">
           <div
-            className={`flex min-w-[220px] items-center gap-3 rounded-full border px-4 py-3 font-mono text-[12px] shadow-2xl backdrop-blur ${
+            className={`flex w-full max-w-[min(420px,100%)] min-w-0 items-center gap-3 rounded-3xl border px-4 py-3 font-mono text-[12px] shadow-2xl backdrop-blur sm:min-w-[220px] sm:rounded-full ${
               mainVoiceError
                 ? "border-red-500/45 bg-red-950/75 text-red-100"
                 : "border-cyan-400/35 bg-black/70 text-white"
@@ -5078,7 +5079,7 @@ export function OfficeScreen({
       ) : null}
 
       {debugEnabled ? (
-        <section className="fixed bottom-3 right-3 z-50 max-h-[45vh] w-[560px] overflow-auto rounded border border-slate-700 bg-black/90 p-3 font-mono text-[11px] text-slate-100">
+        <section className="fixed bottom-[max(0.75rem,env(safe-area-inset-bottom))] right-[max(0.75rem,env(safe-area-inset-right))] z-50 max-h-[45vh] w-[min(560px,calc(100vw-max(1.5rem,calc(env(safe-area-inset-left)+env(safe-area-inset-right)+1.5rem))))] overflow-auto rounded border border-slate-700 bg-black/90 p-3 font-mono text-[11px] text-slate-100">
           <div className="mb-2 font-semibold text-cyan-300">office debug</div>
           <div className="mb-2 text-slate-400">
             status: {status} | agents: {state.agents.length}

--- a/src/features/office/tasks/TaskBoardView.tsx
+++ b/src/features/office/tasks/TaskBoardView.tsx
@@ -90,15 +90,15 @@ export function TaskBoardView({
 }) {
   return (
     <section className="flex h-full min-h-0 flex-col bg-transparent text-white">
-      <div className="border-b border-cyan-500/10 bg-[#070b11]/22 px-4 py-3 backdrop-blur-[1px]">
-        <div className="flex items-start justify-between gap-3">
+      <div className="border-b border-cyan-500/10 bg-[#070b11]/22 px-3 py-3 backdrop-blur-[1px] sm:px-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-cyan-200/80">
               {title}
             </div>
             <div className="mt-1 font-mono text-[11px] text-white/40">{subtitle}</div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 sm:justify-end">
             <button
               type="button"
               onClick={onRefreshCronJobs}
@@ -166,9 +166,13 @@ export function TaskBoardView({
         ) : null}
       </div>
 
-      <div className={`grid min-h-0 flex-1 overflow-hidden ${selectedCard ? "grid-cols-[minmax(0,1fr)_300px]" : "grid-cols-1"}`}>
-        <div className="min-h-0 overflow-auto px-4 py-4">
-          <div className="grid min-w-[700px] grid-cols-5 gap-3">
+      <div
+        className={`grid min-h-0 flex-1 overflow-hidden ${
+          selectedCard ? "grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px]" : "grid-cols-1"
+        }`}
+      >
+        <div className="min-h-0 overflow-auto px-3 py-4 sm:px-4">
+          <div className="grid min-w-[700px] grid-cols-5 gap-3 xl:min-w-0">
             {STATUS_ORDER.map((status) => {
               const cards = cardsByStatus[status];
               return (
@@ -259,8 +263,8 @@ export function TaskBoardView({
         </div>
 
         {selectedCard ? (
-          <aside className="flex min-h-0 flex-col border-l border-white/8 bg-black/25">
-            <div className="flex items-center justify-between border-b border-white/8 px-4 py-3">
+          <aside className="flex min-h-0 max-h-[45dvh] flex-col border-t border-white/8 bg-black/25 xl:max-h-none xl:border-t-0 xl:border-l">
+            <div className="flex items-center justify-between border-b border-white/8 px-3 py-3 sm:px-4">
               <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/45">
                 Task Details
               </div>
@@ -272,7 +276,7 @@ export function TaskBoardView({
                 Close
               </button>
             </div>
-            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4">
+            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-3 py-4 sm:px-4">
               <label className="flex flex-col gap-1">
                 <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/35">
                   Title

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -5230,7 +5230,7 @@ export function RetroOffice3D({
   }, [officeCenterSignal, overviewPreset]);
 
   return (
-    <div className="relative w-full h-full bg-[#1a1008] font-mono text-white overflow-hidden">
+    <div className="relative h-full w-full overflow-hidden bg-[#1a1008] font-mono text-white">
       {/* 3D Canvas — fills everything. */}
       <div
         className="absolute inset-0"
@@ -5904,8 +5904,8 @@ export function RetroOffice3D({
 
       {/* New Idea 2: Camera preset buttons — top left. */}
       {!readOnly && !immersiveOverlayActive ? (
-        <div className="absolute top-3 left-3 z-20 flex flex-col items-start gap-2">
-          <div className="flex items-center gap-1">
+        <div className="absolute left-[max(0.75rem,env(safe-area-inset-left))] top-[max(0.75rem,env(safe-area-inset-top))] z-20 flex max-w-[calc(100vw-max(1.5rem,calc(env(safe-area-inset-left)+env(safe-area-inset-right)+1.5rem)))] flex-col items-start gap-2">
+          <div className="flex flex-wrap items-center gap-1">
             {(
               [
                 {
@@ -5931,7 +5931,7 @@ export function RetroOffice3D({
                 onClick={() => {
                   cameraPresetRef.current = CAMERA_PRESET_MAP[key];
                 }}
-                className="w-7 h-7 flex items-center justify-center rounded-md bg-[#1c1610]/80 text-amber-500/60 border border-amber-900/20 hover:bg-[#2a1e14] hover:text-amber-400 backdrop-blur-sm transition-colors"
+                className="flex h-9 w-9 items-center justify-center rounded-md border border-amber-900/20 bg-[#1c1610]/80 text-amber-500/60 backdrop-blur-sm transition-colors hover:bg-[#2a1e14] hover:text-amber-400 sm:h-7 sm:w-7"
               >
                 {icon}
               </button>
@@ -5941,7 +5941,7 @@ export function RetroOffice3D({
             <button
               type="button"
               onClick={() => setStandupBoardOpen(true)}
-              className="rounded-xl border border-emerald-500/20 bg-[#0b1410]/90 px-3 py-2 text-left shadow-lg backdrop-blur-sm transition-colors hover:border-emerald-400/35 hover:bg-[#102017]/95"
+              className="w-full max-w-[min(19rem,100%)] rounded-xl border border-emerald-500/20 bg-[#0b1410]/90 px-3 py-2 text-left shadow-lg backdrop-blur-sm transition-colors hover:border-emerald-400/35 hover:bg-[#102017]/95 sm:w-auto"
             >
               <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-emerald-200/80">
                 Standup
@@ -5963,7 +5963,7 @@ export function RetroOffice3D({
             <button
               type="button"
               onClick={() => openKanbanBoard(kanbanBoardItem)}
-              className="rounded-xl border border-cyan-500/22 bg-[#09111a]/90 px-3 py-2 text-left shadow-lg backdrop-blur-sm transition-colors hover:border-cyan-300/40 hover:bg-[#0d1b28]/95"
+              className="w-full max-w-[min(19rem,100%)] rounded-xl border border-cyan-500/22 bg-[#09111a]/90 px-3 py-2 text-left shadow-lg backdrop-blur-sm transition-colors hover:border-cyan-300/40 hover:bg-[#0d1b28]/95 sm:w-auto"
             >
               <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan-200/80">
                 Kanban board
@@ -5975,21 +5975,21 @@ export function RetroOffice3D({
 
       {/* Title — top center overlay. */}
       {!immersiveOverlayActive ? (
-        <div className="absolute top-3 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 pointer-events-none select-none z-10">
-          <div className="flex items-center gap-3">
-            <div className="h-px w-12 bg-gradient-to-r from-transparent to-amber-500/40" />
-            <span className="text-sm tracking-[0.3em] text-amber-300/80 font-bold uppercase">
+        <div className="pointer-events-none absolute left-1/2 top-[max(0.75rem,env(safe-area-inset-top))] z-10 flex w-[min(100%-3rem,24rem)] -translate-x-1/2 flex-col items-center gap-2 select-none sm:w-auto">
+          <div className="flex w-full items-center justify-center gap-2 sm:gap-3">
+            <div className="h-px w-6 bg-gradient-to-r from-transparent to-amber-500/40 sm:w-12" />
+            <span className="max-w-full truncate text-center text-xs font-bold uppercase tracking-[0.22em] text-amber-300/80 sm:text-sm sm:tracking-[0.3em]">
               {officeTitle}
             </span>
-            <div className="h-px w-12 bg-gradient-to-l from-transparent to-amber-500/40" />
+            <div className="h-px w-6 bg-gradient-to-l from-transparent to-amber-500/40 sm:w-12" />
           </div>
         </div>
       ) : null}
 
       {/* Agent roster — compact top summary with overflow panel. */}
       {!readOnly && !immersiveOverlayActive ? (
-        <div className="absolute top-10 left-1/2 z-20 -translate-x-1/2">
-          <div className="flex items-center gap-2 rounded-full border border-amber-900/25 bg-[#1c1610]/92 px-2 py-2 shadow-lg backdrop-blur-sm">
+        <div className="absolute left-1/2 top-[calc(max(0.75rem,env(safe-area-inset-top))+2.75rem)] z-20 w-[min(calc(100vw-max(1.5rem,calc(env(safe-area-inset-left)+env(safe-area-inset-right)+1.5rem))),28rem)] -translate-x-1/2 px-1 sm:w-auto sm:px-0">
+          <div className="flex items-center justify-between gap-2 rounded-full border border-amber-900/25 bg-[#1c1610]/92 px-2 py-2 shadow-lg backdrop-blur-sm">
             <div className="flex items-center -space-x-1.5">
               {compactRosterAgents.map((agent) => {
                 const status = agentStatusLookup[agent.id];
@@ -6015,7 +6015,7 @@ export function RetroOffice3D({
                         onAgentEdit?.(agent.id);
                       }
                     }}
-                    className={`relative flex h-8 w-8 items-center justify-center rounded-full border text-[9px] font-bold text-[#120e08] shadow transition-transform hover:-translate-y-0.5 ${
+                    className={`relative flex h-9 w-9 items-center justify-center rounded-full border text-[9px] font-bold text-[#120e08] shadow transition-transform hover:-translate-y-0.5 sm:h-8 sm:w-8 ${
                       spotlightAgentId === agent.id
                         ? "border-amber-200/80 ring-2 ring-amber-200/20"
                         : "border-[#120e08] hover:border-amber-200/50"
@@ -6045,7 +6045,7 @@ export function RetroOffice3D({
                 <button
                   type="button"
                   onClick={() => setAgentRosterOpen(true)}
-                  className="flex h-8 min-w-8 items-center justify-center rounded-full border border-amber-900/30 bg-[#120e08] px-2 text-[10px] font-semibold text-amber-200 transition-colors hover:border-amber-500/40 hover:text-white"
+                  className="flex h-9 min-w-9 items-center justify-center rounded-full border border-amber-900/30 bg-[#120e08] px-2 text-[10px] font-semibold text-amber-200 transition-colors hover:border-amber-500/40 hover:text-white sm:h-8 sm:min-w-8"
                 >
                   +{hiddenAgentCount}
                 </button>
@@ -6055,7 +6055,7 @@ export function RetroOffice3D({
             <button
               type="button"
               onClick={() => setAgentRosterOpen((prev) => !prev)}
-              className="inline-flex items-center gap-2 rounded-full border border-amber-900/25 bg-black/20 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-amber-100 transition-colors hover:border-amber-500/35 hover:text-white"
+              className="inline-flex min-h-9 items-center gap-2 rounded-full border border-amber-900/25 bg-black/20 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-amber-100 transition-colors hover:border-amber-500/35 hover:text-white sm:min-h-8"
             >
               <Users className="h-3.5 w-3.5" />
               <span>{agents.length}</span>
@@ -7028,7 +7028,7 @@ export function RetroOffice3D({
 
       {/* Toolbar — top right. */}
       {!readOnly && !immersiveOverlayActive ? (
-        <div className="absolute top-3 right-3 flex items-center gap-2 z-20">
+        <div className="absolute right-[max(0.75rem,env(safe-area-inset-right))] top-[max(0.75rem,env(safe-area-inset-top))] z-20 flex max-w-[calc(100vw-max(1.5rem,calc(env(safe-area-inset-left)+env(safe-area-inset-right)+1.5rem)))] flex-wrap justify-end gap-2">
           {remoteOfficeEnabled &&
           (remoteOfficeSourceKind === "presence_endpoint"
             ? remoteOfficePresenceUrl.trim().length > 0
@@ -7036,7 +7036,7 @@ export function RetroOffice3D({
             <button
               onClick={() => setSettingsModalOpen(true)}
               title={remoteOfficeStatusText}
-              className="flex h-7 items-center justify-center gap-1 rounded-md border border-white/15 bg-[#120e08]/92 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-white/75 transition-all backdrop-blur-sm hover:border-cyan-400/45 hover:text-cyan-100"
+              className="flex min-h-9 items-center justify-center gap-1 rounded-md border border-white/15 bg-[#120e08]/92 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-white/75 transition-all backdrop-blur-sm hover:border-cyan-400/45 hover:text-cyan-100 sm:min-h-7"
             >
               <span>{remoteOfficeLabel}</span>
             </button>
@@ -7045,14 +7045,14 @@ export function RetroOffice3D({
             <button
               onClick={onAddAgent}
               title="Add agent"
-              className="flex h-7 items-center justify-center gap-1 rounded-md border border-cyan-500/35 bg-[#071018]/92 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-cyan-200 transition-all backdrop-blur-sm hover:border-cyan-400/55 hover:text-white"
+              className="flex min-h-9 items-center justify-center gap-1 rounded-md border border-cyan-500/35 bg-[#071018]/92 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-cyan-200 transition-all backdrop-blur-sm hover:border-cyan-400/55 hover:text-white sm:min-h-7"
             >
               <UserPlus size={12} />
               <span>Add</span>
             </button>
           ) : null}
           <div
-            className={`flex h-7 items-center rounded-md border px-2 text-[10px] font-mono uppercase tracking-[0.12em] ${
+            className={`flex min-h-9 items-center rounded-md border px-2 text-[10px] font-mono uppercase tracking-[0.12em] sm:min-h-7 ${
               gatewayStatus === "connected"
                 ? "border-emerald-400/25 bg-emerald-500/10 text-emerald-100"
                 : gatewayStatus === "connecting"
@@ -7067,14 +7067,14 @@ export function RetroOffice3D({
           <button
             onClick={() => setHeatmapMode((p) => !p)}
             title="Toggle heatmap"
-            className={`w-7 h-7 flex items-center justify-center rounded-md transition-all backdrop-blur-sm border ${heatmapMode ? "bg-amber-500/30 text-amber-300 border-amber-500/50" : "bg-[#1c1610]/80 text-amber-500/40 border-amber-900/20 hover:text-amber-400"}`}
+            className={`flex h-9 w-9 items-center justify-center rounded-md border transition-all backdrop-blur-sm sm:h-7 sm:w-7 ${heatmapMode ? "border-amber-500/50 bg-amber-500/30 text-amber-300" : "border-amber-900/20 bg-[#1c1610]/80 text-amber-500/40 hover:text-amber-400"}`}
           >
             <MapIcon size={12} />
           </button>
           <button
             onClick={() => setTrailMode((p) => !p)}
             title="Toggle trails"
-            className={`w-7 h-7 flex items-center justify-center rounded-md transition-all backdrop-blur-sm border ${trailMode ? "bg-amber-500/30 text-amber-300 border-amber-500/50" : "bg-[#1c1610]/80 text-amber-500/40 border-amber-900/20 hover:text-amber-400"}`}
+            className={`flex h-9 w-9 items-center justify-center rounded-md border transition-all backdrop-blur-sm sm:h-7 sm:w-7 ${trailMode ? "border-amber-500/50 bg-amber-500/30 text-amber-300" : "border-amber-900/20 bg-[#1c1610]/80 text-amber-500/40 hover:text-amber-400"}`}
           >
             <Maximize size={12} />
           </button>
@@ -7228,7 +7228,7 @@ export function RetroOffice3D({
       {!immersiveOverlayActive ? (
         <>
           {/* Ideas 3 + 6 + 8: Mini status bar — bottom left. */}
-          <div className="absolute bottom-3 left-3 flex flex-col items-start gap-1.5 z-10 pointer-events-none select-none">
+          <div className="safe-area-pad-x absolute bottom-[max(0.75rem,env(safe-area-inset-bottom))] left-0 z-10 flex max-w-full flex-col items-start gap-1.5 pointer-events-none select-none">
             {/* Idea 3: Activity feed entries — newest on bottom. */}
             {statusFeedEvents
               .slice(0, 4)
@@ -7236,14 +7236,14 @@ export function RetroOffice3D({
               .map((ev) => (
                 <div
                   key={`${ev.id}-${ev.ts}`}
-                  className="flex items-center gap-2 bg-black/60 backdrop-blur-sm rounded-full px-3 py-1 text-[10px] font-mono"
+                  className="flex max-w-[min(100%,20rem)] items-center gap-2 rounded-full bg-black/60 px-3 py-1 text-[10px] font-mono backdrop-blur-sm"
                 >
-                  <span className="text-amber-400/80 font-semibold">{ev.name}</span>
-                  <span className="text-amber-600/70">{ev.text}</span>
+                  <span className="shrink-0 font-semibold text-amber-400/80">{ev.name}</span>
+                  <span className="truncate text-amber-600/70">{ev.text}</span>
                 </div>
               ))}
             {/* Ideas 6 + 8: Gateway status, agent counts, vibe score. */}
-            <div className="flex items-center gap-3 bg-black/60 backdrop-blur-sm rounded-full px-3 py-1 text-[10px] font-mono">
+            <div className="flex max-w-[min(100%,24rem)] flex-wrap items-center gap-2 rounded-2xl bg-black/60 px-3 py-2 text-[10px] font-mono backdrop-blur-sm sm:rounded-full sm:py-1">
               <span className="text-amber-500/60">
                 {agents.filter((a) => a.status === "working").length} working
               </span>
@@ -7289,7 +7289,7 @@ export function RetroOffice3D({
               {!editMode && !spaceDown && (
                 <>
                   <span className="opacity-30">·</span>
-                  <span className="text-amber-400/40">
+                  <span className="hidden text-amber-400/40 sm:inline">
                     drag · scroll · space+drag · dbl-click
                   </span>
                 </>

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -7082,7 +7082,7 @@ export function RetroOffice3D({
           <button
             onClick={toggleEdit}
             title={editMode ? "Done editing" : "Edit office"}
-            className={`w-7 h-7 flex items-center justify-center rounded-md transition-all backdrop-blur-sm border ${editMode ? "bg-amber-500/30 text-amber-300 border-amber-500/50" : "bg-[#1c1610]/80 text-amber-500/40 border-amber-900/20 hover:text-amber-400"}`}
+            className={`flex h-9 w-9 items-center justify-center rounded-md border transition-all backdrop-blur-sm sm:h-7 sm:w-7 ${editMode ? "border-amber-500/50 bg-amber-500/30 text-amber-300" : "border-amber-900/20 bg-[#1c1610]/80 text-amber-500/40 hover:text-amber-400"}`}
           >
             {editMode ? (
               <Check size={12} strokeWidth={2.5} />
@@ -7093,7 +7093,7 @@ export function RetroOffice3D({
           <button
             onClick={() => setSettingsModalOpen(true)}
             title="Voice reply settings"
-            className={`w-7 h-7 flex items-center justify-center rounded-md transition-all backdrop-blur-sm border ${settingsModalOpen ? "bg-amber-500/30 text-amber-300 border-amber-500/50" : "bg-[#1c1610]/80 text-amber-500/40 border-amber-900/20 hover:text-amber-400"}`}
+            className={`flex h-9 w-9 items-center justify-center rounded-md border transition-all backdrop-blur-sm sm:h-7 sm:w-7 ${settingsModalOpen ? "border-amber-500/50 bg-amber-500/30 text-amber-300" : "border-amber-900/20 bg-[#1c1610]/80 text-amber-500/40 hover:text-amber-400"}`}
           >
             <Settings2 size={12} />
           </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the app shell use a mobile-safe viewport with safe-area-aware spacing
- resize and restack the `/office` connection overlay, HQ rail, chat stack, utility overlays, and scene chrome for phone-width screens
- improve mobile behavior for the kanban/task board, office builder, and local gateway guidance so key controls stay reachable on smaller screens

## Testing
- `npm run build`
- `npm run lint` (repo has pre-existing lint errors outside this change)
- manual mobile walkthrough on `/office` in an iPhone 12 Pro viewport, covering the gateway form, connected office, chat panel, and HQ sidebar

## Artifacts
[Mobile gateway overlay](https://cursor.com/agents/bc-34d5bc3a-1631-41d2-bda4-c9086481be6c/artifacts?path=%2Ftmp%2Fcomputer-use%2F06014.webp)
[Connected mobile office](https://cursor.com/agents/bc-34d5bc3a-1631-41d2-bda4-c9086481be6c/artifacts?path=%2Ftmp%2Fcomputer-use%2F2c4f0.webp)
[Mobile chat panel](https://cursor.com/agents/bc-34d5bc3a-1631-41d2-bda4-c9086481be6c/artifacts?path=%2Ftmp%2Fcomputer-use%2Fcb763.webp)
[Mobile HQ sidebar](https://cursor.com/agents/bc-34d5bc3a-1631-41d2-bda4-c9086481be6c/artifacts?path=%2Ftmp%2Fcomputer-use%2F2a6bd.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34d5bc3a-1631-41d2-bda4-c9086481be6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34d5bc3a-1631-41d2-bda4-c9086481be6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

