### PR TITLE
Add office operations center panel

### DIFF
--- a/src/features/office/components/HQSidebar.tsx
+++ b/src/features/office/components/HQSidebar.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 
 export type HQSidebarTab =
+  | "ops"
   | "inbox"
   | "history"
   | "kanban"
@@ -18,6 +19,7 @@ type HQSidebarProps = {
   onOpenMarketplace: () => void;
   onAddAgent?: () => void;
   onOpenCompanyBuilder?: () => void;
+  operationsPanel: ReactNode;
   inboxPanel: ReactNode;
   historyPanel: ReactNode;
   kanbanPanel: ReactNode;
@@ -26,6 +28,7 @@ type HQSidebarProps = {
 };
 
 const TAB_LABELS: Record<HQSidebarTab, string> = {
+  ops: "Ops",
   inbox: "Inbox",
   history: "History",
   kanban: "Kanban",
@@ -33,7 +36,7 @@ const TAB_LABELS: Record<HQSidebarTab, string> = {
   analytics: "Analytics",
 };
 
-const PRIMARY_TABS: HQSidebarTab[] = ["inbox", "history", "kanban", "playbooks"];
+const PRIMARY_TABS: HQSidebarTab[] = ["ops", "inbox", "history", "kanban", "playbooks"];
 
 export function HQSidebar({
   open,
@@ -44,6 +47,7 @@ export function HQSidebar({
   onOpenMarketplace,
   onAddAgent,
   onOpenCompanyBuilder,
+  operationsPanel,
   inboxPanel,
   historyPanel,
   kanbanPanel,
@@ -53,7 +57,9 @@ export function HQSidebar({
   const analyticsOnly = activeTab === "analytics";
   const railOnly = analyticsOnly;
   const activePanel =
-    activeTab === "inbox"
+    activeTab === "ops"
+      ? operationsPanel
+      : activeTab === "inbox"
       ? inboxPanel
       : activeTab === "history"
         ? historyPanel
@@ -162,7 +168,7 @@ export function HQSidebar({
             <div
               role="tablist"
               aria-label="Headquarters panels"
-              className="grid grid-cols-4 border-b border-cyan-500/15"
+              className="grid grid-cols-5 border-b border-cyan-500/15"
             >
               {PRIMARY_TABS.map((tab) => {
                 const isActive = tab === activeTab;

--- a/src/features/office/components/panels/OperationsCenterPanel.tsx
+++ b/src/features/office/components/panels/OperationsCenterPanel.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { AgentState } from "@/features/agents/state/store";
+import type { RunRecord } from "@/features/office/hooks/useRunLog";
+
+export type OperationsCenterFeedEvent = {
+  id: string;
+  name: string;
+  text: string;
+  ts: number;
+  kind?: "status" | "reply";
+};
+
+type OperationsCenterPanelProps = {
+  agents: AgentState[];
+  runLog: RunRecord[];
+  feedEvents: OperationsCenterFeedEvent[];
+  onSelectAgent: (agentId: string) => void;
+};
+
+const formatRelativeTime = (timestampMs: number | null | undefined) => {
+  if (!timestampMs) return "No activity";
+  const deltaMs = Date.now() - timestampMs;
+  if (deltaMs < 60_000) return "Just now";
+  if (deltaMs < 3_600_000) return `${Math.max(1, Math.floor(deltaMs / 60_000))}m ago`;
+  if (deltaMs < 86_400_000) return `${Math.max(1, Math.floor(deltaMs / 3_600_000))}h ago`;
+  return `${Math.max(1, Math.floor(deltaMs / 86_400_000))}d ago`;
+};
+
+const resolveAgentCondition = (agent: AgentState): "running" | "waiting" | "error" | "idle" => {
+  if (agent.status === "error") return "error";
+  if (agent.awaitingUserInput) return "waiting";
+  if (agent.status === "running" || agent.runId) return "running";
+  return "idle";
+};
+
+const CONDITION_STYLES: Record<ReturnType<typeof resolveAgentCondition>, string> = {
+  running: "bg-emerald-400",
+  waiting: "bg-amber-300",
+  error: "bg-rose-400",
+  idle: "bg-cyan-300/70",
+};
+
+export function OperationsCenterPanel({
+  agents,
+  runLog,
+  feedEvents,
+  onSelectAgent,
+}: OperationsCenterPanelProps) {
+  const summary = useMemo(() => {
+    const running = agents.filter((agent) => resolveAgentCondition(agent) === "running").length;
+    const waiting = agents.filter((agent) => resolveAgentCondition(agent) === "waiting").length;
+    const error = agents.filter((agent) => resolveAgentCondition(agent) === "error").length;
+    const unseen = agents.filter((agent) => agent.hasUnseenActivity).length;
+    return { total: agents.length, running, waiting, error, unseen };
+  }, [agents]);
+
+  const sortedAgents = useMemo(
+    () =>
+      [...agents].sort((left, right) => {
+        const conditionOrder = { error: 0, waiting: 1, running: 2, idle: 3 };
+        const conditionDelta =
+          conditionOrder[resolveAgentCondition(left)] -
+          conditionOrder[resolveAgentCondition(right)];
+        if (conditionDelta !== 0) return conditionDelta;
+        return (right.lastActivityAt ?? 0) - (left.lastActivityAt ?? 0) || left.name.localeCompare(right.name);
+      }),
+    [agents],
+  );
+
+  const recentRuns = useMemo(() => runLog.slice(0, 4), [runLog]);
+  const recentEvents = useMemo(() => feedEvents.slice(0, 4), [feedEvents]);
+
+  return (
+    <section className="flex h-full min-h-0 flex-col">
+      <div className="border-b border-cyan-500/10 px-4 py-3">
+        <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-white/70">
+          Operations Center
+        </div>
+        <div className="mt-1 font-mono text-[11px] text-white/40">
+          Fleet state, activity, and run flow at a glance.
+        </div>
+      </div>
+
+      <div className="grid grid-cols-5 gap-1.5 border-b border-cyan-500/10 px-3 py-3">
+        {[
+          ["Agents", summary.total],
+          ["Running", summary.running],
+          ["Waiting", summary.waiting],
+          ["Errors", summary.error],
+          ["Unread", summary.unseen],
+        ].map(([label, value]) => (
+          <div key={label} className="rounded border border-white/8 bg-white/[0.03] px-2 py-2">
+            <div className="font-mono text-[9px] uppercase tracking-[0.14em] text-white/35">
+              {label}
+            </div>
+            <div className="mt-1 font-mono text-[16px] font-semibold text-cyan-100">
+              {value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        <div className="mb-2 rounded border border-cyan-500/10 bg-cyan-500/[0.04] px-3 py-3">
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-cyan-200/80">
+            Fleet roster
+          </div>
+          <div className="mt-2 grid max-h-72 gap-2 overflow-y-auto pr-1">
+            {sortedAgents.length === 0 ? (
+              <div className="font-mono text-[11px] text-white/35">
+                No agents are connected yet.
+              </div>
+            ) : (
+              sortedAgents.map((agent) => {
+                const condition = resolveAgentCondition(agent);
+                return (
+                  <button
+                    key={agent.agentId}
+                    type="button"
+                    onClick={() => onSelectAgent(agent.agentId)}
+                    className="rounded border border-white/8 bg-black/20 px-3 py-2 text-left transition-colors hover:border-cyan-400/25 hover:bg-cyan-500/[0.05]"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className={`h-2 w-2 shrink-0 rounded-full ${CONDITION_STYLES[condition]}`} />
+                      <span className="min-w-0 flex-1 truncate font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-white/85">
+                        {agent.name || agent.agentId}
+                      </span>
+                      <span className="rounded border border-white/10 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-white/45">
+                        {condition}
+                      </span>
+                    </div>
+                    <div className="mt-1 truncate font-mono text-[10px] text-white/45">
+                      {agent.role?.trim() || agent.identityName?.trim() || "No role label"}
+                    </div>
+                    <div className="mt-2 line-clamp-2 font-mono text-[11px] leading-4 text-white/65">
+                      {agent.streamText?.trim() ||
+                        agent.latestPreview?.trim() ||
+                        agent.lastUserMessage?.trim() ||
+                        "No current activity."}
+                    </div>
+                    <div className="mt-2 font-mono text-[9px] uppercase tracking-[0.14em] text-white/30">
+                      {formatRelativeTime(agent.lastActivityAt)}
+                    </div>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+
+        <div className="mb-2 rounded border border-white/8 bg-white/[0.03] px-3 py-3">
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/55">
+            Recent runs
+          </div>
+          <div className="mt-2 grid gap-2">
+            {recentRuns.length === 0 ? (
+              <div className="font-mono text-[11px] text-white/35">
+                No run lifecycle events captured yet.
+              </div>
+            ) : (
+              recentRuns.map((run) => (
+                <button
+                  key={run.runId}
+                  type="button"
+                  onClick={() => onSelectAgent(run.agentId)}
+                  className="rounded border border-white/8 bg-black/20 px-2.5 py-2 text-left transition-colors hover:border-cyan-400/25"
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`h-2 w-2 rounded-full ${
+                        run.endedAt === null
+                          ? "bg-amber-300"
+                          : run.outcome === "error"
+                            ? "bg-rose-400"
+                            : "bg-emerald-400"
+                      }`}
+                    />
+                    <span className="min-w-0 flex-1 truncate font-mono text-[10px] uppercase tracking-[0.14em] text-white/75">
+                      {run.agentName}
+                    </span>
+                    <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-white/35">
+                      {run.endedAt === null ? "running" : run.outcome ?? "done"}
+                    </span>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="rounded border border-white/8 bg-white/[0.03] px-3 py-3">
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/55">
+            Activity stream
+          </div>
+          <div className="mt-2 grid gap-2">
+            {recentEvents.length === 0 ? (
+              <div className="font-mono text-[11px] text-white/35">
+                No recent office feed events.
+              </div>
+            ) : (
+              recentEvents.map((event) => (
+                <button
+                  key={`${event.id}-${event.ts}-${event.text}`}
+                  type="button"
+                  onClick={() => onSelectAgent(event.id)}
+                  className="rounded border border-white/8 bg-black/20 px-2.5 py-2 text-left transition-colors hover:border-cyan-400/25"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="min-w-0 flex-1 truncate font-mono text-[10px] uppercase tracking-[0.14em] text-white/75">
+                      {event.name}
+                    </span>
+                    <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-white/35">
+                      {event.kind ?? "status"}
+                    </span>
+                  </div>
+                  <div className="mt-1 line-clamp-2 font-mono text-[11px] leading-4 text-white/60">
+                    {event.text}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -1146,7 +1146,7 @@ export function OfficeScreen({
     return searchParams.has("code");
   });
   const [activeSidebarTab, setActiveSidebarTab] =
-    useState<HQSidebarTab>("inbox");
+    useState<HQSidebarTab>("ops");
   const pendingJukeboxCommandTimeoutsRef = useRef<
     Map<string, { requestKey: string; timeoutId: number }>
   >(new Map());

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -159,6 +159,7 @@ import { AnalyticsPanel } from "@/features/office/components/panels/AnalyticsPan
 import { HistoryPanel } from "@/features/office/components/panels/HistoryPanel";
 import { InboxPanel } from "@/features/office/components/panels/InboxPanel";
 import { KanbanDisabledPanel } from "@/features/office/components/panels/KanbanDisabledPanel";
+import { OperationsCenterPanel } from "@/features/office/components/panels/OperationsCenterPanel";
 import { PlaybooksPanel } from "@/features/office/components/panels/PlaybooksPanel";
 import { SkillsMarketplaceModal } from "@/features/office/components/panels/SkillsMarketplaceModal";
 import { TaskBoardPanel } from "@/features/office/components/panels/TaskBoardPanel";
@@ -5164,6 +5165,17 @@ export function OfficeScreen({
           onOpenMarketplace={() => setMarketplaceOpen(true)}
           onAddAgent={handleOpenCreateAgentWizard}
           onOpenCompanyBuilder={handleOpenCompanyBuilder}
+          operationsPanel={
+            <OperationsCenterPanel
+              agents={state.agents}
+              runLog={runLog}
+              feedEvents={feedEvents}
+              onSelectAgent={(agentId) => {
+                handleOpenAgentChat(agentId);
+                setActiveSidebarTab("ops");
+              }}
+            />
+          }
           inboxPanel={
             <InboxPanel
               agents={state.agents}

--- a/tests/unit/operationsCenterPanel.test.ts
+++ b/tests/unit/operationsCenterPanel.test.ts
@@ -1,0 +1,121 @@
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+
+import type { AgentState } from "@/features/agents/state/store";
+import { OperationsCenterPanel } from "@/features/office/components/panels/OperationsCenterPanel";
+import type { RunRecord } from "@/features/office/hooks/useRunLog";
+
+const makeAgent = (overrides: Partial<AgentState> & Pick<AgentState, "agentId" | "name">): AgentState => ({
+  agentId: overrides.agentId,
+  name: overrides.name,
+  runtimeName: overrides.runtimeName,
+  identityName: overrides.identityName,
+  sessionDisplayName: overrides.sessionDisplayName,
+  role: overrides.role,
+  sessionKey: overrides.sessionKey ?? `agent:${overrides.agentId}:main`,
+  avatarSeed: overrides.avatarSeed ?? overrides.agentId,
+  avatarProfile: overrides.avatarProfile,
+  avatarUrl: overrides.avatarUrl ?? null,
+  model: overrides.model ?? null,
+  thinkingLevel: overrides.thinkingLevel ?? "high",
+  sessionExecHost: overrides.sessionExecHost,
+  sessionExecSecurity: overrides.sessionExecSecurity,
+  sessionExecAsk: overrides.sessionExecAsk,
+  toolCallingEnabled: overrides.toolCallingEnabled ?? false,
+  showThinkingTraces: overrides.showThinkingTraces ?? true,
+  status: overrides.status ?? "idle",
+  sessionCreated: overrides.sessionCreated ?? false,
+  awaitingUserInput: overrides.awaitingUserInput ?? false,
+  hasUnseenActivity: overrides.hasUnseenActivity ?? false,
+  outputLines: overrides.outputLines ?? [],
+  lastResult: overrides.lastResult ?? null,
+  lastDiff: overrides.lastDiff ?? null,
+  runId: overrides.runId ?? null,
+  runStartedAt: overrides.runStartedAt ?? null,
+  streamText: overrides.streamText ?? null,
+  thinkingTrace: overrides.thinkingTrace ?? null,
+  latestOverride: overrides.latestOverride ?? null,
+  latestOverrideKind: overrides.latestOverrideKind ?? null,
+  lastAssistantMessageAt: overrides.lastAssistantMessageAt ?? null,
+  lastActivityAt: overrides.lastActivityAt ?? null,
+  latestPreview: overrides.latestPreview ?? null,
+  lastUserMessage: overrides.lastUserMessage ?? null,
+  draft: overrides.draft ?? "",
+  queuedMessages: overrides.queuedMessages ?? [],
+  sessionSettingsSynced: overrides.sessionSettingsSynced ?? false,
+  historyLoadedAt: overrides.historyLoadedAt ?? null,
+  historyFetchLimit: overrides.historyFetchLimit ?? null,
+  historyFetchedCount: overrides.historyFetchedCount ?? null,
+  historyMaybeTruncated: overrides.historyMaybeTruncated ?? false,
+  transcriptEntries: overrides.transcriptEntries ?? [],
+  transcriptRevision: overrides.transcriptRevision ?? 0,
+  transcriptSequenceCounter: overrides.transcriptSequenceCounter ?? 0,
+  sessionEpoch: overrides.sessionEpoch ?? 0,
+  lastHistoryRequestRevision: overrides.lastHistoryRequestRevision ?? null,
+  lastAppliedHistoryRequestId: overrides.lastAppliedHistoryRequestId ?? null,
+});
+
+describe("OperationsCenterPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("summarizes fleet state and opens selected agents", () => {
+    const onSelectAgent = vi.fn();
+    const runLog: RunRecord[] = [
+      {
+        runId: "run-1",
+        agentId: "engineer",
+        agentName: "Engineer",
+        startedAt: Date.now() - 5_000,
+        endedAt: null,
+        outcome: null,
+        trigger: "user",
+      },
+    ];
+
+    render(
+      createElement(OperationsCenterPanel, {
+        agents: [
+          makeAgent({
+            agentId: "engineer",
+            name: "Engineer",
+            role: "Backend engineer",
+            status: "running",
+            runId: "run-1",
+            streamText: "Implementing API changes.",
+          }),
+          makeAgent({
+            agentId: "qa",
+            name: "QA",
+            awaitingUserInput: true,
+            hasUnseenActivity: true,
+          }),
+        ],
+        runLog,
+        feedEvents: [
+          {
+            id: "engineer",
+            name: "Engineer",
+            text: "started working",
+            ts: Date.now(),
+            kind: "status",
+          },
+        ],
+        onSelectAgent,
+      }),
+    );
+
+    expect(screen.getByText("Operations Center")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getByText("Waiting")).toBeInTheDocument();
+    expect(screen.getByText("Backend engineer")).toBeInTheDocument();
+    expect(screen.getByText("Implementing API changes.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Engineer/i })[0]);
+
+    expect(onSelectAgent).toHaveBeenCalledWith("engineer");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an Ops tab to the HQ sidebar.
- Add an operations center panel with fleet counts, prioritized agent roster, recent run outcomes, and recent activity feed.
- Reuse existing AgentState, runLog, feedEvents, and run counts instead of introducing a new store.
- Open HQ to Ops by default so multi-agent visibility is the first sidebar view.
- Add focused component coverage for summary counts and agent selection.

## Testing
- `npm run test -- --run tests/unit/operationsCenterPanel.test.ts tests/unit/stateAnimationMappingsEditor.test.tsx tests/unit/studioSettings.test.ts tests/unit/officeEventTriggers.test.ts`
- `npm run typecheck`
- `npm run smoke:dev-server`
- Browser walkthrough opened `/office`, opened HQ, and verified Operations Center/Fleet roster/Recent runs/Activity stream with zero browser console errors. Note: the walkthrough also shows an existing canvas white-background issue when HQ opens in this dev/browser session; the Ops panel itself renders and functions.

[operations_center_panel.webm](https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foperations_center_panel.webm)
[Operations center panel](https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foperations_center_panel.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

