### PR TITLE
feat(office): embed/minimal mode for kiosk embedding

### DIFF
--- a/src/features/office/embedMode.ts
+++ b/src/features/office/embedMode.ts
@@ -1,0 +1,44 @@
+/**
+ * Office embed mode.
+ *
+ * Claw3D's office screen ships a full "product" chrome: a building directory,
+ * an HQ sidebar (inbox / kanban / marketplace / analytics), an agent event
+ * console, and an in-scene toolbar. That surface is right for the standalone
+ * product, but noise when the office is embedded as a calm ambient view — e.g.
+ * a kitchen kiosk / tablet where a household just wants to see who's around.
+ *
+ * `embed=home` hides that chrome behind a single flag while keeping the scene,
+ * agent nameplates, roster pill, title, camera controls, and chat. The full UI
+ * stays one query param away (`?full=1`) so layout/builder work is unaffected.
+ *
+ * Resolution order (first match wins):
+ *   1. `?full=1`  → always the full UI (explicit escape hatch).
+ *   2. `?embed=home` → minimal home chrome.
+ *   3. `NEXT_PUBLIC_CLAW3D_EMBED=home` → minimal home chrome by default
+ *      (for deployments that are always embedded, with no param to set).
+ *   4. otherwise → full UI (unchanged default).
+ */
+export type OfficeEmbedMode = "home" | null;
+
+const HOME: OfficeEmbedMode = "home";
+
+/** Minimal reader interface so this works with URLSearchParams and Next's
+ * ReadonlyURLSearchParams alike. */
+export interface EmbedParamReader {
+  get(name: string): string | null;
+}
+
+export function resolveOfficeEmbedMode(
+  params: EmbedParamReader | null | undefined,
+): OfficeEmbedMode {
+  if (params?.get("full") === "1") return null;
+  if (params?.get("embed") === "home") return HOME;
+  const embedParam = params?.get("embed") ?? null;
+  if (
+    !embedParam &&
+    (process.env.NEXT_PUBLIC_CLAW3D_EMBED ?? "").trim().toLowerCase() === "home"
+  ) {
+    return HOME;
+  }
+  return null;
+}

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -12,6 +12,7 @@ import { useRouter } from "next/navigation";
 import { MessageSquare, ChevronDown, ChevronLeft, ChevronRight, Mic } from "lucide-react";
 import { RetroOffice3D } from "@/features/retro-office/RetroOffice3D";
 import type { OfficeAgent } from "@/features/retro-office/core/types";
+import { resolveOfficeEmbedMode } from "@/features/office/embedMode";
 import { RunningAvatarLoader } from "@/features/agents/components/RunningAvatarLoader";
 import { GatewayConnectScreen } from "@/features/agents/components/GatewayConnectScreen";
 import { useAgentStore, type AgentState } from "@/features/agents/state/store";
@@ -961,6 +962,17 @@ export function OfficeScreen({
   const debugEnabled = useMemo(() => {
     if (typeof window === "undefined") return false;
     return new URLSearchParams(window.location.search).get("officeDebug") === "1";
+  }, []);
+  // Minimal "home" embed (kiosk/tablet ambient view): hide product chrome —
+  // building directory, HQ sidebar, event console, in-scene toolbar — behind one
+  // flag. `?full=1` restores everything. Read via the same SSR-safe window path
+  // as debugEnabled above (no useSearchParams). See embedMode.ts for resolution.
+  const isHomeEmbed = useMemo(() => {
+    if (typeof window === "undefined") return false;
+    return (
+      resolveOfficeEmbedMode(new URLSearchParams(window.location.search)) ===
+      "home"
+    );
   }, []);
   const [settingsCoordinator] = useState(() =>
     createStudioSettingsCoordinator(),
@@ -4748,18 +4760,21 @@ export function OfficeScreen({
           </div>
         </div>
       ) : null}
-      <OfficeFloorNav
-        activeFloorId={activeFloor.id}
-        floorRosterCache={floorRosterCache}
-        onSelectFloor={(floorId) => {
-          void handleSelectFloor(floorId);
-        }}
-        activeAdapterType={(selectedAdapterType as FloorProvider) ?? null}
-      />
+      {!isHomeEmbed ? (
+        <OfficeFloorNav
+          activeFloorId={activeFloor.id}
+          floorRosterCache={floorRosterCache}
+          onSelectFloor={(floorId) => {
+            void handleSelectFloor(floorId);
+          }}
+          activeAdapterType={(selectedAdapterType as FloorProvider) ?? null}
+        />
+      ) : null}
       <section className="relative h-full min-h-0 min-w-0 overflow-hidden">
         <RetroOffice3D
           key={activeFloor.id}
           agents={allVisibleAgents}
+          embedHome={isHomeEmbed}
           storageNamespace={activeFloor.id}
           layoutPreset={activeFloor.kind === "lobby" ? "lobby" : "office"}
           officeCenterSignal={officeCameraCenterSignal}
@@ -4992,7 +5007,7 @@ export function OfficeScreen({
         ) : null}
       </section>
 
-      {showEmptyFleetBanner ? (
+      {showEmptyFleetBanner && !isHomeEmbed ? (
         <div className="pointer-events-none fixed left-1/2 top-16 z-40 w-full max-w-xl -translate-x-1/2 px-4">
           <div className="pointer-events-auto rounded-lg border border-amber-400/35 bg-black/80 px-4 py-3 shadow-2xl backdrop-blur">
             <div className="flex items-center justify-between gap-3">
@@ -5047,7 +5062,7 @@ export function OfficeScreen({
         </div>
       ) : null}
 
-      {!debugEnabled ? (
+      {!debugEnabled && !isHomeEmbed ? (
         <HQSidebar
           open={sidebarOpen}
           activeTab={activeSidebarTab}
@@ -5172,7 +5187,7 @@ export function OfficeScreen({
         />
       ) : null}
 
-      {showOpenClawConsole ? (
+      {showOpenClawConsole && !isHomeEmbed ? (
         <section className="pointer-events-auto fixed bottom-3 left-3 z-30 flex w-[520px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded border border-cyan-500/25 bg-black/78 shadow-2xl backdrop-blur">
           <div className="flex items-center justify-between border-b border-cyan-500/15 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-cyan-200/80">
             <span>Agent Event Console</span>

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -2246,6 +2246,7 @@ export function RetroOffice3D({
   officeCenterSignal = 0,
   animationState = null,
   readOnly = false,
+  embedHome = false,
   storageNamespace = "default",
   layoutPreset = "office",
   deskAssignmentByDeskUid = EMPTY_STRING_RECORD,
@@ -2360,6 +2361,10 @@ export function RetroOffice3D({
     | "jukeboxHoldByAgentId"
   > | null;
   readOnly?: boolean;
+  /** Minimal "home" embed: hide product chrome (top-right toolbar, in-scene
+   * kanban/standup buttons, bottom-left status bar). Scene, nameplates, title,
+   * roster pill, and camera controls stay. See features/office/embedMode.ts. */
+  embedHome?: boolean;
   storageNamespace?: string;
   layoutPreset?: OfficeLayoutPreset;
   deskAssignmentByDeskUid?: Record<string, string>;
@@ -5866,7 +5871,7 @@ export function RetroOffice3D({
               </button>
             ))}
           </div>
-          {standupMeeting ? (
+          {standupMeeting && !embedHome ? (
             <button
               type="button"
               onClick={() => setStandupBoardOpen(true)}
@@ -5888,7 +5893,7 @@ export function RetroOffice3D({
               </div>
             </button>
           ) : null}
-          {kanbanBoardItem ? (
+          {kanbanBoardItem && !embedHome ? (
             <button
               type="button"
               onClick={() => openKanbanBoard(kanbanBoardItem)}
@@ -6956,7 +6961,7 @@ export function RetroOffice3D({
       )}
 
       {/* Toolbar — top right. */}
-      {!readOnly && !immersiveOverlayActive ? (
+      {!readOnly && !immersiveOverlayActive && !embedHome ? (
         <div className="absolute top-3 right-3 flex items-center gap-2 z-20">
           {remoteOfficeEnabled &&
           (remoteOfficeSourceKind === "presence_endpoint"
@@ -7154,7 +7159,7 @@ export function RetroOffice3D({
         </div>
       ) : null}
 
-      {!immersiveOverlayActive ? (
+      {!immersiveOverlayActive && !embedHome ? (
         <>
           {/* Ideas 3 + 6 + 8: Mini status bar — bottom left. */}
           <div className="absolute bottom-3 left-3 flex flex-col items-start gap-1.5 z-10 pointer-events-none select-none">


### PR DESCRIPTION
## What

Adds an **embed / minimal mode** for the office screen so Claw3D can be dropped
into a calm ambient surface — a kitchen kiosk, a wall tablet, a status display —
without its full product chrome. One flag hides the chrome; the default is
completely unchanged.

Motivation: we embed `/office` as the "Home" tab of a household kiosk. The
building directory, HQ sidebar, agent event console, in-scene toolbar, and
kanban/standup buttons are meaningful in the product but pure noise on a family
tablet that just wants to see who's around.

## The flag

Resolution order (`src/features/office/embedMode.ts`, first match wins):

1. `?full=1` → **always** the full UI (explicit escape hatch — keeps
   `/office/builder` + directory reachable for layout work).
2. `?embed=home` → minimal home chrome.
3. `NEXT_PUBLIC_CLAW3D_EMBED=home` → minimal by default (always-embedded
   deployments with no param to set).
4. otherwise → full UI, **unchanged**.

## What it hides (only under `embed=home`)

- `OfficeScreen`: building directory (`OfficeFloorNav`), HQ sidebar
  (inbox/kanban/marketplace/analytics), agent event console, empty-fleet banner.
- `RetroOffice3D` (via a new `embedHome` prop): top-right toolbar (add / runtime
  badge / heatmap / trails / edit / settings), in-scene kanban + standup buttons,
  and the bottom-left status bar (counts + `drag · scroll · dbl-click` hint).

## What it keeps

3D scene, agent nameplates, office title, roster pill, camera controls (top-left),
and the chat entry point — in **both** modes.

## Safety

- Default (no flag) render is byte-for-byte the current full UI — existing users
  are unaffected.
- `isHomeEmbed` is read via the same SSR-safe `window.location.search` +
  `useMemo` path the screen already uses for `officeDebug` (no `useSearchParams`
  at the component root, matching the existing hydration-suspense fix).
- `tsc --noEmit` passes.

## Verification

Loaded both modes × desktop/tablet × light/dark and asserted every chrome marker
is **absent** under `embed=home` and **present** under `full=1` (screenshots
attached in the downstream repo). Before/after:

- `embed=home`: scene + nameplates + title + roster pill + camera + chat only.
- `full=1`: kanban button, directory, runtime badge, HQ rail, and event console
  all restored.

Third contribution from the Casa Pinello household-embedding work (after the
zero-config kiosk seam and the configurable floor footprint, #143).
