### PR TITLE
fix(gateway+server): improve diagnostics for origin/auth rejection and silent upstream reject

### DIFF
--- a/server/gateway-proxy.js
+++ b/server/gateway-proxy.js
@@ -71,7 +71,15 @@ const createFrameRateLimiter = (
 const isUpstreamAllowed = (url) => {
   const allowlist = (process.env.UPSTREAM_ALLOWLIST || "").trim();
   if (!allowlist) {
-    return process.env.NODE_ENV !== "production";
+    if (process.env.NODE_ENV === "production") {
+      console.warn(
+        "[gateway-proxy] refusing upstream connection: UPSTREAM_ALLOWLIST is " +
+          "empty in production. Set UPSTREAM_ALLOWLIST=host1,host2 (comma-" +
+          "separated hostnames) to allow specific upstream hosts."
+      );
+      return false;
+    }
+    return true;
   }
   try {
     const parsed = new URL(url);
@@ -79,8 +87,22 @@ const isUpstreamAllowed = (url) => {
       .split(",")
       .map((h) => h.trim().toLowerCase())
       .filter(Boolean);
-    return allowed.includes(parsed.hostname.toLowerCase());
-  } catch {
+    const hostname = parsed.hostname.toLowerCase();
+    if (!allowed.includes(hostname)) {
+      console.warn(
+        `[gateway-proxy] refusing upstream connection to "${hostname}": host ` +
+          `not in UPSTREAM_ALLOWLIST (${allowlist}). Add the host to the ` +
+          `allowlist if you trust it.`
+      );
+      return false;
+    }
+    return true;
+  } catch (err) {
+    const reason = err && typeof err === "object" && "message" in err ? err.message : "invalid URL";
+    console.warn(
+      `[gateway-proxy] refusing upstream connection: could not parse URL ` +
+        `"${url}" (${reason}).`
+    );
     return false;
   }
 };

--- a/src/lib/gateway/GatewayClient.ts
+++ b/src/lib/gateway/GatewayClient.ts
@@ -558,6 +558,23 @@ const requiresDeviceIdentityHint =
 
 const isGatewayProtocolMismatchError = (error: GatewayResponseError) => {
   if (error.code.trim().toUpperCase() !== "INVALID_REQUEST") return false;
+  // The gateway may provide a structured details.code alongside the
+  // generic INVALID_REQUEST. Known non-protocol rejection codes must
+  // not surface the "possible protocol mismatch" hint, since it
+  // misleads operators whose real problem is origin allowlist, missing
+  // device identity, or upstream policy.
+  const details = error.details;
+  if (details && typeof details === "object") {
+    const code = (details as { code?: unknown }).code;
+    if (typeof code === "string") {
+      const NON_PROTOCOL_DETAIL_CODES = new Set([
+        "CONTROL_UI_ORIGIN_NOT_ALLOWED",
+        "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
+        "UPSTREAM_NOT_ALLOWED",
+      ]);
+      if (NON_PROTOCOL_DETAIL_CODES.has(code)) return false;
+    }
+  }
   const message = error.message.trim();
   if (!message) return false;
   return /minProtocol|maxProtocol/i.test(message);

--- a/src/lib/gateway/GatewayClient.ts
+++ b/src/lib/gateway/GatewayClient.ts
@@ -604,7 +604,12 @@ const formatGatewayError = (error: unknown) => {
   }
   if (error instanceof Error) {
     if (/timed out connecting to the gateway/i.test(error.message)) {
-      return `${error.message} If you are testing locally, an older OpenClaw build may be speaking an incompatible protocol. Try upgrading OpenClaw, using the Hermes adapter, or running \`npm run demo-gateway\`.`;
+      // A local timeout carries no information about why the upstream did
+      // not respond. Suggest the directions the operator can actually check,
+      // without biasing toward a protocol mismatch — that is only one of
+      // several possible root causes (network, origin allowlist, upstream
+      // policy, credentials, nginx idle timeout, ...).
+      return `${error.message} Verify that the gateway is reachable at the configured URL, that origin and credentials meet the gateway's requirements, and (if testing locally with a self-built gateway) consider \`npm run demo-gateway\` to isolate the problem.`;
     }
     return error.message;
   }


### PR DESCRIPTION
# fix(gateway+server): improve diagnostics for origin/auth rejection and silent upstream reject

Fixes #124.

## Summary

Three small, independent fixes that together eliminate an entire class of opaque connection failures when Claw3D is deployed outside of localhost. The issue explains the reproduction in detail; this PR addresses the three root causes.

## Changes

### Commit 1 — `src/lib/gateway/GatewayClient.ts`

Refine `isGatewayProtocolMismatchError` so it no longer flags origin/auth/policy rejections as protocol mismatches.

- Prefer the structured `details.code` when the gateway provides one.
- Treat known non-protocol detail codes (`CONTROL_UI_ORIGIN_NOT_ALLOWED`, `CONTROL_UI_DEVICE_IDENTITY_REQUIRED`, `UPSTREAM_NOT_ALLOWED`) as non-mismatches.
- Keep the existing regex as a fallback, so this is a purely additive refinement for gateways that do not set `details.code`.

Minimal diff: 17 inserted lines, nothing removed.

### Commit 2 — `server/gateway-proxy.js`

Add `console.warn` to every branch of `isUpstreamAllowed` that returns `false`, so operators see the real reason in server logs instead of an opaque browser-side timeout.

- Empty `UPSTREAM_ALLOWLIST` in production — names the env var and the expected format.
- Hostname not in allowlist — names the hostname and the current allowlist contents.
- URL parse error — includes the parse error message.

No behaviour change other than logging. 25 inserted / 3 removed.

### Commit 3 — `src/lib/gateway/GatewayClient.ts`

Refine `formatGatewayError`'s local-timeout branch so it no longer suggests a protocol mismatch as the default explanation for every timeout.

- Replace the "upgrade OpenClaw / try Hermes" suggestion with a neutral pointer to the likely diagnostic paths: gateway URL, reachability, origin, credentials, and `npm run demo-gateway` for local isolation.
- No logic change — only the hint text and a code comment explaining why a local timeout cannot tell the UI anything about the server's protocol version.

Minimal diff: 4 line replacement + 5 comment lines.

## Testing

Verified manually on a production VPS deploy reproducing the scenario in the linked issue:

- **Before:** connection timed out at the browser, UI suggested "possible protocol mismatch", server logs had no trace of the rejection.
- **After:** server logs show `[gateway-proxy] refusing upstream connection: UPSTREAM_ALLOWLIST is empty in production ...` when the env var is missing, and the analogous messages for the other two branches. The UI no longer surfaces the protocol-mismatch hint for origin/auth rejections that set `details.code`.
- After Commit 3, local timeouts (including a deliberately unreachable `CLAW3D_GATEWAY_URL`) no longer surface the protocol-upgrade hint in the UI.

Happy to add unit coverage if there is an existing pattern for `GatewayClient` tests; I did not find one under `tests/unit/` that fits naturally, so left it out to keep the diff scoped.

## Compatibility

- No breaking changes to any exported symbol or public API.
- The `details.code` lookup is fully guarded (`typeof code === "string"` inside `details && typeof details === "object"`), so the behaviour is identical for gateways that do not populate `details` or `details.code`.
- No schema or config changes.
