### PR TITLE
Add configurable office state animation mappings

### DIFF
--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -3187,12 +3187,45 @@ export function OfficeScreen({
     const skillTriggerHoldMaps = buildOfficeSkillTriggerHoldMaps(
       skillTriggers.movementTargetByAgentId,
     );
-    const configuredStateHoldMaps = buildOfficeStateAnimationMappingResult({
-      agents: state.agents,
-      animationState: base,
-      mappings: stateAnimationMappings,
-      nowMs: animationNowMs,
-    });
+    if (stateAnimationMappings.length === 0) {
+      return {
+        ...base,
+        danceUntilByAgentId: danceUntilByAgentId,
+        deskHoldByAgentId: {
+          ...base.deskHoldByAgentId,
+          ...skillTriggerHoldMaps.deskHoldByAgentId,
+        },
+        githubHoldByAgentId: {
+          ...base.githubHoldByAgentId,
+          ...skillTriggerHoldMaps.githubHoldByAgentId,
+        },
+        gymHoldByAgentId: {
+          ...base.gymHoldByAgentId,
+          ...skillTriggerHoldMaps.gymHoldByAgentId,
+        },
+        jukeboxHoldByAgentId: {
+          ...base.jukeboxHoldByAgentId,
+          ...skillTriggerHoldMaps.jukeboxHoldByAgentId,
+        },
+        qaHoldByAgentId: {
+          ...base.qaHoldByAgentId,
+          ...skillTriggerHoldMaps.qaHoldByAgentId,
+        },
+        skillGymHoldByAgentId: {
+          ...base.skillGymHoldByAgentId,
+          ...skillTriggerHoldMaps.skillGymHoldByAgentId,
+        },
+      };
+    }
+    const configuredStateHoldMaps =
+      stateAnimationMappings.length > 0
+        ? buildOfficeStateAnimationMappingResult({
+            agents: state.agents,
+            animationState: base,
+            mappings: stateAnimationMappings,
+            nowMs: animationNowMs,
+          })
+        : null;
 
     return {
       ...base,
@@ -3200,40 +3233,40 @@ export function OfficeScreen({
       deskHoldByAgentId: {
         ...base.deskHoldByAgentId,
         ...skillTriggerHoldMaps.deskHoldByAgentId,
-        ...configuredStateHoldMaps.deskHoldByAgentId,
+        ...(configuredStateHoldMaps?.deskHoldByAgentId ?? {}),
       },
       githubHoldByAgentId: {
         ...base.githubHoldByAgentId,
         ...skillTriggerHoldMaps.githubHoldByAgentId,
-        ...configuredStateHoldMaps.githubHoldByAgentId,
+        ...(configuredStateHoldMaps?.githubHoldByAgentId ?? {}),
       },
       gymHoldByAgentId: {
         ...base.gymHoldByAgentId,
         ...skillTriggerHoldMaps.gymHoldByAgentId,
-        ...configuredStateHoldMaps.gymHoldByAgentId,
+        ...(configuredStateHoldMaps?.gymHoldByAgentId ?? {}),
       },
       jukeboxHoldByAgentId: {
         ...base.jukeboxHoldByAgentId,
         ...skillTriggerHoldMaps.jukeboxHoldByAgentId,
-        ...configuredStateHoldMaps.jukeboxHoldByAgentId,
+        ...(configuredStateHoldMaps?.jukeboxHoldByAgentId ?? {}),
       },
       phoneBoothHoldByAgentId: {
         ...base.phoneBoothHoldByAgentId,
-        ...configuredStateHoldMaps.phoneBoothHoldByAgentId,
+        ...(configuredStateHoldMaps?.phoneBoothHoldByAgentId ?? {}),
       },
       qaHoldByAgentId: {
         ...base.qaHoldByAgentId,
         ...skillTriggerHoldMaps.qaHoldByAgentId,
-        ...configuredStateHoldMaps.qaHoldByAgentId,
+        ...(configuredStateHoldMaps?.qaHoldByAgentId ?? {}),
       },
       smsBoothHoldByAgentId: {
         ...base.smsBoothHoldByAgentId,
-        ...configuredStateHoldMaps.smsBoothHoldByAgentId,
+        ...(configuredStateHoldMaps?.smsBoothHoldByAgentId ?? {}),
       },
       skillGymHoldByAgentId: {
         ...base.skillGymHoldByAgentId,
         ...skillTriggerHoldMaps.skillGymHoldByAgentId,
-        ...configuredStateHoldMaps.skillGymHoldByAgentId,
+        ...(configuredStateHoldMaps?.skillGymHoldByAgentId ?? {}),
       },
     };
   }, [

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -198,6 +198,7 @@ import {
   type OfficePhoneCallRequest,
   type OfficeTextMessageRequest,
 } from "@/lib/office/eventTriggers";
+import { buildOfficeStateAnimationMappingResult } from "@/lib/office/stateAnimationMapping";
 import { buildOfficeSkillTriggerHoldMaps } from "@/lib/office/places";
 import type { MockPhoneCallScenario } from "@/lib/office/call/types";
 import type { MockTextMessageScenario } from "@/lib/office/text/types";
@@ -1320,6 +1321,7 @@ export function OfficeScreen({
   const {
     loaded: officeTitleLoaded,
     title: officeTitle,
+    stateAnimationMappings,
     remoteOfficeEnabled,
     remoteOfficeSourceKind,
     remoteOfficeLabel,
@@ -3185,6 +3187,12 @@ export function OfficeScreen({
     const skillTriggerHoldMaps = buildOfficeSkillTriggerHoldMaps(
       skillTriggers.movementTargetByAgentId,
     );
+    const configuredStateHoldMaps = buildOfficeStateAnimationMappingResult({
+      agents: state.agents,
+      animationState: base,
+      mappings: stateAnimationMappings,
+      nowMs: animationNowMs,
+    });
 
     return {
       ...base,
@@ -3192,26 +3200,40 @@ export function OfficeScreen({
       deskHoldByAgentId: {
         ...base.deskHoldByAgentId,
         ...skillTriggerHoldMaps.deskHoldByAgentId,
+        ...configuredStateHoldMaps.deskHoldByAgentId,
       },
       githubHoldByAgentId: {
         ...base.githubHoldByAgentId,
         ...skillTriggerHoldMaps.githubHoldByAgentId,
+        ...configuredStateHoldMaps.githubHoldByAgentId,
       },
       gymHoldByAgentId: {
         ...base.gymHoldByAgentId,
         ...skillTriggerHoldMaps.gymHoldByAgentId,
+        ...configuredStateHoldMaps.gymHoldByAgentId,
       },
       jukeboxHoldByAgentId: {
         ...base.jukeboxHoldByAgentId,
         ...skillTriggerHoldMaps.jukeboxHoldByAgentId,
+        ...configuredStateHoldMaps.jukeboxHoldByAgentId,
+      },
+      phoneBoothHoldByAgentId: {
+        ...base.phoneBoothHoldByAgentId,
+        ...configuredStateHoldMaps.phoneBoothHoldByAgentId,
       },
       qaHoldByAgentId: {
         ...base.qaHoldByAgentId,
         ...skillTriggerHoldMaps.qaHoldByAgentId,
+        ...configuredStateHoldMaps.qaHoldByAgentId,
+      },
+      smsBoothHoldByAgentId: {
+        ...base.smsBoothHoldByAgentId,
+        ...configuredStateHoldMaps.smsBoothHoldByAgentId,
       },
       skillGymHoldByAgentId: {
         ...base.skillGymHoldByAgentId,
         ...skillTriggerHoldMaps.skillGymHoldByAgentId,
+        ...configuredStateHoldMaps.skillGymHoldByAgentId,
       },
     };
   }, [
@@ -3220,6 +3242,7 @@ export function OfficeScreen({
     marketplaceGymHoldByAgentId,
     officeTriggerState,
     skillTriggers.movementTargetByAgentId,
+    stateAnimationMappings,
     state.agents,
   ]);
   const {

--- a/src/hooks/useStudioOfficePreference.ts
+++ b/src/hooks/useStudioOfficePreference.ts
@@ -7,6 +7,7 @@ import {
   resolveOfficePreferencePublic,
   type StudioOfficePreferencePublic,
 } from "@/lib/studio/settings";
+import type { OfficeStateAnimationMapping } from "@/lib/office/stateMappingConfig";
 
 type UseStudioOfficePreferenceParams = {
   gatewayUrl: string;
@@ -193,10 +194,30 @@ export const useStudioOfficePreference = ({
     [gatewayUrl, settingsCoordinator]
   );
 
+  const setStateAnimationMappings = useCallback(
+    (stateAnimationMappings: OfficeStateAnimationMapping[]) => {
+      const gatewayKey = gatewayUrl.trim();
+      setPreference((current) => ({ ...current, stateAnimationMappings }));
+      if (!gatewayKey) return;
+      settingsCoordinator.schedulePatch(
+        {
+          office: {
+            [gatewayKey]: {
+              stateAnimationMappings,
+            },
+          },
+        },
+        0
+      );
+    },
+    [gatewayUrl, settingsCoordinator]
+  );
+
   return {
     loaded,
     preference,
     title: preference.title,
+    stateAnimationMappings: preference.stateAnimationMappings,
     remoteOfficeEnabled: preference.remoteOfficeEnabled,
     remoteOfficeSourceKind: preference.remoteOfficeSourceKind,
     remoteOfficeLabel: preference.remoteOfficeLabel,
@@ -210,5 +231,6 @@ export const useStudioOfficePreference = ({
     setRemoteOfficePresenceUrl,
     setRemoteOfficeGatewayUrl,
     setRemoteOfficeToken,
+    setStateAnimationMappings,
   };
 };

--- a/src/lib/office/stateAnimationMapping.ts
+++ b/src/lib/office/stateAnimationMapping.ts
@@ -1,0 +1,125 @@
+import type { AgentState } from "@/features/agents/state/store";
+import type { OfficeAnimationState } from "@/lib/office/eventTriggers";
+import {
+  normalizeOfficeStateToken,
+  type OfficeStateAnimationMapping,
+  type OfficeStateAnimationTarget,
+} from "@/lib/office/stateMappingConfig";
+
+type BooleanByAgentId = Record<string, boolean>;
+
+type OfficeStateAnimationHoldMaps = {
+  deskHoldByAgentId: BooleanByAgentId;
+  githubHoldByAgentId: BooleanByAgentId;
+  gymHoldByAgentId: BooleanByAgentId;
+  jukeboxHoldByAgentId: BooleanByAgentId;
+  qaHoldByAgentId: BooleanByAgentId;
+  smsBoothHoldByAgentId: BooleanByAgentId;
+  phoneBoothHoldByAgentId: BooleanByAgentId;
+  skillGymHoldByAgentId: BooleanByAgentId;
+};
+
+export type OfficeStateAnimationMappingResult = OfficeStateAnimationHoldMaps & {
+  matchedMappingByAgentId: Record<string, OfficeStateAnimationMapping>;
+};
+
+const emptyHoldMaps = (): OfficeStateAnimationHoldMaps => ({
+  deskHoldByAgentId: {},
+  githubHoldByAgentId: {},
+  gymHoldByAgentId: {},
+  jukeboxHoldByAgentId: {},
+  qaHoldByAgentId: {},
+  smsBoothHoldByAgentId: {},
+  phoneBoothHoldByAgentId: {},
+  skillGymHoldByAgentId: {},
+});
+
+const setTargetHold = (
+  maps: OfficeStateAnimationHoldMaps,
+  agentId: string,
+  target: OfficeStateAnimationTarget,
+) => {
+  if (target === "desk") maps.deskHoldByAgentId[agentId] = true;
+  if (target === "server_room") maps.githubHoldByAgentId[agentId] = true;
+  if (target === "gym") {
+    maps.gymHoldByAgentId[agentId] = true;
+    maps.skillGymHoldByAgentId[agentId] = true;
+  }
+  if (target === "jukebox") maps.jukeboxHoldByAgentId[agentId] = true;
+  if (target === "qa_lab") maps.qaHoldByAgentId[agentId] = true;
+  if (target === "sms_booth") maps.smsBoothHoldByAgentId[agentId] = true;
+  if (target === "phone_booth") maps.phoneBoothHoldByAgentId[agentId] = true;
+};
+
+const deriveAgentStateTokens = (
+  agent: AgentState,
+  animationState: Pick<
+    OfficeAnimationState,
+    | "awaitingApprovalByAgentId"
+    | "streamingByAgentId"
+    | "thinkingByAgentId"
+    | "workingUntilByAgentId"
+  >,
+  nowMs: number,
+): string[] => {
+  const tokens = new Set<string>();
+  tokens.add(normalizeOfficeStateToken(agent.status));
+  if (agent.runId || agent.status === "running") tokens.add("executing");
+  if ((animationState.workingUntilByAgentId[agent.agentId] ?? 0) > nowMs) {
+    tokens.add("working");
+    tokens.add("executing");
+  }
+  if (animationState.streamingByAgentId[agent.agentId] || agent.streamText?.trim()) {
+    tokens.add("writing");
+  }
+  if (animationState.thinkingByAgentId[agent.agentId] || agent.thinkingTrace?.trim()) {
+    tokens.add("thinking");
+  }
+  if (animationState.awaitingApprovalByAgentId[agent.agentId] || agent.awaitingUserInput) {
+    tokens.add("waiting");
+    tokens.add("approval_pending");
+  }
+  if (agent.status === "error") tokens.add("error");
+  return [...tokens].filter(Boolean);
+};
+
+export const buildOfficeStateAnimationMappingResult = (params: {
+  agents: AgentState[];
+  animationState: Pick<
+    OfficeAnimationState,
+    | "awaitingApprovalByAgentId"
+    | "streamingByAgentId"
+    | "thinkingByAgentId"
+    | "workingUntilByAgentId"
+  >;
+  mappings: OfficeStateAnimationMapping[];
+  nowMs?: number;
+}): OfficeStateAnimationMappingResult => {
+  const maps = emptyHoldMaps();
+  const matchedMappingByAgentId: Record<string, OfficeStateAnimationMapping> = {};
+  const enabledMappings = params.mappings
+    .filter((mapping) => mapping.enabled && mapping.animationTarget !== "none")
+    .sort((left, right) => right.priority - left.priority);
+  const mappingByState = new Map<string, OfficeStateAnimationMapping>();
+  for (const mapping of enabledMappings) {
+    if (!mappingByState.has(mapping.sourceState)) {
+      mappingByState.set(mapping.sourceState, mapping);
+    }
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  for (const agent of params.agents) {
+    const tokens = deriveAgentStateTokens(agent, params.animationState, nowMs);
+    const matched = tokens
+      .map((token) => mappingByState.get(token))
+      .find((mapping): mapping is OfficeStateAnimationMapping => Boolean(mapping));
+    if (!matched) continue;
+    matchedMappingByAgentId[agent.agentId] = matched;
+    setTargetHold(maps, agent.agentId, matched.animationTarget);
+  }
+
+  return {
+    ...maps,
+    matchedMappingByAgentId,
+  };
+};

--- a/src/lib/office/stateMappingConfig.ts
+++ b/src/lib/office/stateMappingConfig.ts
@@ -1,0 +1,198 @@
+export const OFFICE_STATE_ANIMATION_TARGETS = [
+  "none",
+  "desk",
+  "server_room",
+  "gym",
+  "jukebox",
+  "qa_lab",
+  "sms_booth",
+  "phone_booth",
+] as const;
+
+export type OfficeStateAnimationTarget =
+  (typeof OFFICE_STATE_ANIMATION_TARGETS)[number];
+
+export const OFFICE_STATE_EFFECT_IDS = [
+  "none",
+  "confetti",
+  "alarm",
+  "doorbell",
+] as const;
+
+export type OfficeStateEffectId = (typeof OFFICE_STATE_EFFECT_IDS)[number];
+
+export type OfficeStateAnimationMapping = {
+  id: string;
+  sourceState: string;
+  label: string;
+  animationTarget: OfficeStateAnimationTarget;
+  effect: OfficeStateEffectId;
+  soundCueId: string | null;
+  priority: number;
+  enabled: boolean;
+};
+
+export type OfficeStateAnimationMappingPatch = Partial<
+  Omit<OfficeStateAnimationMapping, "id">
+> & {
+  id?: string | null;
+};
+
+export type OfficeStateAnimationHoldMaps = {
+  deskHoldByAgentId: Record<string, boolean>;
+  githubHoldByAgentId: Record<string, boolean>;
+  gymHoldByAgentId: Record<string, boolean>;
+  jukeboxHoldByAgentId: Record<string, boolean>;
+  qaHoldByAgentId: Record<string, boolean>;
+  smsBoothHoldByAgentId: Record<string, boolean>;
+  phoneBoothHoldByAgentId: Record<string, boolean>;
+};
+
+export type OfficeStateMappingAgentSnapshot = {
+  agentId: string;
+  status?: string | null;
+  streamText?: string | null;
+  thinkingTrace?: string | null;
+  awaitingUserInput?: boolean | null;
+  latestOverrideKind?: string | null;
+};
+
+const MAX_STATE_MAPPINGS = 64;
+const MAX_STATE_TOKEN_LENGTH = 64;
+const MAX_LABEL_LENGTH = 80;
+const MAX_SOUND_CUE_ID_LENGTH = 80;
+
+export const normalizeOfficeStateToken = (value: unknown): string => {
+  if (typeof value !== "string") return "";
+  return value.trim().toLowerCase().replace(/\s+/g, "_").slice(0, MAX_STATE_TOKEN_LENGTH);
+};
+
+const coerceString = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : "";
+
+const normalizeMappingId = (value: unknown, fallback: string): string => {
+  const raw = coerceString(value) || fallback;
+  const normalized = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return normalized || fallback;
+};
+
+export const isOfficeStateAnimationTarget = (
+  value: unknown,
+): value is OfficeStateAnimationTarget =>
+  typeof value === "string" &&
+  OFFICE_STATE_ANIMATION_TARGETS.includes(value as OfficeStateAnimationTarget);
+
+export const isOfficeStateEffectId = (
+  value: unknown,
+): value is OfficeStateEffectId =>
+  typeof value === "string" &&
+  OFFICE_STATE_EFFECT_IDS.includes(value as OfficeStateEffectId);
+
+const normalizePriority = (value: unknown, fallback = 50): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.min(100, Math.round(value)));
+};
+
+export const normalizeOfficeStateAnimationMappings = (
+  value: unknown,
+  fallback: OfficeStateAnimationMapping[] = [],
+): OfficeStateAnimationMapping[] => {
+  const entries = Array.isArray(value) ? value : fallback;
+  const seenIds = new Set<string>();
+  const mappings: OfficeStateAnimationMapping[] = [];
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    const sourceState = normalizeOfficeStateToken(record.sourceState);
+    if (!sourceState) continue;
+    const fallbackId = `state-${sourceState}`;
+    let id = normalizeMappingId(record.id, fallbackId);
+    if (seenIds.has(id)) {
+      id = `${id}-${mappings.length + 1}`;
+    }
+    seenIds.add(id);
+    const label = (coerceString(record.label) || sourceState).slice(0, MAX_LABEL_LENGTH);
+    const animationTarget = isOfficeStateAnimationTarget(record.animationTarget)
+      ? record.animationTarget
+      : "none";
+    const effect = isOfficeStateEffectId(record.effect) ? record.effect : "none";
+    const soundCueId = coerceString(record.soundCueId).slice(0, MAX_SOUND_CUE_ID_LENGTH) || null;
+
+    mappings.push({
+      id,
+      sourceState,
+      label,
+      animationTarget,
+      effect,
+      soundCueId,
+      priority: normalizePriority(record.priority),
+      enabled: typeof record.enabled === "boolean" ? record.enabled : true,
+    });
+
+    if (mappings.length >= MAX_STATE_MAPPINGS) break;
+  }
+
+  return mappings;
+};
+
+const createEmptyOfficeStateAnimationHoldMaps = (): OfficeStateAnimationHoldMaps => ({
+  deskHoldByAgentId: {},
+  githubHoldByAgentId: {},
+  gymHoldByAgentId: {},
+  jukeboxHoldByAgentId: {},
+  qaHoldByAgentId: {},
+  smsBoothHoldByAgentId: {},
+  phoneBoothHoldByAgentId: {},
+});
+
+const resolveAgentSourceStateTokens = (
+  agent: OfficeStateMappingAgentSnapshot,
+): Set<string> => {
+  const tokens = new Set<string>();
+  const status = normalizeOfficeStateToken(agent.status);
+  if (status) tokens.add(status);
+  if (agent.awaitingUserInput) tokens.add("waiting");
+  if (agent.streamText?.trim()) tokens.add("writing");
+  if (agent.thinkingTrace?.trim()) tokens.add("thinking");
+  const overrideKind = normalizeOfficeStateToken(agent.latestOverrideKind);
+  if (overrideKind) tokens.add(overrideKind);
+  return tokens;
+};
+
+export const buildOfficeStateMappingHoldMaps = (
+  agents: OfficeStateMappingAgentSnapshot[],
+  mappings: OfficeStateAnimationMapping[],
+): OfficeStateAnimationHoldMaps => {
+  const holds = createEmptyOfficeStateAnimationHoldMaps();
+  const enabledMappings = mappings
+    .filter((mapping) => mapping.enabled && mapping.animationTarget !== "none")
+    .sort((a, b) => b.priority - a.priority);
+
+  for (const agent of agents) {
+    const tokens = resolveAgentSourceStateTokens(agent);
+    const mapping = enabledMappings.find((entry) => tokens.has(entry.sourceState));
+    if (!mapping) continue;
+    if (mapping.animationTarget === "desk") {
+      holds.deskHoldByAgentId[agent.agentId] = true;
+    } else if (mapping.animationTarget === "server_room") {
+      holds.githubHoldByAgentId[agent.agentId] = true;
+    } else if (mapping.animationTarget === "gym") {
+      holds.gymHoldByAgentId[agent.agentId] = true;
+    } else if (mapping.animationTarget === "jukebox") {
+      holds.jukeboxHoldByAgentId[agent.agentId] = true;
+    } else if (mapping.animationTarget === "qa_lab") {
+      holds.qaHoldByAgentId[agent.agentId] = true;
+    } else if (mapping.animationTarget === "sms_booth") {
+      holds.smsBoothHoldByAgentId[agent.agentId] = true;
+    } else if (mapping.animationTarget === "phone_booth") {
+      holds.phoneBoothHoldByAgentId[agent.agentId] = true;
+    }
+  }
+
+  return holds;
+};

--- a/src/lib/studio/settings.ts
+++ b/src/lib/studio/settings.ts
@@ -22,6 +22,11 @@ import {
   type TaskBoardPreference,
   type TaskBoardPreferencePatch,
 } from "@/features/office/tasks/types";
+import {
+  normalizeOfficeStateAnimationMappings,
+  type OfficeStateAnimationMapping,
+  type OfficeStateAnimationMappingPatch,
+} from "@/lib/office/stateMappingConfig";
 
 export type StudioGatewaySettings = {
   url: string;
@@ -145,6 +150,7 @@ export type StudioVoiceRepliesPreferencePatch = {
 
 export type StudioOfficePreference = {
   title: string;
+  stateAnimationMappings: OfficeStateAnimationMapping[];
   remoteOfficeEnabled: boolean;
   remoteOfficeSourceKind: "presence_endpoint" | "openclaw_gateway";
   remoteOfficeLabel: string;
@@ -162,6 +168,7 @@ export type StudioOfficePreference = {
 
 export type StudioOfficePreferencePublic = {
   title: string;
+  stateAnimationMappings: OfficeStateAnimationMapping[];
   remoteOfficeEnabled: boolean;
   remoteOfficeSourceKind: "presence_endpoint" | "openclaw_gateway";
   remoteOfficeLabel: string;
@@ -179,6 +186,7 @@ export type StudioOfficePreferencePublic = {
 
 export type StudioOfficePreferencePatch = {
   title?: string | null;
+  stateAnimationMappings?: OfficeStateAnimationMappingPatch[] | null;
   remoteOfficeEnabled?: boolean;
   remoteOfficeSourceKind?: "presence_endpoint" | "openclaw_gateway";
   remoteOfficeLabel?: string | null;
@@ -608,6 +616,7 @@ const normalizeCompanyRoleTitles = (value: unknown, fallback: string[] = []) => 
 
 export const defaultStudioOfficePreference = (): StudioOfficePreference => ({
   title: DEFAULT_OFFICE_TITLE,
+  stateAnimationMappings: [],
   remoteOfficeEnabled: false,
   remoteOfficeSourceKind: DEFAULT_REMOTE_OFFICE_SOURCE_KIND,
   remoteOfficeLabel: DEFAULT_REMOTE_OFFICE_LABEL,
@@ -626,6 +635,7 @@ export const defaultStudioOfficePreference = (): StudioOfficePreference => ({
 export const defaultStudioOfficePreferencePublic =
   (): StudioOfficePreferencePublic => ({
     title: DEFAULT_OFFICE_TITLE,
+    stateAnimationMappings: [],
     remoteOfficeEnabled: false,
     remoteOfficeSourceKind: DEFAULT_REMOTE_OFFICE_SOURCE_KIND,
     remoteOfficeLabel: DEFAULT_REMOTE_OFFICE_LABEL,
@@ -645,6 +655,7 @@ export const sanitizeStudioOfficePreference = (
   value: StudioOfficePreference
 ): StudioOfficePreferencePublic => ({
   title: value.title,
+  stateAnimationMappings: value.stateAnimationMappings,
   remoteOfficeEnabled: value.remoteOfficeEnabled,
   remoteOfficeSourceKind: value.remoteOfficeSourceKind,
   remoteOfficeLabel: value.remoteOfficeLabel,
@@ -1171,6 +1182,10 @@ const normalizeOfficePreference = (
   if (!isRecord(value)) return fallback;
   return {
     title: normalizeOfficeTitle(value.title, fallback.title),
+    stateAnimationMappings: normalizeOfficeStateAnimationMappings(
+      value.stateAnimationMappings,
+      fallback.stateAnimationMappings,
+    ),
     remoteOfficeEnabled:
       typeof value.remoteOfficeEnabled === "boolean"
         ? value.remoteOfficeEnabled

--- a/tests/unit/officeEventTriggers.test.ts
+++ b/tests/unit/officeEventTriggers.test.ts
@@ -9,6 +9,7 @@ import {
   reconcileOfficeAnimationTriggerState,
   reduceOfficeAnimationTriggerEvent,
 } from "@/lib/office/eventTriggers";
+import { buildOfficeStateAnimationMappingResult } from "@/lib/office/stateAnimationMapping";
 import type { EventFrame } from "@/lib/gateway/GatewayClient";
 
 const makeAgent = (
@@ -121,6 +122,84 @@ describe("office event triggers", () => {
     expect(animationState.githubHoldByAgentId.main).toBe(true);
     expect(animationState.qaHoldByAgentId.qa).toBe(true);
     expect(animationState.skillGymHoldByAgentId.skill).toBe(true);
+  });
+
+  it("applies configured state-to-animation mappings to derived agent state", () => {
+    const agents = [
+      makeAgent({
+        agentId: "writer",
+        name: "Writer",
+        sessionKey: "agent:writer:main",
+        status: "running",
+        runId: "run-writer",
+        streamText: "Drafting the client brief.",
+      }),
+      makeAgent({
+        agentId: "blocked",
+        name: "Blocked",
+        sessionKey: "agent:blocked:main",
+        awaitingUserInput: true,
+      }),
+      makeAgent({
+        agentId: "broken",
+        name: "Broken",
+        sessionKey: "agent:broken:main",
+        status: "error",
+      }),
+    ];
+    const state = reconcileOfficeAnimationTriggerState({
+      state: createOfficeAnimationTriggerState(),
+      agents,
+      nowMs: 10_000,
+    });
+    const animationState = buildOfficeAnimationState({
+      state,
+      agents,
+      nowMs: 10_000,
+    });
+
+    const mapped = buildOfficeStateAnimationMappingResult({
+      agents,
+      animationState,
+      nowMs: 10_000,
+      mappings: [
+        {
+          id: "writing-desk",
+          sourceState: "writing",
+          label: "Writing",
+          animationTarget: "desk",
+          effect: "none",
+          soundCueId: null,
+          priority: 90,
+          enabled: true,
+        },
+        {
+          id: "waiting-booth",
+          sourceState: "approval_pending",
+          label: "Approval pending",
+          animationTarget: "phone_booth",
+          effect: "doorbell",
+          soundCueId: "approval",
+          priority: 80,
+          enabled: true,
+        },
+        {
+          id: "error-server-room",
+          sourceState: "error",
+          label: "Error",
+          animationTarget: "server_room",
+          effect: "alarm",
+          soundCueId: "alarm",
+          priority: 100,
+          enabled: true,
+        },
+      ],
+    });
+
+    expect(mapped.deskHoldByAgentId.writer).toBe(true);
+    expect(mapped.phoneBoothHoldByAgentId.blocked).toBe(true);
+    expect(mapped.githubHoldByAgentId.broken).toBe(true);
+    expect(mapped.matchedMappingByAgentId.writer?.id).toBe("writing-desk");
   });
 
   it("reacts to runtime chat commands regardless of channel transport", () => {

--- a/tests/unit/studioSettings.test.ts
+++ b/tests/unit/studioSettings.test.ts
@@ -175,6 +175,43 @@ describe("studio settings normalization", () => {
     );
   });
 
+  it("normalizes office state animation mappings per gateway", () => {
+    const normalized = normalizeStudioSettings({
+      office: {
+        " [REDACTED] ": {
+          stateAnimationMappings: [
+            {
+              id: " Writing State ",
+              sourceState: " Writing ",
+              label: "Writing",
+              animationTarget: "desk",
+              effect: "none",
+              soundCueId: " key-tap ",
+              priority: 125,
+            },
+            {
+              sourceState: "",
+              animationTarget: "bad",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(normalized.office["[REDACTED]"]?.stateAnimationMappings).toEqual([
+      {
+        id: "writing-state",
+        sourceState: "writing",
+        label: "Writing",
+        animationTarget: "desk",
+        effect: "none",
+        soundCueId: "key-tap",
+        priority: 100,
+        enabled: true,
+      },
+    ]);
+  });
+
   it("merges office title patches", () => {
     const current = normalizeStudioSettings({
       office: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a persisted per-office state-to-animation mapping config for custom runtime states such as writing, executing, waiting, and error.
- Apply configured mappings to derived office animation hold maps without moving policy into the 3D scene.
- Keep the default office path inert when no custom mappings are configured.
- Cover settings normalization and mapping derivation with focused unit tests.

## Testing
- `npm run test -- --run tests/unit/studioSettings.test.ts tests/unit/officeEventTriggers.test.ts`
- `npm run typecheck`
- `npm run smoke:dev-server`
- Fresh Chrome/Playwright office load with onboarding bypassed and zero captured console errors.

[configurable_state_mapping_final_office.webm](https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconfigurable_state_mapping_final_office.webm)
[Final office smoke screenshot](https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconfigurable_state_mapping_final_office.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

