### PR TITLE
ci: lowercase the GHCR namespace so forks can publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/claw3d
+  # IMAGE_NAME is assembled in the "Prepare Docker tags" step rather than here:
+  # GHCR requires a lowercase namespace, `github.repository_owner` preserves the
+  # owner's original casing, and `env:` cannot lowercase a value.
+  IMAGE_BASENAME: claw3d
 
 jobs:
   publish:
@@ -38,6 +41,8 @@ jobs:
         run: |
           set -euo pipefail
           tags=()
+          owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          IMAGE_NAME="${REGISTRY}/${owner}/${IMAGE_BASENAME}"
           ref_name="$(printf '%s' "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]' | tr '/_' '-' | tr -cd 'a-z0-9.-')"
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             tags+=("${IMAGE_NAME}:main")


### PR DESCRIPTION
Docker Publish fails on every push for any fork whose owner login contains an uppercase letter:

  ERROR: failed to build: invalid tag
  "ghcr.io/SomeOwner/claw3d:main": repository name must be lowercase

IMAGE_NAME is built from `github.repository_owner`, which preserves the owner's original casing, but a GHCR namespace must be lowercase. The workflow already lowercases the ref name when composing the tag; it just never lowercases the owner. The upstream owner login is already lowercase, so this never shows up here — only in forks.

`env:` cannot lowercase a value, so assemble IMAGE_NAME in the "Prepare Docker tags" step and keep only the basename in `env:`. The image name is unchanged for any lowercase owner, so this is a no-op upstream.

Verified by running the tag-preparation script for a branch push, a main push, and a `v*` tag push, under both a lowercase and a mixed-case owner, and checking each resulting tag against Docker's reference grammar.