### PR TITLE
fix(gateway): support OpenClaw protocol v4 and fix SSH tunnel device auth timing

### DIFF
--- a/src/lib/gateway/nodeGatewayClient.ts
+++ b/src/lib/gateway/nodeGatewayClient.ts
@@ -121,7 +121,7 @@ const buildConnectParams = async (params: {
   const signature = await signAsync(new TextEncoder().encode(payload), params.deviceIdentity.privateKey);
   return {
   minProtocol: 3,
-  maxProtocol: 3,
+  maxProtocol: 4,
   client: {
     id: GATEWAY_CLIENT_ID,
     version: "dev",

--- a/src/lib/gateway/openclaw/GatewayBrowserClient.ts
+++ b/src/lib/gateway/openclaw/GatewayBrowserClient.ts
@@ -1,6 +1,8 @@
 // Adapted from `openclaw/openclaw` `ui/src/ui/gateway.ts`.
 // Source license: MIT. Last verified against OpenClaw 2026.2.12
 // (`f9e444dd56ccfc2271e8ae1729b7a14a55e1c11e`).
+// Protocol v4 support (maxProtocol: 4) added 2026-05-17 to match OpenClaw
+// ≥ 2026.3.x which bumped the required gateway protocol version from 3 to 4.
 // Update this file via `npm run sync:gateway-client -- /path/to/gateway.ts` and record
 // provenance changes in `THIRD_PARTY_CODE.md` whenever the upstream source changes.
 import { getPublicKeyAsync, signAsync, utils } from "@noble/ed25519";
@@ -540,13 +542,15 @@ export class GatewayBrowserClient {
         }
       | undefined;
 
+    const effectiveMode = this.opts.mode ?? GATEWAY_CLIENT_MODES.WEBCHAT;
+
     if (isSecureContext && deviceIdentity) {
       const signedAtMs = Date.now();
       const nonce = this.connectNonce ?? undefined;
       const payload = buildDeviceAuthPayload({
         deviceId: deviceIdentity.deviceId,
         clientId: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
-        clientMode: this.opts.mode ?? GATEWAY_CLIENT_MODES.WEBCHAT,
+        clientMode: effectiveMode,
         role,
         scopes,
         signedAtMs,
@@ -564,12 +568,12 @@ export class GatewayBrowserClient {
     }
     const params = {
       minProtocol: 3,
-      maxProtocol: 3,
+      maxProtocol: 4,
       client: {
         id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
         version: this.opts.clientVersion ?? "dev",
         platform: this.opts.platform ?? navigator.platform ?? "web",
-        mode: this.opts.mode ?? GATEWAY_CLIENT_MODES.WEBCHAT,
+        mode: effectiveMode,
         instanceId: this.opts.instanceId,
       },
       role,
@@ -703,10 +707,24 @@ export class GatewayBrowserClient {
     this.connectNonce = null;
     this.connectSent = false;
     if (this.connectTimer !== null) window.clearTimeout(this.connectTimer);
-    const SOCKET_OPEN_CONNECT_DELAY_MS = 75;
-    gatewayBrowserDebugLog("queue-connect", { delayMs: SOCKET_OPEN_CONNECT_DELAY_MS });
+    // When device auth is active the gateway sends a connect.challenge nonce
+    // that must arrive before we transmit the connect frame. 75 ms is fine for
+    // low-latency links (LAN, Tailscale) but SSH tunnels to remote hosts can
+    // easily exceed that, causing the timer to fire before the nonce arrives.
+    // The result is a nonce-less device payload that the proxy treats as
+    // incomplete (hasDevice=false), downgrades to webchat-ui, and OpenClaw then
+    // rejects with a protocol-version mismatch. Use a generous fallback when we
+    // would actually generate device auth so the nonce has time to arrive; the
+    // challenge handler cancels the timer immediately when it does, so fast
+    // connections are unaffected.
+    const expectChallenge =
+      !this.opts.disableDeviceAuth &&
+      typeof crypto !== "undefined" &&
+      !!crypto.subtle;
+    const delayMs = expectChallenge ? 5_000 : 75;
+    gatewayBrowserDebugLog("queue-connect", { delayMs });
     this.connectTimer = window.setTimeout(() => {
       void this.sendConnect();
-    }, SOCKET_OPEN_CONNECT_DELAY_MS);
+    }, delayMs);
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes two compounding issues that prevented Claw3D from connecting to an up-to-date OpenClaw gateway via SSH tunnel.

### Root cause 1 — Protocol version out of date

OpenClaw >= 2026.3.x bumped the required gateway protocol version from v3 to v4. Both `GatewayBrowserClient` and `nodeGatewayClient` were advertising `maxProtocol: 3`, so OpenClaw rejected every connect attempt with:

```
Gateway error (INVALID_REQUEST): protocol mismatch
```

**Fix:** widen the advertised range to `maxProtocol: 4` while keeping `minProtocol: 3` for backwards compatibility with older instances.

### Root cause 2 — SSH tunnel latency races the device-auth nonce timer

`queueConnect()` starts a 75 ms fallback timer that fires if no `connect.challenge` nonce arrives before it expires. On low-latency links (Tailscale, LAN) the challenge always wins. On SSH tunnels to a remote host (typical RTT 100-300 ms) the timer fires first.

When the connect frame is sent without a nonce, the gateway proxy's `hasCompleteDeviceAuth()` check fails (nonce field is missing), so the proxy silently downgrades the client from `openclaw-control-ui` to `webchat-ui`. The webchat endpoint only speaks protocol v3, producing the same misleading "protocol mismatch" error and leaving no trace of the real cause in the logs.

**Fix:** increase the fallback timer to 5 000 ms when device auth is active (`disableDeviceAuth: false` and `crypto.subtle` available). The `connect.challenge` handler cancels the timer the instant the nonce arrives, so fast connections are completely unaffected.

## Test plan

- [ ] Connect to an OpenClaw >= 2026.3.x gateway via SSH tunnel — onboarding completes without a protocol mismatch error
- [ ] Connect via Tailscale — still works, no regression in connect latency
- [ ] Connect to an older OpenClaw instance (protocol v3) — still works (`minProtocol: 3` preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
