### PR TITLE
Add signed external office events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,6 @@ DEBUG=true
 # ELEVENLABS_API_KEY=
 # ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
 # ELEVENLABS_MODEL_ID=eleven_flash_v2_5
+
+# Optional: signed external office event webhooks.
+# OFFICE_EVENTS_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Common environment variables:
 - `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` override the default OpenClaw paths.
 - `OPENCLAW_GATEWAY_SSH_TARGET`, `OPENCLAW_GATEWAY_SSH_USER`, `OPENCLAW_GATEWAY_SSH_PORT`, and `OPENCLAW_GATEWAY_SSH_STRICT_HOST_KEY_CHECKING` support advanced gateway-host operations over SSH when needed.
 - `ELEVENLABS_API_KEY`, `ELEVENLABS_VOICE_ID`, and `ELEVENLABS_MODEL_ID` enable voice reply integration.
+- `CLAW3D_OFFICE_EVENTS_SECRET` enables signed external office events at `/api/office/events`. Send `X-Claw3D-Signature: sha256=<hex hmac>` over the raw JSON body.
 
 See [`.env.example`](.env.example) for the full local development template.
 

--- a/src/app/api/office/events/route.ts
+++ b/src/app/api/office/events/route.ts
@@ -1,0 +1,135 @@
+import crypto from "node:crypto";
+import { NextResponse } from "next/server";
+
+import {
+  appendOfficeExternalEvent,
+  listOfficeExternalEvents,
+  type OfficeExternalEventEffect,
+} from "@/lib/office/externalEventsStore";
+
+export const runtime = "nodejs";
+
+const MAX_BODY_BYTES = 64 * 1024;
+const SIGNATURE_HEADER = "x-claw3d-signature";
+const TIMESTAMP_HEADER = "x-claw3d-timestamp";
+const MAX_TIMESTAMP_SKEW_MS = 5 * 60_000;
+
+const json = (body: unknown, status = 200) =>
+  NextResponse.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
+
+const errorJson = (message: string, status: number) => json({ error: message }, status);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+const resolveSecret = () => process.env.CLAW3D_OFFICE_EVENTS_SECRET?.trim() ?? "";
+
+const safeCompare = (left: string, right: string): boolean => {
+  const leftBuffer = Buffer.from(left, "utf8");
+  const rightBuffer = Buffer.from(right, "utf8");
+  if (leftBuffer.length !== rightBuffer.length) {
+    crypto.timingSafeEqual(leftBuffer, leftBuffer);
+    return false;
+  }
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+};
+
+const buildExpectedSignature = (params: {
+  bodyText: string;
+  secret: string;
+  timestamp: string;
+}) =>
+  `sha256=${crypto
+    .createHmac("sha256", params.secret)
+    .update(`${params.timestamp}.${params.bodyText}`)
+    .digest("hex")}`;
+
+const verifySignature = (request: Request, bodyText: string): string | null => {
+  const secret = resolveSecret();
+  if (!secret) return null;
+  const signature = request.headers.get(SIGNATURE_HEADER)?.trim() ?? "";
+  const timestamp = request.headers.get(TIMESTAMP_HEADER)?.trim() ?? "";
+  if (!signature || !timestamp) {
+    return "Office event signature and timestamp are required.";
+  }
+  const timestampMs = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(timestampMs)) {
+    return "Office event timestamp is invalid.";
+  }
+  if (Math.abs(Date.now() - timestampMs) > MAX_TIMESTAMP_SKEW_MS) {
+    return "Office event timestamp is outside the allowed window.";
+  }
+  const expected = buildExpectedSignature({ bodyText, secret, timestamp });
+  return safeCompare(signature, expected) ? null : "Office event signature is invalid.";
+};
+
+const normalizeString = (value: unknown, maxLength: number) =>
+  typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+
+const normalizeEffect = (value: unknown): OfficeExternalEventEffect | "none" => {
+  if (value === "confetti" || value === "alarm" || value === "doorbell") return value;
+  return "none";
+};
+
+export async function GET() {
+  try {
+    return json({ events: listOfficeExternalEvents() });
+  } catch (error) {
+    console.error("[office-events] GET failed.", error);
+    return errorJson("Internal error reading office events.", 500);
+  }
+}
+
+export async function POST(request: Request) {
+  let bodyText = "";
+  try {
+    bodyText = await request.text();
+  } catch {
+    return errorJson("Invalid office event payload.", 400);
+  }
+  if (Buffer.byteLength(bodyText, "utf8") > MAX_BODY_BYTES) {
+    return errorJson("Office event payload is too large.", 413);
+  }
+  const signatureError = verifySignature(request, bodyText);
+  if (signatureError) {
+    return errorJson(signatureError, 401);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return errorJson("Invalid JSON payload.", 400);
+  }
+  if (!isRecord(body)) {
+    return errorJson("Office event payload must be an object.", 400);
+  }
+
+  const source = normalizeString(body.source, 80);
+  const eventType = normalizeString(body.eventType ?? body.type, 120);
+  const title = normalizeString(body.title, 140);
+  if (!source || !eventType || !title) {
+    return errorJson("source, eventType, and title are required.", 400);
+  }
+
+  try {
+    const event = appendOfficeExternalEvent({
+      source,
+      type: eventType,
+      title,
+      message: normalizeString(body.message, 500) || null,
+      effect: normalizeEffect(body.effect),
+      agentId: normalizeString(body.agentId, 120) || null,
+      metadata: {
+        externalUrl: normalizeString(body.externalUrl, 500) || null,
+      },
+    });
+    return json({ event }, 201);
+  } catch (error) {
+    console.error("[office-events] POST failed.", error);
+    return errorJson("Internal error writing office event.", 500);
+  }
+}

--- a/src/features/office/components/panels/OperationsCenterPanel.tsx
+++ b/src/features/office/components/panels/OperationsCenterPanel.tsx
@@ -10,7 +10,8 @@ export type OperationsCenterFeedEvent = {
   name: string;
   text: string;
   ts: number;
-  kind?: "status" | "reply";
+  kind?: "status" | "reply" | "external";
+  effect?: "confetti" | "alarm" | "doorbell" | null;
 };
 
 type OperationsCenterPanelProps = {

--- a/src/features/office/hooks/useOfficeExternalEvents.ts
+++ b/src/features/office/hooks/useOfficeExternalEvents.ts
@@ -46,7 +46,7 @@ export const useOfficeExternalEvents = (
         const newEvents = nextEvents.filter((event) => !previousSeen.has(event.id));
         seenIdsRef.current = new Set(nextEvents.map((event) => event.id));
         setEvents(nextEvents);
-        if (initializedRef.current && newEvents.length > 0) {
+        if (newEvents.length > 0) {
           setLatestNewEvent(newEvents[0] ?? null);
         }
         initializedRef.current = true;

--- a/src/features/office/hooks/useOfficeExternalEvents.ts
+++ b/src/features/office/hooks/useOfficeExternalEvents.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { OfficeExternalEvent } from "@/lib/office/externalEventsStore";
+import type { OperationsCenterFeedEvent } from "@/features/office/components/panels/OperationsCenterPanel";
+
+type UseOfficeExternalEventsResult = {
+  events: OfficeExternalEvent[];
+  feedEvents: OperationsCenterFeedEvent[];
+  latestNewEvent: OfficeExternalEvent | null;
+};
+
+const toFeedEvent = (event: OfficeExternalEvent): OperationsCenterFeedEvent => ({
+  id: event.agentId ?? `external:${event.id}`,
+  name: event.source,
+  text: event.message ? `${event.title}: ${event.message}` : event.title,
+  ts: event.receivedAt,
+  kind: "external",
+  effect: event.effect,
+});
+
+export const useOfficeExternalEvents = (
+  pollIntervalMs = 5_000,
+): UseOfficeExternalEventsResult => {
+  const [events, setEvents] = useState<OfficeExternalEvent[]>([]);
+  const [latestNewEvent, setLatestNewEvent] = useState<OfficeExternalEvent | null>(null);
+  const seenIdsRef = useRef<Set<string>>(new Set());
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: number | null = null;
+
+    const load = async () => {
+      try {
+        const response = await fetch("/api/office/events", { cache: "no-store" });
+        const payload = (await response.json()) as
+          | { events?: OfficeExternalEvent[] }
+          | { error?: string };
+        if (!response.ok || !("events" in payload) || !Array.isArray(payload.events)) {
+          return;
+        }
+        if (cancelled) return;
+        const nextEvents = payload.events;
+        const previousSeen = seenIdsRef.current;
+        const newEvents = nextEvents.filter((event) => !previousSeen.has(event.id));
+        seenIdsRef.current = new Set(nextEvents.map((event) => event.id));
+        setEvents(nextEvents);
+        if (initializedRef.current && newEvents.length > 0) {
+          setLatestNewEvent(newEvents[0] ?? null);
+        }
+        initializedRef.current = true;
+      } catch {
+        // External event polling is best-effort; the office should keep rendering.
+      }
+    };
+
+    void load();
+    intervalId = window.setInterval(() => {
+      void load();
+    }, Math.max(1_000, pollIntervalMs));
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== null) window.clearInterval(intervalId);
+    };
+  }, [pollIntervalMs]);
+
+  return { events, feedEvents: events.map(toFeedEvent), latestNewEvent };
+};

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -3139,6 +3139,10 @@ export function OfficeScreen({
     events: externalOfficeEvents,
     feedEvents: externalOfficeFeedEvents,
   } = useOfficeExternalEvents();
+  const operationsFeedEvents = useMemo(
+    () => [...externalOfficeFeedEvents, ...feedEvents],
+    [externalOfficeFeedEvents, feedEvents],
+  );
   const taskBoard = useTaskBoardController({
     gatewayUrl,
     settingsCoordinator,
@@ -5175,7 +5179,7 @@ export function OfficeScreen({
             <OperationsCenterPanel
               agents={state.agents}
               runLog={runLog}
-              feedEvents={feedEvents}
+              feedEvents={operationsFeedEvents}
               onSelectAgent={(agentId) => {
                 handleOpenAgentChat(agentId);
                 setActiveSidebarTab("ops");

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -170,6 +170,8 @@ import {
   SOUNDCLAW_PLAYBACK_STARTED_EVENT_NAME,
   useJukeboxStore,
 } from "@/features/spotify-jukebox/store";
+import confetti from "canvas-confetti";
+import { useOfficeExternalEvents } from "@/features/office/hooks/useOfficeExternalEvents";
 import { useOfficeSkillTriggers } from "@/features/office/hooks/useOfficeSkillTriggers";
 import { useRemoteOfficePresence } from "@/features/office/hooks/useRemoteOfficePresence";
 import { useRemoteOfficeLayout } from "@/features/office/hooks/useRemoteOfficeLayout";
@@ -3133,6 +3135,10 @@ export function OfficeScreen({
     gatewayUrl,
     agents: standupAgentSnapshots,
   });
+  const {
+    events: externalOfficeEvents,
+    feedEvents: externalOfficeFeedEvents,
+  } = useOfficeExternalEvents();
   const taskBoard = useTaskBoardController({
     gatewayUrl,
     settingsCoordinator,

--- a/src/lib/office/externalEventsStore.ts
+++ b/src/lib/office/externalEventsStore.ts
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { resolveStateDir } from "@/lib/clawdbot/paths";
+import {
+  isOfficeStateEffectId,
+  type OfficeStateEffectId,
+} from "@/lib/office/stateMappingConfig";
+
+export type OfficeExternalEventEffect = Exclude<OfficeStateEffectId, "none">;
+
+export type OfficeExternalEvent = {
+  id: string;
+  source: string;
+  type: string;
+  title: string;
+  message: string;
+  effect: OfficeExternalEventEffect | null;
+  agentId: string | null;
+  receivedAt: number;
+  metadata: Record<string, string | number | boolean | null>;
+};
+
+export type OfficeExternalEventInput = {
+  id?: unknown;
+  source?: unknown;
+  type?: unknown;
+  title?: unknown;
+  message?: unknown;
+  effect?: unknown;
+  agentId?: unknown;
+  metadata?: unknown;
+};
+
+type OfficeExternalEventsStore = {
+  schemaVersion: 1;
+  events: OfficeExternalEvent[];
+};
+
+const STORE_DIR = "claw3d";
+const STORE_FILE = "office-events.json";
+const MAX_EVENTS = 50;
+const MAX_FIELD_LENGTH = 240;
+const MAX_METADATA_ENTRIES = 24;
+
+const ensureDirectory = (dirPath: string) => {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+};
+
+const resolveStorePath = () => {
+  const dir = path.join(resolveStateDir(), STORE_DIR);
+  ensureDirectory(dir);
+  return path.join(dir, STORE_FILE);
+};
+
+const defaultStore = (): OfficeExternalEventsStore => ({
+  schemaVersion: 1,
+  events: [],
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+const coerceString = (value: unknown, fallback = "") =>
+  typeof value === "string" ? value.trim().slice(0, MAX_FIELD_LENGTH) : fallback;
+
+const normalizeMetadata = (value: unknown): OfficeExternalEvent["metadata"] => {
+  if (!isRecord(value)) return {};
+  const entries: OfficeExternalEvent["metadata"] = {};
+  for (const [keyRaw, valueRaw] of Object.entries(value).slice(0, MAX_METADATA_ENTRIES)) {
+    const key = coerceString(keyRaw).slice(0, 80);
+    if (!key) continue;
+    if (
+      typeof valueRaw === "string" ||
+      typeof valueRaw === "number" ||
+      typeof valueRaw === "boolean" ||
+      valueRaw === null
+    ) {
+      entries[key] =
+        typeof valueRaw === "string" ? valueRaw.slice(0, MAX_FIELD_LENGTH) : valueRaw;
+    }
+  }
+  return entries;
+};
+
+const normalizeEffect = (value: unknown): OfficeExternalEventEffect | null => {
+  if (!isOfficeStateEffectId(value) || value === "none") return null;
+  return value;
+};
+
+const normalizeEvent = (value: unknown): OfficeExternalEvent | null => {
+  if (!isRecord(value)) return null;
+  const source = coerceString(value.source);
+  const type = coerceString(value.type);
+  if (!source || !type) return null;
+  const receivedAt =
+    typeof value.receivedAt === "number" && Number.isFinite(value.receivedAt)
+      ? value.receivedAt
+      : Date.now();
+  return {
+    id: coerceString(value.id) || randomUUID(),
+    source,
+    type,
+    title: coerceString(value.title) || type,
+    message: coerceString(value.message),
+    effect: normalizeEffect(value.effect),
+    agentId: coerceString(value.agentId) || null,
+    receivedAt,
+    metadata: normalizeMetadata(value.metadata),
+  };
+};
+
+const readStore = (): OfficeExternalEventsStore => {
+  const storePath = resolveStorePath();
+  if (!fs.existsSync(storePath)) return defaultStore();
+  try {
+    const raw = fs.readFileSync(storePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed) || parsed.schemaVersion !== 1 || !Array.isArray(parsed.events)) {
+      return defaultStore();
+    }
+    return {
+      schemaVersion: 1,
+      events: parsed.events
+        .map((entry) => normalizeEvent(entry))
+        .filter((entry): entry is OfficeExternalEvent => Boolean(entry))
+        .slice(0, MAX_EVENTS),
+    };
+  } catch {
+    return defaultStore();
+  }
+};
+
+const writeStore = (store: OfficeExternalEventsStore) => {
+  fs.writeFileSync(resolveStorePath(), JSON.stringify(store, null, 2), "utf8");
+};
+
+export const listOfficeExternalEvents = (limit = MAX_EVENTS): OfficeExternalEvent[] =>
+  readStore().events.slice(0, Math.max(1, Math.min(MAX_EVENTS, limit)));
+
+export const appendOfficeExternalEvent = (
+  input: OfficeExternalEventInput,
+): OfficeExternalEvent => {
+  const event = normalizeEvent({
+    ...input,
+    receivedAt: Date.now(),
+  });
+  if (!event) {
+    throw new Error("External event source and type are required.");
+  }
+  const store = readStore();
+  const deduped = store.events.filter((entry) => entry.id !== event.id);
+  const next = {
+    schemaVersion: 1 as const,
+    events: [event, ...deduped].slice(0, MAX_EVENTS),
+  };
+  writeStore(next);
+  return event;
+};

--- a/tests/unit/officeEventsRoute.test.ts
+++ b/tests/unit/officeEventsRoute.test.ts
@@ -1,0 +1,120 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GET, POST } from "@/app/api/office/events/route";
+
+const makeTempDir = (name: string) => fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+
+const sign = (body: string, secret: string, timestamp: string) =>
+  `sha256=${crypto
+    .createHmac("sha256", secret)
+    .update(`${timestamp}.${body}`)
+    .digest("hex")}`;
+
+const makeSignedRequest = (body: unknown, secret = "test-secret") => {
+  const rawBody = JSON.stringify(body);
+  const timestamp = String(Date.now());
+  return new Request("http://localhost/api/office/events", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-claw3d-signature": sign(rawBody, secret, timestamp),
+      "x-claw3d-timestamp": timestamp,
+    },
+    body: rawBody,
+  });
+};
+
+describe("office events route", () => {
+  const priorStateDir = process.env.OPENCLAW_STATE_DIR;
+  const priorSecret = process.env.CLAW3D_OFFICE_EVENTS_SECRET;
+  let tempDir: string | null = null;
+
+  afterEach(() => {
+    process.env.OPENCLAW_STATE_DIR = priorStateDir;
+    process.env.CLAW3D_OFFICE_EVENTS_SECRET = priorSecret;
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it("stores signed office events and returns recent events", async () => {
+    tempDir = makeTempDir("office-events-route-store");
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+    process.env.CLAW3D_OFFICE_EVENTS_SECRET = "test-secret";
+
+    const response = await POST(
+      makeSignedRequest({
+        source: "hubspot",
+        eventType: "deal.closed",
+        title: "Deal closed",
+        message: "Automotive account signed.",
+        effect: "confetti",
+      }),
+    );
+    const body = (await response.json()) as {
+      event?: { id?: string; source?: string; effect?: string };
+    };
+
+    expect(response.status).toBe(201);
+    expect(body.event).toEqual(
+      expect.objectContaining({
+        source: "hubspot",
+        effect: "confetti",
+      }),
+    );
+
+    const getResponse = await GET();
+    const getBody = (await getResponse.json()) as {
+      events?: Array<{ title?: string; message?: string }>;
+    };
+    expect(getResponse.status).toBe(200);
+    expect(getBody.events?.[0]).toEqual(
+      expect.objectContaining({
+        title: "Deal closed",
+        message: "Automotive account signed.",
+      }),
+    );
+  });
+
+  it("rejects missing or invalid signatures when a secret is configured", async () => {
+    tempDir = makeTempDir("office-events-route-signature");
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+    process.env.CLAW3D_OFFICE_EVENTS_SECRET = "test-secret";
+
+    const missing = await POST(
+      new Request("http://localhost/api/office/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ eventType: "ci.failed" }),
+      }),
+    );
+    expect(missing.status).toBe(401);
+
+    const invalid = await POST(
+      new Request("http://localhost/api/office/events", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-claw3d-signature": "sha256=bad",
+        },
+        body: JSON.stringify({ eventType: "ci.failed" }),
+      }),
+    );
+    expect(invalid.status).toBe(401);
+  });
+
+  it("returns 400 for invalid payloads", async () => {
+    tempDir = makeTempDir("office-events-route-invalid");
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+    process.env.CLAW3D_OFFICE_EVENTS_SECRET = "test-secret";
+
+    const response = await POST(makeSignedRequest({ source: "ci" }));
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add signed `POST /api/office/events` and no-store `GET /api/office/events` for recent external office events.
- Persist a bounded recent-event list under the Claw3D state directory.
- Poll external office events from the office UI and merge them into the Ops Center activity stream.
- Trigger confetti for incoming external events with `effect: "confetti"`.
- Document `CLAW3D_OFFICE_EVENTS_SECRET` and add route coverage for signatures and validation.

## Testing
- `npm run test -- --run tests/unit/officeEventsRoute.test.ts tests/unit/operationsCenterPanel.test.ts tests/unit/stateAnimationMappingsEditor.test.tsx tests/unit/studioSettings.test.ts tests/unit/officeEventTriggers.test.ts`
- `npm run typecheck`
- `npm run smoke:dev-server`
- Browser walkthrough with `CLAW3D_OFFICE_EVENTS_SECRET=test-secret`: posted a signed HubSpot-style `deal.closed` event and verified `Deal closed: Automotive account signed.` appears in Ops Center with zero captured browser console errors.

[external_office_event_ops.webm](https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexternal_office_event_ops.webm)
[External office event in Ops Center](https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexternal_office_event_ops.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7adeb4-45d7-4159-a3c1-efe7741b8c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

