### PR TITLE
feat(voice): add MiniMax speech provider for voice replies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,11 @@ DEBUG=true
 # ELEVENLABS_API_KEY=
 # ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
 # ELEVENLABS_MODEL_ID=eleven_flash_v2_5
+
+# MiniMax voice replies (alternative TTS provider)
+# Set voice reply provider to "minimax" on the client to use this backend.
+# MINIMAX_REGION selects the API host: global_en (api.minimax.io) or cn_zh (api.minimaxi.com).
+# MINIMAX_API_KEY=
+# MINIMAX_VOICE_ID=
+# MINIMAX_MODEL_ID=speech-2.8-hd
+# MINIMAX_REGION=global_en

--- a/src/app/api/office/voice/reply/route.ts
+++ b/src/app/api/office/voice/reply/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
-import { synthesizeVoiceReply, type VoiceReplyProvider } from "@/lib/voiceReply/provider";
+import {
+  synthesizeVoiceReply,
+  type MiniMaxVoiceRegion,
+  type VoiceReplyProvider,
+} from "@/lib/voiceReply/provider";
 
 export const runtime = "nodejs";
 
@@ -8,6 +12,7 @@ type VoiceReplyRequestBody = {
   provider?: VoiceReplyProvider;
   voiceId?: string | null;
   speed?: number;
+  region?: MiniMaxVoiceRegion;
 };
 
 const MAX_REPLY_CHARS = 5_000;
@@ -30,6 +35,7 @@ export async function POST(request: Request) {
       provider: body.provider,
       voiceId: body.voiceId,
       speed: body.speed,
+      region: body.region,
     });
     return new Response(response.body, {
       status: 200,
@@ -41,7 +47,7 @@ export async function POST(request: Request) {
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Failed to synthesize the voice reply.";
-    const status = message.includes("Missing ELEVENLABS_API_KEY") ? 503 : 500;
+    const status = message.startsWith("Missing ") ? 503 : 500;
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/lib/voiceReply/provider.ts
+++ b/src/lib/voiceReply/provider.ts
@@ -1,10 +1,18 @@
-export type VoiceReplyProvider = "elevenlabs";
+export type VoiceReplyProvider = "elevenlabs" | "minimax";
+
+export type MiniMaxVoiceRegion = "global_en" | "cn_zh";
 
 export type VoiceReplySynthesisRequest = {
   text: string;
   provider?: VoiceReplyProvider;
   voiceId?: string | null;
   speed?: number;
+  /**
+   * MiniMax speech region. When omitted, falls back to the
+   * MINIMAX_REGION environment variable (defaults to global_en).
+   * Only used by the MiniMax provider.
+   */
+  region?: MiniMaxVoiceRegion;
 };
 
 const ELEVENLABS_API_URL = "https://api.elevenlabs.io/v1/text-to-speech";
@@ -12,6 +20,41 @@ const DEFAULT_VOICE_REPLY_PROVIDER: VoiceReplyProvider = "elevenlabs";
 const DEFAULT_ELEVENLABS_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
 const DEFAULT_ELEVENLABS_MODEL_ID =
   process.env.ELEVENLABS_MODEL_ID?.trim() || "eleven_flash_v2_5";
+
+// MiniMax text-to-audio (speech-2.x) endpoints. The global and CN regions are
+// served from distinct hosts, so callers must hit the endpoint that matches
+// their credentials' region.
+const MINIMAX_T2A_ENDPOINTS: Record<MiniMaxVoiceRegion, string> = {
+  global_en: "https://api.minimax.io/v1/t2a_v2",
+  cn_zh: "https://api.minimaxi.com/v1/t2a_v2",
+};
+
+// MiniMax speech models supported by the /v1/t2a_v2 endpoint. The default is
+// configurable via MINIMAX_MODEL_ID so newly released models can be opted into
+// without a code change; the list documents the current model choices.
+const MINIMAX_SPEECH_MODEL_IDS = [
+  "speech-2.8-hd",
+  "speech-2.8-turbo",
+  "speech-2.6-hd",
+  "speech-2.6-turbo",
+  "speech-02-hd",
+  "speech-02-turbo",
+  "speech-01-hd",
+  "speech-01-turbo",
+] as const;
+const resolveMiniMaxModelId = (): string =>
+  process.env.MINIMAX_MODEL_ID?.trim() || MINIMAX_SPEECH_MODEL_IDS[0];
+
+const isMiniMaxRegion = (value: string | null | undefined): value is MiniMaxVoiceRegion =>
+  value === "global_en" || value === "cn_zh";
+
+const resolveMiniMaxRegion = (request: VoiceReplySynthesisRequest): MiniMaxVoiceRegion => {
+  const explicit = request.region?.trim().toLowerCase();
+  if (isMiniMaxRegion(explicit)) return explicit;
+  const fromEnv = process.env.MINIMAX_REGION?.trim().toLowerCase();
+  if (isMiniMaxRegion(fromEnv)) return fromEnv;
+  return "global_en";
+};
 
 const normalizeVoiceSpeed = (value: number | null | undefined): number => {
   if (typeof value !== "number" || !Number.isFinite(value)) return 1;
@@ -24,6 +67,14 @@ const normalizeVoiceId = (value: string | null | undefined): string => {
   const fromEnv = process.env.ELEVENLABS_VOICE_ID?.trim();
   if (fromEnv) return fromEnv;
   return DEFAULT_ELEVENLABS_VOICE_ID;
+};
+
+const normalizeMiniMaxVoiceId = (value: string | null | undefined): string => {
+  const explicit = value?.trim();
+  if (explicit) return explicit;
+  const fromEnv = process.env.MINIMAX_VOICE_ID?.trim();
+  if (fromEnv) return fromEnv;
+  throw new Error("Missing MINIMAX_VOICE_ID.");
 };
 
 const synthesizeWithElevenLabs = async (
@@ -66,6 +117,74 @@ const synthesizeWithElevenLabs = async (
   return response;
 };
 
+const synthesizeWithMiniMax = async (
+  request: VoiceReplySynthesisRequest
+): Promise<Response> => {
+  const apiKey = process.env.MINIMAX_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("Missing MINIMAX_API_KEY.");
+  }
+  const voiceId = normalizeMiniMaxVoiceId(request.voiceId);
+  const speed = normalizeVoiceSpeed(request.speed);
+  const region = resolveMiniMaxRegion(request);
+  const endpoint = MINIMAX_T2A_ENDPOINTS[region];
+  const modelId = resolveMiniMaxModelId();
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: modelId,
+      text: request.text,
+      stream: false,
+      voice_setting: {
+        voice_id: voiceId,
+        speed,
+      },
+      audio_setting: {
+        sample_rate: 24000,
+        bitrate: 128000,
+        format: "mp3",
+        channel: 1,
+      },
+    }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const detail = (await response.text().catch(() => "")).trim();
+    throw new Error(detail || "MiniMax voice synthesis failed.");
+  }
+
+  // MiniMax returns a JSON envelope with base64-encoded audio under data.audio
+  // (and a base_resp status code/message). Parse it into a binary audio
+  // response so downstream callers receive the same shape as ElevenLabs.
+  const payload = (await response.json().catch(() => null)) as
+    | {
+        data?: { audio?: string | null; status?: number };
+        base_resp?: { status_code?: number; status_msg?: string };
+      }
+    | null;
+
+  const audioBase64 = payload?.data?.audio ?? "";
+  if (!audioBase64) {
+    const statusMsg = payload?.base_resp?.status_msg?.trim();
+    throw new Error(statusMsg || "MiniMax voice synthesis returned no audio.");
+  }
+
+  const audioBytes = Buffer.from(audioBase64, "base64");
+  return new Response(new Uint8Array(audioBytes), {
+    status: 200,
+    headers: {
+      "Content-Type": "audio/mpeg",
+      "Cache-Control": "no-store",
+    },
+  });
+};
+
 export const synthesizeVoiceReply = async (
   request: VoiceReplySynthesisRequest
 ): Promise<Response> => {
@@ -73,6 +192,8 @@ export const synthesizeVoiceReply = async (
   switch (provider) {
     case "elevenlabs":
       return synthesizeWithElevenLabs(request);
+    case "minimax":
+      return synthesizeWithMiniMax(request);
     default:
       throw new Error("Unsupported voice reply provider.");
   }

--- a/tests/unit/voiceReplyProvider.test.ts
+++ b/tests/unit/voiceReplyProvider.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { synthesizeVoiceReply } from "@/lib/voiceReply/provider";
+
+// ---------------------------------------------------------------------------
+// fetch is mocked so the MiniMax provider is exercised without a network call.
+// ---------------------------------------------------------------------------
+
+const jsonLike = (body: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+const fetchMock = vi.fn();
+
+vi.stubGlobal("fetch", fetchMock);
+
+const BASE_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env = { ...BASE_ENV };
+});
+
+afterEach(() => {
+  process.env = { ...BASE_ENV };
+});
+
+describe("synthesizeVoiceReply — MiniMax provider", () => {
+  it("hits the global region endpoint and parses data.audio into an mp3 response", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    process.env.MINIMAX_VOICE_ID = "voice-123";
+
+    // base64 for "audio" bytes: Buffer.from("clip").toString("base64")
+    const audioBase64 = Buffer.from("clip").toString("base64");
+    fetchMock.mockResolvedValueOnce(
+      jsonLike({
+        data: { audio: audioBase64, status: 2 },
+        base_resp: { status_code: 0, status_msg: "" },
+      })
+    );
+
+    const response = await synthesizeVoiceReply({
+      text: "hello",
+      provider: "minimax",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.minimax.io/v1/t2a_v2");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers?.Authorization).toBe("Bearer test-key");
+    const sentBody = JSON.parse(String(init?.body));
+    expect(sentBody.model).toBe("speech-2.8-hd");
+    expect(sentBody.text).toBe("hello");
+    expect(sentBody.stream).toBe(false);
+    expect(sentBody.voice_setting.voice_id).toBe("voice-123");
+    expect(sentBody.audio_setting.format).toBe("mp3");
+
+    expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    expect(Buffer.from(bytes).toString("utf8")).toBe("clip");
+  });
+
+  it("uses the cn_zh region endpoint when configured via the request", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    process.env.MINIMAX_VOICE_ID = "voice-cn";
+
+    fetchMock.mockResolvedValueOnce(
+      jsonLike({
+        data: { audio: Buffer.from("ok").toString("base64") },
+        base_resp: { status_code: 0 },
+      })
+    );
+
+    await synthesizeVoiceReply({
+      text: "你好",
+      provider: "minimax",
+      region: "cn_zh",
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.minimaxi.com/v1/t2a_v2");
+  });
+
+  it("honors MINIMAX_REGION for the cn_zh host", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    process.env.MINIMAX_VOICE_ID = "voice-cn";
+    process.env.MINIMAX_REGION = "cn_zh";
+
+    fetchMock.mockResolvedValueOnce(
+      jsonLike({ data: { audio: Buffer.from("ok").toString("base64") } })
+    );
+
+    await synthesizeVoiceReply({ text: "hi", provider: "minimax" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.minimaxi.com/v1/t2a_v2");
+  });
+
+  it("allows overriding the speech model via MINIMAX_MODEL_ID", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    process.env.MINIMAX_VOICE_ID = "voice-123";
+    process.env.MINIMAX_MODEL_ID = "speech-2.6-turbo";
+
+    fetchMock.mockResolvedValueOnce(
+      jsonLike({ data: { audio: Buffer.from("ok").toString("base64") } })
+    );
+
+    await synthesizeVoiceReply({ text: "hi", provider: "minimax" });
+
+    const sent = fetchMock.mock.calls[0][1];
+    const sentBody = JSON.parse(String(sent?.body));
+    expect(sentBody.model).toBe("speech-2.6-turbo");
+  });
+
+  it("rejects an unknown region and falls back to the global host", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    process.env.MINIMAX_VOICE_ID = "voice-123";
+
+    fetchMock.mockResolvedValueOnce(
+      jsonLike({ data: { audio: Buffer.from("ok").toString("base64") } })
+    );
+
+    await synthesizeVoiceReply({
+      text: "hi",
+      provider: "minimax",
+      // @ts-expect-error — exercise the runtime guard with a bogus region
+      region: "mars",
+    });
+
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.minimax.io/v1/t2a_v2");
+  });
+
+  it("throws when MINIMAX_API_KEY is missing", async () => {
+    delete process.env.MINIMAX_API_KEY;
+    process.env.MINIMAX_VOICE_ID = "voice-123";
+
+    await expect(
+      synthesizeVoiceReply({ text: "hi", provider: "minimax" })
+    ).rejects.toThrow(/Missing MINIMAX_API_KEY/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when MINIMAX_VOICE_ID is missing", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    delete process.env.MINIMAX_VOICE_ID;
+
+    await expect(
+      synthesizeVoiceReply({ text: "hi", provider: "minimax" })
+    ).rejects.toThrow(/Missing MINIMAX_VOICE_ID/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the base_resp status message when no audio is returned", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    process.env.MINIMAX_VOICE_ID = "voice-123";
+
+    fetchMock.mockResolvedValueOnce(
+      jsonLike({ data: { audio: "" }, base_resp: { status_code: 1004, status_msg: "voice not found" } })
+    );
+
+    await expect(
+      synthesizeVoiceReply({ text: "hi", provider: "minimax" })
+    ).rejects.toThrow(/voice not found/);
+  });
+
+  it("throws on a non-2xx response", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    process.env.MINIMAX_VOICE_ID = "voice-123";
+
+    fetchMock.mockResolvedValueOnce(
+      new Response("unauthorized", { status: 401 })
+    );
+
+    await expect(
+      synthesizeVoiceReply({ text: "hi", provider: "minimax" })
+    ).rejects.toThrow(/unauthorized|MiniMax voice synthesis failed/);
+  });
+
+  it("clamps voice speed to the supported range", async () => {
+    process.env.MINIMAX_API_KEY = "test-key";
+    process.env.MINIMAX_VOICE_ID = "voice-123";
+
+    fetchMock.mockResolvedValueOnce(
+      jsonLike({ data: { audio: Buffer.from("ok").toString("base64") } })
+    );
+
+    await synthesizeVoiceReply({ text: "hi", provider: "minimax", speed: 5 });
+
+    const sent = fetchMock.mock.calls[0][1];
+    const sentBody = JSON.parse(String(sent?.body));
+    expect(sentBody.voice_setting.speed).toBe(1.2);
+  });
+});
+
+describe("synthesizeVoiceReply — provider dispatch", () => {
+  it("throws on an unsupported provider", async () => {
+    await expect(
+      // @ts-expect-error — exercise the default branch
+      synthesizeVoiceReply({ text: "hi", provider: "nope" })
+    ).rejects.toThrow(/Unsupported voice reply provider/);
+  });
+});


### PR DESCRIPTION
Reason: Add a MiniMax speech provider so voice replies can use the /v1/t2a_v2 endpoint (global and CN regions) alongside ElevenLabs.

## Changes

- `src/lib/voiceReply/provider.ts`: Add a `minimax` provider to `VoiceReplyProvider`. The new `synthesizeWithMiniMax` targets the `/v1/t2a_v2` endpoint, supports both regions (`api.minimax.io` for `global_en`, `api.minimaxi.com` for `cn_zh`), sends the `model`/`text`/`stream`/`voice_setting`/`audio_setting` request fields, and parses the base64 audio returned under `data.audio` into a binary mp3 response (surfacing `base_resp.status_msg` on failure). The speech model defaults to `speech-2.8-hd` and is overridable via `MINIMAX_MODEL_ID`; region is selectable per request or via `MINIMAX_REGION`.
- `src/app/api/office/voice/reply/route.ts`: Forward the new `region` field to the provider and map any missing-credential error to HTTP 503 (not just ElevenLabs).
- `.env.example`: Document the `MINIMAX_*` environment variables.
- `tests/unit/voiceReplyProvider.test.ts`: Cover region selection, model override, env resolution, credential/validation errors, response parsing, speed clamping, and provider dispatch.

## Checks

- `npx vitest run tests/unit/voiceReplyProvider.test.ts` — 11 tests pass.
- `npx vitest run` (full suite) — the voice-reply tests pass; the only failing suites (`agentFleetHydration`, `agentChatPanel-controls`, `useAgentSettingsMutationController`, `useGatewayConnection`) also fail on a clean upstream `main` checkout with the same dependencies, so they are pre-existing and unrelated to this change.
- `npx eslint src/lib/voiceReply/provider.ts src/app/api/office/voice/reply/route.ts tests/unit/voiceReplyProvider.test.ts` — clean.
