### PR TITLE
docs: fix directory case in clone instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please use GitHub Issues for bugs, feature requests, and questions about planned
 ## Local setup
 ```bash
 git clone https://github.com/iamlukethedev/Claw3D.git
-cd claw3d
+cd Claw3D
 npm install
 cp .env.example .env
 npm run dev


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` told contributors to run `cd claw3d` after `git clone`, but a plain `git clone` with no target directory creates a folder matching the repo name, `Claw3D` (capital C).
- On case-sensitive filesystems (Linux, most CI runners) `cd claw3d` fails right after the clone step, breaking the documented local setup flow.

## Fix
- Changed `cd claw3d` to `cd Claw3D` to match the actual cloned directory name.

## Test plan
- [x] Visual diff review — doc-only change, no code affected.