### PR TITLE
fix(office): unblock Hermes adapter + stop persistence loops

### DIFF
--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { MessageSquare, ChevronDown, ChevronLeft, ChevronRight, Mic } from "lucide-react";
 import { RetroOffice3D } from "@/features/retro-office/RetroOffice3D";
 import type { OfficeAgent } from "@/features/retro-office/core/types";
@@ -953,8 +953,15 @@ type OfficeScreenProps = {
 export function OfficeScreen({
   showOpenClawConsole = true,
 }: OfficeScreenProps) {
-  const searchParams = useSearchParams();
-  const debugEnabled = searchParams.get("officeDebug") === "1";
+  // Patch Hermes Phase 2: avoid useSearchParams() at component root — it
+  // suspends during hydration in Next.js dev mode and keeps the parent
+  // Suspense fallback stuck on "Loading...". Use a sync useMemo so
+  // debugEnabled is stable across renders (state+useEffect caused a
+  // re-render cascade through downstream useCallbacks).
+  const debugEnabled = useMemo(() => {
+    if (typeof window === "undefined") return false;
+    return new URLSearchParams(window.location.search).get("officeDebug") === "1";
+  }, []);
   const [settingsCoordinator] = useState(() =>
     createStudioSettingsCoordinator(),
   );

--- a/src/features/office/tasks/useTaskBoardController.ts
+++ b/src/features/office/tasks/useTaskBoardController.ts
@@ -695,6 +695,7 @@ export const useTaskBoardController = ({
     "unknown" | "supported" | "unsupported"
   >("unknown");
   const sharedRefreshInFlightRef = useRef(false);
+  const lastPersistedTaskBoardSnapshotRef = useRef<string | null>(null);
 
   useEffect(() => {
     stateRef.current = state;
@@ -831,6 +832,15 @@ export const useTaskBoardController = ({
 
   useEffect(() => {
     if (!hydratedRef.current || !gatewayUrl.trim()) return;
+    const nextSnapshot = JSON.stringify({
+      gatewayUrl,
+      cards: state.cards,
+      selectedCardId: state.selectedCardId,
+    });
+    if (lastPersistedTaskBoardSnapshotRef.current === nextSnapshot) {
+      return;
+    }
+    lastPersistedTaskBoardSnapshotRef.current = nextSnapshot;
     settingsCoordinator.schedulePatch(
       {
         taskBoard: {
@@ -1141,8 +1151,26 @@ export const useTaskBoardController = ({
     [applySharedTaskRecord],
   );
 
+  const lastDedupeSnapshotRef = useRef<string | null>(null);
   useEffect(() => {
     if (!hydratedRef.current) return;
+    // Patch Hermes Phase 2: snapshot guard prevents re-entering the dedupe
+    // loop when state.cards is replaced by a structurally-identical array
+    // (upstream dispatch churn). Without this, the effect dispatches
+    // `upsert` to mark duplicates archived → state.cards new ref →
+    // effect re-runs → "Maximum update depth exceeded" in dev mode.
+    const snapshot = JSON.stringify(
+      stateRef.current.cards
+        .filter((card) => !card.isArchived && card.source === "openclaw_event")
+        .map((card) => ({
+          id: card.id,
+          title: card.title,
+          assignedAgentId: card.assignedAgentId ?? null,
+          externalThreadId: card.externalThreadId ?? null,
+        })),
+    );
+    if (lastDedupeSnapshotRef.current === snapshot) return;
+    lastDedupeSnapshotRef.current = snapshot;
     const grouped = new Map<string, TaskBoardCard[]>();
     for (const card of stateRef.current.cards) {
       if (card.isArchived || card.source !== "openclaw_event") continue;

--- a/src/lib/gateway/GatewayClient.ts
+++ b/src/lib/gateway/GatewayClient.ts
@@ -739,6 +739,7 @@ export const useGatewayConnection = (
   const [connectErrorCode, setConnectErrorCode] = useState<string | null>(null);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [hasLastKnownGoodState, setHasLastKnownGoodState] = useState(false);
+  const lastScheduledGatewaySnapshotRef = useRef<string | null>(null);
   const setSelectedAdapterType = useCallback(
     (value: StudioGatewayAdapterType) => {
       setSelectedAdapterTypeState(value);
@@ -1114,14 +1115,25 @@ export const useGatewayConnection = (
         token: persistToken,
       },
     };
+    const nextSnapshot = JSON.stringify({
+      gatewayUrl: nextGatewayUrl,
+      token,
+      selectedAdapterType,
+      profiles: nextProfiles,
+    });
+    if (lastScheduledGatewaySnapshotRef.current === nextSnapshot) {
+      return;
+    }
     if (
       nextGatewayUrl === baseline.gatewayUrl &&
       token === baseline.token &&
       selectedAdapterType === baseline.adapterType &&
       JSON.stringify(nextProfiles) === JSON.stringify(baseline.profiles ?? {})
     ) {
+      lastScheduledGatewaySnapshotRef.current = nextSnapshot;
       return;
     }
+    lastScheduledGatewaySnapshotRef.current = nextSnapshot;
     settingsCoordinator.schedulePatch(
       {
         gateway: {
@@ -1133,6 +1145,13 @@ export const useGatewayConnection = (
       },
       400
     );
+    loadedGatewaySettings.current = {
+      gatewayUrl: nextGatewayUrl,
+      token,
+      adapterType: selectedAdapterType,
+      profiles: nextProfiles,
+      hasLastKnownGood: baseline.hasLastKnownGood,
+    };
   }, [adapterProfiles, gatewayUrl, selectedAdapterType, settingsCoordinator, settingsLoaded, token]);
 
   const useLocalGatewayDefaults = useCallback(() => {

--- a/src/lib/gateway/GatewayClient.ts
+++ b/src/lib/gateway/GatewayClient.ts
@@ -795,18 +795,26 @@ export const useGatewayConnection = (
           resolveDefaultStudioGatewayProfile(nextAdapterType, normalizedDefaults);
         const nextGatewayUrl = selectedProfile.url ?? "";
         const nextToken = selectedProfile.token ?? "";
+        // Patch Hermes Phase 2: allow auto-connect for auto-managed adapters
+        // (hermes/openclaw/demo) when a persisted URL exists, even if
+        // gateway.lastKnownGood.adapterType doesn't match the currently
+        // selected adapter. Without this, switching to Hermes never
+        // auto-connects because lastKnownGood is still "openclaw".
+        const hasPersistedProfileForSelected =
+          Boolean(resolvedGatewayProfiles.lastKnownGoodForSelected?.url) ||
+          (isAutoManagedAdapter(nextAdapterType) && nextGatewayUrl.trim().length > 0);
         loadedGatewaySettings.current = {
           gatewayUrl: nextGatewayUrl.trim(),
           token: nextToken,
           adapterType: nextAdapterType,
           profiles: resolvedGatewayProfiles.profiles,
-          hasLastKnownGood: Boolean(resolvedGatewayProfiles.lastKnownGoodForSelected?.url),
+          hasLastKnownGood: hasPersistedProfileForSelected,
         };
         setGatewayUrl(nextGatewayUrl);
         setToken(nextToken);
         setSelectedAdapterTypeState(nextAdapterType);
         setAdapterProfiles(resolvedGatewayProfiles.profiles);
-        setHasLastKnownGoodState(Boolean(resolvedGatewayProfiles.lastKnownGoodForSelected?.url));
+        setHasLastKnownGoodState(hasPersistedProfileForSelected);
       } catch (err) {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : "Failed to load gateway settings.";

--- a/src/lib/studio/coordinator.ts
+++ b/src/lib/studio/coordinator.ts
@@ -353,6 +353,7 @@ const mergeStudioPatch = (
       ...(next.voiceReplies ? { voiceReplies: { ...next.voiceReplies } } : {}),
       ...(next.office ? { office: { ...next.office } } : {}),
       ...(next.standup ? { standup: { ...next.standup } } : {}),
+      ...(next.taskBoard ? { taskBoard: { ...next.taskBoard } } : {}),
       ...(next.officeFloors ? { officeFloors: { ...next.officeFloors } } : {}),
     };
   }


### PR DESCRIPTION
## Summary

Two issues prevented the Hermes adapter from working end-to-end in this repo, and a third caused `PUT /api/studio` spam (~1/sec) plus React "Maximum update depth exceeded" warnings whenever `<OfficeScreen>` mounted in dev mode. All three are fixed here with minimal, defensive patches.

I'm submitting this because I'm integrating Claw3D with the [Hermes Agent](https://hermes-agent.nousresearch.com/) runtime (custom adapter on `:18790` forwarding to a Hermes API at `:8642`). Without these fixes the UI couldn't auto-connect to Hermes; with them, the full pipeline (`browser → /api/gateway/ws → adapter → Hermes API`) works end-to-end.

## Changes

### 1. `OfficeScreen` Suspense fallback stuck on `Loading…`

`useSearchParams()` is called at the component root, directly under the page-level `<Suspense>`. In Next.js App Router dev mode this hook suspends during hydration and the parent Suspense fallback (`OfficeLoadingFallback`) never resolves on the client — even though the server-side stream completes correctly (`<!--\$-->` boundary closed with the resolved `<main>`). The user sees `Loading…` indefinitely.

Replaced with a sync `useMemo` that reads `window.location.search` once. `debugEnabled` is now stable across renders, no Suspense involvement. (An earlier attempt using `useState + useEffect` caused a re-render cascade through downstream `useCallback` deps, so `useMemo` is the right shape here.)

### 2. Hermes adapter never auto-connects when `lastKnownGood` is openclaw

`hasLastKnownGoodState` is computed from `gateway.lastKnownGood.adapterType === selectedAdapterType`. So if a user switches from openclaw to hermes (via the connect screen), `lastKnownGood` remains `openclaw` until a successful hermes connect — but `connect()` is only auto-fired when `hasLastKnownGoodState` is true. Chicken-and-egg.

Allow auto-connect for auto-managed adapters (`hermes`, `openclaw`, `demo`) when a persisted URL exists for the selected adapter, regardless of `lastKnownGood`. The lastKnownGood check is preserved for non-auto-managed types.

### 3. Persistence-layer feedback loop → `PUT /api/studio` spam + React "Maximum update depth"

After OfficeScreen mounts, the dev server logs `PUT /api/studio` at ~1/second indefinitely, even on an idle page. React occasionally throws \`Maximum update depth exceeded\`. Three independent contributors:

- **`GatewayClient.ts` schedulePatch effect** compared against `loadedGatewaySettings.current`, a baseline frozen at boot. After any valid adapter switch, every render saw state as "dirty" and re-scheduled the same patch. Fix: add a JSON-snapshot ref AND update the baseline after scheduling.
- **`useTaskBoardController.ts` taskBoard persistence effect** wrote on every `state.cards` reference change without semantic equality. Fix: JSON-snapshot ref.
- **`useTaskBoardController.ts` dedupe effect** dispatched `upsert` for archive marks, mutating `state.cards` and re-running the effect — a tight render→effect→dispatch loop that intermittently hit the React update-depth limit. Fix: snapshot ref keyed on the not-archived openclaw_event cards (id/title/agent/thread).
- **`coordinator.ts` `mergeStudioPatch`** missed copying `taskBoard` in the \`!current\` branch, allowing initial writes to drop persisted task-board state.

## Test plan

- [x] **OfficeScreen mounts in dev mode**: page renders \`<main bg-black>\` with Building Directory, Kanban board, etc. — no Suspense fallback stuck on "Loading…".
- [x] **Hermes auto-connect**: with \`gateway.adapterType="hermes"\`, \`gateway.url="ws://localhost:18790"\` in \`settings.json\` (lastKnownGood unchanged from openclaw), the UI fires \`client.connect()\` on mount and shows \`HERMES • CONNECTING\` then \`HERMES • CONNECTED\` if the upstream answers.
- [x] **End-to-end frame validation** via the bundled \`ws\` package (proves the proxy path \`browser → /api/gateway/ws → upstream\` is intact for hermes adapter):
  ```bash
  node -e "
  const WS = require('ws');
  const ws = new WS('ws://127.0.0.1:3030/api/gateway/ws', { origin: 'http://localhost:3030' });
  ws.on('open', () => ws.send(JSON.stringify({type:'req',id:'1',method:'connect',params:{client:{id:'t',name:'t'},auth:{}}})));
  ws.on('message', m => console.log(JSON.parse(m)));"
  ```
  Returns \`connect.challenge\` then a \`res\` with \`hello-ok\`, \`adapterType: "hermes"\`, and the method list.
- [x] **PUT spam gone**: server log shows **0 \`PUT /api/studio\`** in a 30s steady-state window post-mount (vs ~30 before).
- [x] **React warnings reduced**: \`Maximum update depth exceeded\` console errors drop from ~3-4/30s to ≤1/30s after patches 3+4 (residual cause unclear but no longer dominant).
- [x] **ESLint clean** on the four modified files (no new warnings; one pre-existing warning on \`client.lastDisconnectCode\` in \`GatewayClient.ts\` is unrelated).

## Notes

- Patches are minimal and additive — no public API changes, no behavior changes outside the broken paths.
- Snapshot-ref pattern is used twice; if you'd prefer a shared utility (\`useStableSchedule\` or similar) happy to refactor in a follow-up.
- The \`useSearchParams\` workaround in patch 1 is dev-mode-pragmatic; if Claw3D ever needs search-param reactivity in this component, lift the call to a child wrapped in its own \`<Suspense>\`.
- Tested against commit \`06e2cbd\` (current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)