### PR TITLE
feat(office): hide OpenClaw's built-in main agent from the 3D room

### DIFF
--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -4228,7 +4228,12 @@ export function OfficeScreen({
         smsBoothHeld: boolean;
       }
     >();
-    const nextOfficeAgents = state.agents.map((agent) => {
+    // OpenClaw's built-in "main" agent is a permanent fallback/default that cannot
+    // be deleted; hide it from the 3D room without touching the OpenClaw config.
+    const visibleAgents = state.agents.filter(
+      (agent) => agent.agentId !== "main",
+    );
+    const nextOfficeAgents = visibleAgents.map((agent) => {
       const latchedWorking = (workingUntilByAgentId[agent.agentId] ?? 0) > now;
       const deskHeld = Boolean(deskHoldByAgentId[agent.agentId]);
       const gymHeld = Boolean(gymHoldByAgentId[agent.agentId]);


### PR DESCRIPTION
## Summary
- OpenClaw ships a non-deletable default agent (`main`) that acts as the routing fallback. `openclaw agents delete main` refuses outright with `"main" cannot be deleted.` even with `--force`. On installs that use named agents for the actual work, `main` still occupies a desk in the 3D office as an avatar.
- Filter `main` out of the 3D roster only, in `officeAgents` (`src/features/office/screens/OfficeScreen.tsx`).
- Scope is narrow by construction: `officeAgents` feeds `allVisibleAgents`, which is consumed **solely** by `<RetroOffice3D>`. Every other surface (agent settings, chat panel, kanban, floor nav) reads `state.agents` directly and still lists `main`, so it stays fully manageable.
- No gateway behavior change. No OpenClaw config is read or written.

## Testing
- [x] `npm run lint` — 0 errors (8 pre-existing warnings in this file, none on the changed lines)
- [x] `npm run typecheck` — clean (`tsc --noEmit`, exit 0)
- [x] `npm run test` — 5 tests fail across 3 files, **all pre-existing**. Verified the identical 5 failures on a clean `origin/main` checkout: `agentChatPanel-controls`, `agentFleetHydration`, `useGatewayConnection`. None are related to this change.
- [ ] `npm run e2e` — not run (requires `npx playwright install`; no browser dependencies on this headless VPS)

## Reviewer notes
- The filter is a hardcoded `agentId !== "main"`. Deliberately minimal, but it is your call whether that belongs in the product: would you prefer it behind config (env var or studio setting), so users who *do* want `main` on the floor can keep it? Happy to rework.
- `"main"` is OpenClaw's own default-agent id, resolved from `agents.list[0].id` when no agent sets `default: true`. If Claw3D should instead resolve the default agent dynamically from the gateway rather than matching the literal string, say so and I will switch it.

## AI-assisted
- [x] AI-assisted (Claude Code). The change came out of diagnosing why OpenClaw refuses to delete the `main` agent; hiding it from the 3D roster was the non-destructive alternative to deletion.
