### PR TITLE
chore: regenerate package-lock.json after npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5882,6 +5882,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

Running `npm install` against the existing lockfile on Node 20 added a `"dev": true` metadata flag to the `fsevents` entry. Committing the regenerated lockfile so a clean install no longer produces a dirty working tree.

## What changed
- `package-lock.json`: single-line metadata addition on the `fsevents` (v2.3.2) optional dependency.

## Why
Keeps the lockfile in sync with what `npm install` produces, removing spurious diffs for contributors.

## Test plan
- [x] `npm install` runs clean
- [x] `npm run dev` starts (verified locally)

> Note: this is a tiny housekeeping change. Feel free to close if not desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)