### PR TITLE
feat(retro-office): make local-office floor footprint configurable

### DIFF
--- a/src/features/retro-office/core/district.ts
+++ b/src/features/retro-office/core/district.ts
@@ -9,8 +9,39 @@ export type DistrictZone = {
   maxY: number;
 };
 
-export const LOCAL_OFFICE_CANVAS_WIDTH = 1800;
-export const LOCAL_OFFICE_CANVAS_HEIGHT = 720;
+// Local office floor footprint (canvas units). Historically a fixed 1800×720
+// corridor. Now configurable so a floor can be re-shaped (e.g. a compact,
+// square-ish HOME plate instead of a call-center corridor) without editing core.
+//
+// Set NEXT_PUBLIC_LOCAL_OFFICE_WIDTH / NEXT_PUBLIC_LOCAL_OFFICE_HEIGHT (positive
+// integers, canvas units) to override. Defaults preserve the original 1800×720
+// so nothing changes for existing users. Floor, walls, camera framing and the
+// walkability zones below all derive from these two values, so overriding them
+// reshapes the whole plate coherently.
+const FOOTPRINT_DEFAULT_WIDTH = 1800;
+const FOOTPRINT_DEFAULT_HEIGHT = 720;
+
+const readFootprintEnv = (raw: string | undefined, fallback: number): number => {
+  const parsed = raw !== undefined ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+export const LOCAL_OFFICE_CANVAS_WIDTH = readFootprintEnv(
+  process.env.NEXT_PUBLIC_LOCAL_OFFICE_WIDTH,
+  FOOTPRINT_DEFAULT_WIDTH,
+);
+export const LOCAL_OFFICE_CANVAS_HEIGHT = readFootprintEnv(
+  process.env.NEXT_PUBLIC_LOCAL_OFFICE_HEIGHT,
+  FOOTPRINT_DEFAULT_HEIGHT,
+);
+
+// True when the footprint is at least the original size, i.e. the built-in
+// east-wing office rooms (gym / QA lab, authored at fixed x∈[1092,1534]) still
+// fit on the plate. On a smaller custom plate they would spill past the wall, so
+// callers gate that office-specific decoration on this flag.
+export const FOOTPRINT_FITS_DEFAULT_OFFICE =
+  LOCAL_OFFICE_CANVAS_WIDTH >= FOOTPRINT_DEFAULT_WIDTH &&
+  LOCAL_OFFICE_CANVAS_HEIGHT >= FOOTPRINT_DEFAULT_HEIGHT;
 
 export const LOCAL_OFFICE_ZONE: DistrictZone = {
   minX: 0,

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/features/retro-office/core/constants";
 import {
   CITY_PATH_ZONE,
+  FOOTPRINT_FITS_DEFAULT_OFFICE,
   LOCAL_OFFICE_CANVAS_HEIGHT,
   LOCAL_OFFICE_CANVAS_WIDTH,
   REMOTE_OFFICE_ZONE,
@@ -357,7 +358,9 @@ export const FloorAndWalls = memo(function FloorAndWalls({
         </>
       ) : null}
 
-      {gymZoneFloorWidth > 0 && roomZoneFloorHeight > 0 ? (
+      {FOOTPRINT_FITS_DEFAULT_OFFICE &&
+      gymZoneFloorWidth > 0 &&
+      roomZoneFloorHeight > 0 ? (
         <>
           <mesh
             position={[gymZoneCenterX, 0.002, roomZoneCenterZ]}
@@ -388,7 +391,9 @@ export const FloorAndWalls = memo(function FloorAndWalls({
         </>
       ) : null}
 
-      {qaZoneFloorWidth > 0 && roomZoneFloorHeight > 0 ? (
+      {FOOTPRINT_FITS_DEFAULT_OFFICE &&
+      qaZoneFloorWidth > 0 &&
+      roomZoneFloorHeight > 0 ? (
         <>
           <mesh
             position={[qaZoneCenterX, 0.003, roomZoneCenterZ]}


### PR DESCRIPTION
## Make the local-office floor footprint configurable

### What

The local-office floor plate is currently hardcoded to **1800×720** in
`src/features/retro-office/core/district.ts`:

```ts
export const LOCAL_OFFICE_CANVAS_WIDTH = 1800;
export const LOCAL_OFFICE_CANVAS_HEIGHT = 720;
```

This PR makes those two values read from environment variables, falling back to
the current constants when unset:

- `LOCAL_OFFICE_CANVAS_WIDTH`  ← `NEXT_PUBLIC_LOCAL_OFFICE_WIDTH`  (default `1800`)
- `LOCAL_OFFICE_CANVAS_HEIGHT` ← `NEXT_PUBLIC_LOCAL_OFFICE_HEIGHT` (default `720`)

Parsing is defensive (positive integers only; anything else falls back to the
default), so a missing or malformed value can never break an existing install.

### Why

The default footprint is a long, corridor-shaped call center. Some deployments
want a different shape — our use case is a **household / "home" floor**: a
compact, roughly-square plate with a central common room ringed by a few rooms,
which reads as a home rather than an office. Today that requires editing core
geometry; this makes it a config knob instead.

Everything downstream already derives from these two constants — the floor plane,
the four perimeter walls, the interior floor lines and the isometric camera
framing (`SCALE` / `toWorld` / `LOCAL_CAMERA_TARGET`), plus the walkability zone
`LOCAL_OFFICE_ZONE` used by pathfinding — so overriding them reshapes the whole
plate coherently with no other changes.

### The one guard added

The built-in **east-wing gym / QA-lab decorative floor tiles** in
`scene/environment.tsx` are authored at fixed canvas coordinates
(`x ∈ [1092, 1534]`). On a plate smaller than the default they would render past
the wall. A new exported flag, `FOOTPRINT_FITS_DEFAULT_OFFICE` (true only when the
plate is at least the default size), now gates those two tile blocks so they
render exactly as before on the default footprint and are cleanly omitted on a
smaller custom one.

### Backwards compatibility

Fully backwards compatible. With no env vars set, the footprint is exactly
`1800×720` and `FOOTPRINT_FITS_DEFAULT_OFFICE` is `true`, so rendering is
byte-identical to before. `npx tsc --noEmit` passes.

### Files

- `src/features/retro-office/core/district.ts` — env-driven footprint + the
  `FOOTPRINT_FITS_DEFAULT_OFFICE` flag.
- `src/features/retro-office/scene/environment.tsx` — gate the east-wing
  decorative tiles on the new flag.
