### PR TITLE
fix(security-headers): only send TLS-only directives when behind TLS

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,15 @@
 import type { NextConfig } from "next";
 import path from "node:path";
 
+// Set CLAW3D_BEHIND_TLS=1 only when Studio is actually served over HTTPS.
+// When it is served over plain HTTP (e.g. behind an HTTP-only reverse proxy),
+// `upgrade-insecure-requests` / HSTS would force the browser to https:// and
+// wss:// endpoints that do not exist, breaking asset loading and the gateway
+// WebSocket. Keep these HTTPS-only directives off unless TLS is present.
+const behindTls =
+  process.env.CLAW3D_BEHIND_TLS === "1" ||
+  process.env.CLAW3D_BEHIND_TLS === "true";
+
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
@@ -24,7 +33,8 @@ const securityHeaders = [
       "media-src 'self' blob: data: http: https:",
       "worker-src 'self' blob:",
       "object-src 'none'",
-      "upgrade-insecure-requests",
+      // Only upgrade to https/wss when the deployment is actually TLS-terminated.
+      ...(behindTls ? ["upgrade-insecure-requests"] : []),
     ].join("; "),
   },
   {
@@ -49,7 +59,7 @@ const securityHeaders = [
   },
 ];
 
-if (process.env.NODE_ENV === "production") {
+if (process.env.NODE_ENV === "production" && behindTls) {
   securityHeaders.push({
     key: "Strict-Transport-Security",
     value: "max-age=31536000; includeSubDomains",


### PR DESCRIPTION
## Summary
- `upgrade-insecure-requests` (CSP) and `Strict-Transport-Security` were emitted unconditionally.
- When Studio is served over plain HTTP behind an HTTP-only reverse proxy, both force the browser to `https://` and `wss://` endpoints that do not exist. That breaks asset loading and the gateway WebSocket.
- Gate both behind a new `CLAW3D_BEHIND_TLS` env var (`1` or `true`), so they are only sent when TLS is actually terminated in front of Studio.

## Behavior change
Previously these headers were always on; now they are off unless `CLAW3D_BEHIND_TLS` is set. **Existing TLS deployments must set `CLAW3D_BEHIND_TLS=1` to keep the current behavior.** Worth calling out in release notes.

## Testing
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean (`tsc --noEmit`, exit 0)
- [x] `npm run test` — 5 tests fail across 3 files, **all pre-existing** (verified identical failures on a clean `origin/main`): `agentChatPanel-controls`, `agentFleetHydration`, `useGatewayConnection`. Unrelated to this change.
- [ ] `npm run e2e` — not run (requires `npx playwright install`; no browser dependencies on this headless VPS)

## Open items for the reviewer
- **Default direction:** should this be opt-*out* (headers on by default, disabled when explicitly not behind TLS) instead of opt-in? Opt-in is the safer runtime default but silently drops HSTS for anyone upgrading.
- **Docs gap:** `CLAW3D_BEHIND_TLS` is not documented in `.env.example` or the README. Per `CONTRIBUTING.md` ("Update docs when the user-facing behavior or architecture changes") that should probably land in this PR — happy to add it once you confirm the preferred default.

## AI-assisted
- [ ] Not AI-authored. The code change predates the assistant session; the assistant only committed it, ran the test suite, and wrote this description. Please sanity-check that the description matches the original intent.
