### PR TITLE
feat: add OrcaRouter as a first-class OpenAI-compatible runtime provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,16 @@ NEXT_PUBLIC_GATEWAY_URL=ws://localhost:18789
 # CLAW3D_GATEWAY_URL=ws://localhost:18789
 # CLAW3D_GATEWAY_TOKEN=
 # Optional: tell Studio which backend that runtime gateway URL represents.
-# Valid values: openclaw, hermes, demo, custom
+# Valid values: openclaw, hermes, demo, local, claw3d, orcarouter, custom
 # CLAW3D_GATEWAY_ADAPTER_TYPE=openclaw
+
+
+# OrcaRouter backend (OpenAI-compatible model gateway)
+# Choose the OrcaRouter backend in Studio, keep the default URL below, and
+# paste your OrcaRouter API key as the upstream token.
+# CLAW3D_GATEWAY_URL=https://api.orcarouter.ai
+# CLAW3D_GATEWAY_TOKEN=
+# CLAW3D_GATEWAY_ADAPTER_TYPE=orcarouter
 
 
 # HERMES_API_URL=http://localhost:8642

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Common environment variables:
 - `CUSTOM_RUNTIME_ALLOWLIST` restricts which hosts `/api/runtime/custom` may fetch. If unset, it falls back to `UPSTREAM_ALLOWLIST`.
 - `NEXT_PUBLIC_GATEWAY_URL` provides the default upstream gateway URL when Studio settings are empty. **Note:** this is a build-time variable — changes require `npm run build` to take effect.
 - `CLAW3D_GATEWAY_URL` and `CLAW3D_GATEWAY_TOKEN` provide a runtime alternative to `NEXT_PUBLIC_GATEWAY_URL` that takes effect on server restart without a rebuild.
-- `CLAW3D_GATEWAY_ADAPTER_TYPE` can pair with `CLAW3D_GATEWAY_URL` to mark those runtime defaults as `openclaw`, `hermes`, `demo`, `local`, `claw3d`, or `custom`.
+- `CLAW3D_GATEWAY_ADAPTER_TYPE` can pair with `CLAW3D_GATEWAY_URL` to mark those runtime defaults as `openclaw`, `hermes`, `demo`, `local`, `claw3d`, `orcarouter`, or `custom`.
 - If `CLAW3D_GATEWAY_URL` is not set, Studio can still surface local Hermes or demo adapter defaults from `HERMES_ADAPTER_PORT` / `DEMO_ADAPTER_PORT`.
 - OpenClaw file defaults still come from `~/.openclaw/openclaw.json` when present.
 - `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` override the default OpenClaw paths.

--- a/docs/runtime-profiles.md
+++ b/docs/runtime-profiles.md
@@ -9,6 +9,7 @@ Claw3D now treats runtime backends as named saved profiles instead of one global
 - `demo`
 - `local`
 - `claw3d`
+- `orcarouter`
 - `custom`
 
 Each profile keeps its own saved URL and token in Studio settings.
@@ -71,6 +72,22 @@ Typical URL:
 http://localhost:3000/api/runtime/custom
 ```
 
+### `orcarouter`
+
+A provider-native OpenAI-compatible gateway profile for [OrcaRouter](https://www.orcarouter.ai).
+
+OrcaRouter exposes a provider/model namespace across many models behind a single
+endpoint, combined with adaptive routing, automatic failover, observability, and
+guardrails. Claw3D treats it as a named backend rather than an anonymous custom
+base URL: the connect flow probes `/v1/models` and the upstream token is
+forwarded as a Bearer token on every request.
+
+Typical URL:
+
+```text
+https://api.orcarouter.ai
+```
+
 ### `custom`
 
 The generic HTTP runtime seam when you want to point Claw3D at any compatible orchestrator boundary.
@@ -91,6 +108,11 @@ The direct runtime seam currently probes for:
 - `POST /v1/chat/completions`
 
 That means `local`, `claw3d`, and `custom` are first-class saved profiles today.
+
+`orcarouter` is a first-class saved profile as well, but it speaks the
+OpenAI-conformant transport instead of the Claw3D direct-runtime triple: it
+probes `GET /v1/models` and chats over `POST /v1/chat/completions`, with the
+saved upstream token forwarded as a `Bearer` token.
 
 On top of the normal chat/session calls, runtime providers now expose a shared multi-agent message seam:
 

--- a/src/app/api/runtime/custom/route.ts
+++ b/src/app/api/runtime/custom/route.ts
@@ -7,6 +7,7 @@ type CustomRuntimeRequestBody = {
   pathname?: string;
   method?: string;
   body?: unknown;
+  token?: string;
 };
 
 const isRuntimeUrlAllowed = (runtimeUrl: string): boolean => {
@@ -84,12 +85,14 @@ export async function POST(request: Request) {
     const runtimeUrl = normalizeRuntimeUrl(payload.runtimeUrl ?? "");
     const pathname = normalizePathname(payload.pathname);
     const method = normalizeMethod(payload.method);
+    const token = typeof payload.token === "string" ? payload.token.trim() : "";
     // Propagate the browser abort signal so that cancelling the client-side fetch
     // (e.g. hitting Stop) also cancels the upstream runtime request.
     const response = await fetch(`${runtimeUrl}${pathname}`, {
       method,
       headers: {
         Accept: "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : null),
         ...(method === "POST" ? { "Content-Type": "application/json" } : null),
       },
       body: method === "POST" ? JSON.stringify(payload.body ?? {}) : undefined,

--- a/src/features/agents/components/ConnectionPanel.tsx
+++ b/src/features/agents/components/ConnectionPanel.tsx
@@ -43,6 +43,7 @@ export const ConnectionPanel = ({
     selectedAdapterType === "demo" ||
     selectedAdapterType === "local" ||
     selectedAdapterType === "claw3d" ||
+    selectedAdapterType === "orcarouter" ||
     selectedAdapterType === "custom";
   const applyDemoPreset = () => {
     onAdapterTypeChange("demo");
@@ -52,6 +53,9 @@ export const ConnectionPanel = ({
   };
   const applyCustomPreset = () => {
     onAdapterTypeChange("custom");
+  };
+  const applyOrcaRouterPreset = () => {
+    onAdapterTypeChange("orcarouter");
   };
   const applyLocalPreset = () => {
     onAdapterTypeChange("local");
@@ -73,7 +77,9 @@ export const ConnectionPanel = ({
             ? "Claw3D runtime keeps Claw3D transcript semantics over direct HTTP."
             : selectedAdapterType === "local"
               ? "Local runtime expects a direct orchestrator boundary."
-              : "Custom is a generic runtime endpoint, not a provider-native adapter.";
+              : selectedAdapterType === "orcarouter"
+                ? "OrcaRouter is a provider-native OpenAI-compatible gateway that routes many models behind one endpoint."
+                : "Custom is a generic runtime endpoint, not a provider-native adapter.";
 
   return (
     <div className="fade-up-delay flex flex-col gap-3">
@@ -167,6 +173,13 @@ export const ConnectionPanel = ({
           onClick={applyClaw3dPreset}
         >
           Claw3D runtime
+        </button>
+        <button
+          className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"
+          type="button"
+          onClick={applyOrcaRouterPreset}
+        >
+          OrcaRouter backend
         </button>
         <button
           className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"

--- a/src/features/agents/components/GatewayConnectScreen.tsx
+++ b/src/features/agents/components/GatewayConnectScreen.tsx
@@ -52,6 +52,7 @@ export const GatewayConnectScreen = ({
     selectedAdapterType === "demo" ||
     selectedAdapterType === "local" ||
     selectedAdapterType === "claw3d" ||
+    selectedAdapterType === "orcarouter" ||
     selectedAdapterType === "custom";
   const isLocal = useMemo(() => isLocalGatewayUrl(gatewayUrl), [gatewayUrl]);
   const localPort = useMemo(() => resolveLocalGatewayPort(gatewayUrl), [gatewayUrl]);
@@ -78,6 +79,9 @@ export const GatewayConnectScreen = ({
   };
   const useCustomPreset = () => {
     onAdapterTypeChange("custom");
+  };
+  const useOrcaRouterPreset = () => {
+    onAdapterTypeChange("orcarouter");
   };
   const useLocalPreset = () => {
     onAdapterTypeChange("local");
@@ -109,6 +113,8 @@ export const GatewayConnectScreen = ({
         return "Local runtime expects a direct HTTP runtime/orchestrator boundary, not a provider catalog.";
       case "claw3d":
         return "Claw3D runtime preserves Claw3D transcript conventions over the direct runtime seam.";
+      case "orcarouter":
+        return "OrcaRouter is a provider-native OpenAI-compatible gateway. Point it at your OrcaRouter endpoint and paste your API key as the upstream token.";
       case "custom":
       default:
         return "Custom is the generic direct runtime seam. Use it for compatible orchestrators, not for provider-specific auth flows.";
@@ -303,6 +309,13 @@ export const GatewayConnectScreen = ({
             <button
               type="button"
               className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"
+              onClick={useOrcaRouterPreset}
+            >
+              OrcaRouter backend
+            </button>
+            <button
+              type="button"
+              className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"
               onClick={useCustomPreset}
             >
               Custom backend
@@ -353,6 +366,14 @@ export const GatewayConnectScreen = ({
               <span className="font-mono text-foreground"> Custom backend</span> and point the URL at
               your orchestrator or runtime boundary. These profiles already preserve separate saved URLs
               and tokens, but transport-specific chat handoff still needs a follow-up slice.
+            </p>
+          </div>
+          <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+            <p className="text-xs font-medium text-foreground">Using OrcaRouter as your model gateway?</p>
+            <p className="mt-1 text-xs leading-snug text-muted-foreground">
+              Choose <span className="font-mono text-foreground">OrcaRouter backend</span>, keep the
+              default <span className="font-mono text-foreground">https://api.orcarouter.ai</span> URL,
+              and paste your OrcaRouter API key as the upstream token.
             </p>
           </div>
           <div className="rounded-md border border-border bg-muted/30 px-3 py-3">

--- a/src/features/office/components/OfficeFloorNav.tsx
+++ b/src/features/office/components/OfficeFloorNav.tsx
@@ -31,6 +31,7 @@ const PROVIDER_LABEL: Record<FloorProvider, string> = {
   custom: "Custom",
   local: "Local",
   claw3d: "Claw3D",
+  orcarouter: "OrcaRouter",
 };
 
 const renderFloorButton = (params: {

--- a/src/features/office/components/panels/SettingsPanel.tsx
+++ b/src/features/office/components/panels/SettingsPanel.tsx
@@ -90,6 +90,7 @@ export function SettingsPanel({
     selectedAdapterType === "demo" ||
     selectedAdapterType === "local" ||
     selectedAdapterType === "claw3d" ||
+    selectedAdapterType === "orcarouter" ||
     selectedAdapterType === "custom";
   const [remoteOfficeTokenDraft, setRemoteOfficeTokenDraft] = useState("");
 
@@ -139,6 +140,7 @@ export function SettingsPanel({
               ["hermes", "Hermes"],
               ["local", "Local"],
               ["claw3d", "Claw3D"],
+              ["orcarouter", "OrcaRouter"],
               ["custom", "Custom"],
               ["openclaw", "OpenClaw"],
             ] as const
@@ -175,6 +177,8 @@ export function SettingsPanel({
                   ? "http://localhost:7770"
                   : selectedAdapterType === "claw3d"
                     ? "http://localhost:3000/api/runtime/custom"
+                    : selectedAdapterType === "orcarouter"
+                      ? "https://api.orcarouter.ai"
                   : "ws://localhost:18789"
               }
               className="w-full rounded-md border border-cyan-500/10 bg-black/25 px-3 py-2 font-mono text-[11px] text-cyan-100 outline-none transition-colors placeholder:text-cyan-100/30 focus:border-cyan-400/30"

--- a/src/lib/gateway/GatewayClient.ts
+++ b/src/lib/gateway/GatewayClient.ts
@@ -37,7 +37,10 @@ const gatewayDebugLog = (message: string, details?: Record<string, unknown>) => 
   }
   console.info("[gateway-client]", message);
 };
-import { probeCustomRuntime } from "@/lib/runtime/custom/http";
+import {
+  probeCustomRuntime,
+  probeOpenAIConformantRuntime,
+} from "@/lib/runtime/custom/http";
 
 export type ReqFrame = {
   type: "req";
@@ -187,6 +190,7 @@ const normalizeLocalGatewayDefaults = (value: unknown): StudioGatewaySettings | 
     raw.adapterType === "openclaw" ||
     raw.adapterType === "local" ||
     raw.adapterType === "claw3d" ||
+    raw.adapterType === "orcarouter" ||
     raw.adapterType === "custom"
       ? raw.adapterType
       : "openclaw";
@@ -210,7 +214,7 @@ const normalizeGatewayProfilesPublic = (
   if (!value || typeof value !== "object") return undefined;
   const raw = value as Partial<Record<StudioGatewayAdapterType, StudioGatewayProfilePublic>>;
   const profiles: Partial<Record<StudioGatewayAdapterType, { url: string; token: string }>> = {};
-  for (const adapterType of ["openclaw", "hermes", "demo", "local", "claw3d", "custom"] as const) {
+  for (const adapterType of ["openclaw", "hermes", "demo", "local", "claw3d", "orcarouter", "custom"] as const) {
     const profile = normalizeGatewayProfilePublic(raw[adapterType]);
     if (profile) {
       profiles[adapterType] = profile;
@@ -892,12 +896,17 @@ export const useGatewayConnection = (
     if (
       selectedAdapterType === "custom" ||
       selectedAdapterType === "local" ||
-      selectedAdapterType === "claw3d"
+      selectedAdapterType === "claw3d" ||
+      selectedAdapterType === "orcarouter"
     ) {
       setStatus("connecting");
       try {
         await settingsCoordinator.flushPending();
-        await probeCustomRuntime(gatewayUrl);
+        if (selectedAdapterType === "orcarouter") {
+          await probeOpenAIConformantRuntime(gatewayUrl, token);
+        } else {
+          await probeCustomRuntime(gatewayUrl);
+        }
         setDetectedAdapterType(selectedAdapterType);
         setStatus("connected");
         setConnectErrorCode(null);
@@ -1190,7 +1199,8 @@ export const useGatewayConnection = (
     if (
       selectedAdapterType === "custom" ||
       selectedAdapterType === "local" ||
-      selectedAdapterType === "claw3d"
+      selectedAdapterType === "claw3d" ||
+      selectedAdapterType === "orcarouter"
     ) {
       setStatus("disconnected");
       return;
@@ -1213,6 +1223,7 @@ export const useGatewayConnection = (
     (selectedAdapterType === "custom" ||
       selectedAdapterType === "local" ||
       selectedAdapterType === "claw3d" ||
+      selectedAdapterType === "orcarouter" ||
       !hasLastKnownGoodState ||
       !(gatewayUrl ?? "").trim() ||
       (selectedAdapterType === "openclaw" && !(token ?? "").trim()) ||

--- a/src/lib/office/floors.ts
+++ b/src/lib/office/floors.ts
@@ -5,7 +5,8 @@ export type FloorProvider =
   | "custom"
   | "demo"
   | "local"
-  | "claw3d";
+  | "claw3d"
+  | "orcarouter";
 export type FloorZone = "building" | "outside";
 
 export type FloorId =
@@ -14,6 +15,7 @@ export type FloorId =
   | "hermes-first"
   | "local-runtime"
   | "claw3d-runtime"
+  | "orcarouter-floor"
   | "custom-second"
   | "training"
   | "traders-floor"
@@ -88,6 +90,17 @@ export const OFFICE_FLOORS: readonly FloorDefinition[] = [
     enabled: true,
     sortOrder: 28,
     runtimeProfileId: "claw3d-default",
+  },
+  {
+    id: "orcarouter-floor",
+    label: "OrcaRouter Floor",
+    shortLabel: "OrcaRouter",
+    provider: "orcarouter",
+    kind: "runtime",
+    zone: "building",
+    enabled: true,
+    sortOrder: 29,
+    runtimeProfileId: "orcarouter-default",
   },
   {
     id: "custom-second",

--- a/src/lib/runtime/createRuntimeProvider.ts
+++ b/src/lib/runtime/createRuntimeProvider.ts
@@ -9,7 +9,8 @@ import type { StudioGatewayAdapterType } from "@/lib/studio/settings";
 export const createRuntimeProvider = (
   providerId: RuntimeProvider["id"] | StudioGatewayAdapterType,
   client: GatewayClient,
-  runtimeUrl: string
+  runtimeUrl: string,
+  token?: string
 ): RuntimeProvider => {
   switch (providerId) {
     case "local":
@@ -25,6 +26,16 @@ export const createRuntimeProvider = (
         label: "Claw3D Runtime",
         runtimeName: "Claw3D Runtime",
         routeProfile: "claw3d",
+      });
+    case "orcarouter":
+      return new CustomRuntimeProvider(client, runtimeUrl, {
+        id: "orcarouter",
+        label: "OrcaRouter",
+        runtimeName: "OrcaRouter",
+        vendor: "orcarouter",
+        routeProfile: "orcarouter",
+        token,
+        openAIConformant: true,
       });
     case "custom":
       return new CustomRuntimeProvider(client, runtimeUrl, {

--- a/src/lib/runtime/custom/http.ts
+++ b/src/lib/runtime/custom/http.ts
@@ -20,6 +20,8 @@ type CustomRuntimeProxyInput = {
   method?: "GET" | "POST";
   body?: unknown;
   signal?: AbortSignal;
+  /** Optional Bearer token forwarded to the upstream runtime by the proxy. */
+  token?: string;
 };
 
 export async function requestCustomRuntime<T = unknown>({
@@ -28,6 +30,7 @@ export async function requestCustomRuntime<T = unknown>({
   method = "GET",
   body,
   signal,
+  token,
 }: CustomRuntimeProxyInput): Promise<T> {
   const normalizedRuntimeUrl = normalizeCustomBaseUrl(runtimeUrl);
   if (!normalizedRuntimeUrl) {
@@ -46,6 +49,7 @@ export async function requestCustomRuntime<T = unknown>({
       pathname,
       method,
       body,
+      ...(token ? { token } : {}),
     }),
   });
   if (!response.ok) {
@@ -64,11 +68,20 @@ export async function requestCustomRuntime<T = unknown>({
 
 export async function fetchCustomRuntimeJson<T = unknown>(
   runtimeUrl: string,
-  pathname: string
+  pathname: string,
+  token?: string
 ): Promise<T> {
-  return requestCustomRuntime<T>({ runtimeUrl, pathname, method: "GET" });
+  return requestCustomRuntime<T>({ runtimeUrl, pathname, method: "GET", token });
 }
 
 export async function probeCustomRuntime(runtimeUrl: string): Promise<void> {
   await fetchCustomRuntimeJson(runtimeUrl, "/health");
+}
+
+/** Probe an OpenAI-compatible remote gateway (e.g. OrcaRouter) via its model catalog. */
+export async function probeOpenAIConformantRuntime(
+  runtimeUrl: string,
+  token?: string
+): Promise<void> {
+  await fetchCustomRuntimeJson(runtimeUrl, "/v1/models", token);
 }

--- a/src/lib/runtime/custom/provider.ts
+++ b/src/lib/runtime/custom/provider.ts
@@ -59,6 +59,7 @@ type CustomRuntimeStateResponse = {
 
 type CustomRuntimeRegistryResponse = {
   models?: Record<string, unknown> | null;
+  data?: Array<{ id?: unknown } | null> | null;
   [key: string]: unknown;
 };
 
@@ -150,8 +151,19 @@ const isAbortLikeError = (error: unknown, controller?: AbortController | null): 
 };
 
 const normalizeModelChoices = (registry: CustomRuntimeRegistryResponse | null): string[] => {
-  if (!registry || !isRecord(registry.models)) return [];
-  return Object.keys(registry.models).map((value) => value.trim()).filter(Boolean);
+  if (!registry) return [];
+  // OpenAI-conformant catalog: { data: [{ id, ... }] }.
+  if (Array.isArray(registry.data)) {
+    const ids = registry.data
+      .map((entry) => (isRecord(entry) && typeof entry.id === "string" ? entry.id.trim() : ""))
+      .filter(Boolean);
+    if (ids.length > 0) return ids;
+  }
+  // Claw3D direct-runtime catalog: { models: { "id": ... } }.
+  if (isRecord(registry.models)) {
+    return Object.keys(registry.models).map((value) => value.trim()).filter(Boolean);
+  }
+  return [];
 };
 
 const resolveOptionalString = (value: unknown): string | null =>
@@ -241,6 +253,8 @@ export class CustomRuntimeProvider implements RuntimeProvider {
   readonly capabilities = CUSTOM_RUNTIME_CAPABILITIES;
   readonly metadata;
   private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly openAIConformant: boolean;
   private readonly sessions = new Map<string, SessionRecord>();
   private readonly activeRunsByRunId = new Map<string, ActiveRunRecord>();
   private readonly activeRunIdBySessionKey = new Map<string, string>();
@@ -249,16 +263,26 @@ export class CustomRuntimeProvider implements RuntimeProvider {
     readonly client: GatewayClient,
     runtimeUrl: string,
     options?: {
-      id?: Extract<RuntimeProviderId, "custom" | "local" | "claw3d">;
+      id?: Extract<RuntimeProviderId, "custom" | "local" | "claw3d" | "orcarouter">;
       label?: string;
       runtimeName?: string;
       vendor?: string | null;
       routeProfile?: string | null;
+      /** Optional Bearer token forwarded to the upstream runtime. */
+      token?: string;
+      /**
+       * Treat the upstream as an OpenAI-conformant gateway: probe `/v1/models`
+       * for the model catalog instead of the Claw3D direct-runtime
+       * `/health` + `/state` + `/registry` triple.
+       */
+      openAIConformant?: boolean;
     }
   ) {
     this.id = options?.id ?? "custom";
     this.label = options?.label ?? "Custom";
     this.baseUrl = normalizeCustomBaseUrl(runtimeUrl);
+    this.token = options?.token ?? "";
+    this.openAIConformant = options?.openAIConformant ?? false;
     this.metadata = {
       id: this.id,
       label: this.label,
@@ -338,29 +362,38 @@ export class CustomRuntimeProvider implements RuntimeProvider {
   }
 
   async fetchRegistry(): Promise<CustomRuntimeRegistryResponse> {
-    return this.fetchJson<CustomRuntimeRegistryResponse>("/registry");
+    return this.fetchJson<CustomRuntimeRegistryResponse>(
+      this.openAIConformant ? "/v1/models" : "/registry"
+    );
   }
 
   async describeRuntime() {
-    const [health, state, registry] = await Promise.all([
-      this.fetchHealth().catch(() => null),
-      this.fetchState().catch(() => null),
-      this.fetchRegistry().catch(() => null),
+    const health = this.openAIConformant
+      ? Promise.resolve(null)
+      : this.fetchHealth().catch(() => null);
+    const state = this.openAIConformant
+      ? Promise.resolve(null)
+      : this.fetchState().catch(() => null);
+    const registry = this.fetchRegistry().catch(() => null);
+    const [healthResult, stateResult, registryResult] = await Promise.all([
+      health,
+      state,
+      registry,
     ]);
 
-    const routeProfile = resolveRouteProfile(state);
+    const routeProfile = resolveRouteProfile(stateResult);
     const runtimeName =
-      typeof state?.runtime?.name === "string" && state.runtime.name.trim()
-        ? state.runtime.name.trim()
+      typeof stateResult?.runtime?.name === "string" && stateResult.runtime.name.trim()
+        ? stateResult.runtime.name.trim()
         : this.metadata.runtimeName;
     const runtimeVersion =
-      typeof state?.runtime?.version === "string" && state.runtime.version.trim()
-        ? state.runtime.version.trim()
+      typeof stateResult?.runtime?.version === "string" && stateResult.runtime.version.trim()
+        ? stateResult.runtime.version.trim()
         : null;
     const vendor =
-      typeof state?.runtime?.vendor === "string" && state.runtime.vendor.trim()
-        ? state.runtime.vendor.trim()
-        : null;
+      typeof stateResult?.runtime?.vendor === "string" && stateResult.runtime.vendor.trim()
+        ? stateResult.runtime.vendor.trim()
+        : this.metadata.vendor;
 
     return {
       metadata: {
@@ -370,9 +403,9 @@ export class CustomRuntimeProvider implements RuntimeProvider {
         vendor,
         routeProfile,
       },
-      health,
-      state,
-      registry,
+      health: healthResult,
+      state: stateResult,
+      registry: registryResult,
     };
   }
 
@@ -533,6 +566,7 @@ export class CustomRuntimeProvider implements RuntimeProvider {
         pathname: "/v1/chat/completions",
         method: "POST",
         signal: controller.signal,
+        token: this.token,
         body: {
           model: session.model ?? undefined,
           stream: false,
@@ -710,6 +744,6 @@ export class CustomRuntimeProvider implements RuntimeProvider {
   }
 
   private async fetchJson<T = unknown>(pathname: string): Promise<T> {
-    return fetchCustomRuntimeJson<T>(this.baseUrl, pathname);
+    return fetchCustomRuntimeJson<T>(this.baseUrl, pathname, this.token);
   }
 }

--- a/src/lib/runtime/types.ts
+++ b/src/lib/runtime/types.ts
@@ -35,6 +35,7 @@ export type RuntimeProviderId =
   | "demo"
   | "local"
   | "claw3d"
+  | "orcarouter"
   | "custom";
 
 export type RuntimeProviderMetadata = {

--- a/src/lib/runtime/useRuntimeConnection.ts
+++ b/src/lib/runtime/useRuntimeConnection.ts
@@ -25,8 +25,14 @@ export const useRuntimeConnection = (
 ): RuntimeConnectionState => {
   const gateway = useGatewayConnection(settingsCoordinator);
   const provider = useMemo(
-    () => createRuntimeProvider(gateway.activeAdapterType, gateway.client, gateway.gatewayUrl),
-    [gateway.activeAdapterType, gateway.client, gateway.gatewayUrl]
+    () =>
+      createRuntimeProvider(
+        gateway.activeAdapterType,
+        gateway.client,
+        gateway.gatewayUrl,
+        gateway.token
+      ),
+    [gateway.activeAdapterType, gateway.client, gateway.gatewayUrl, gateway.token]
   );
   const capabilities = provider.capabilities;
 

--- a/src/lib/studio/settings-store.ts
+++ b/src/lib/studio/settings-store.ts
@@ -77,6 +77,7 @@ const normalizeAdapterType = (value: string | undefined): StudioGatewayAdapterTy
     normalized === "demo" ||
     normalized === "local" ||
     normalized === "claw3d" ||
+    normalized === "orcarouter" ||
     normalized === "custom"
   ) {
     return normalized;

--- a/src/lib/studio/settings.ts
+++ b/src/lib/studio/settings.ts
@@ -37,6 +37,7 @@ export type StudioGatewayAdapterType =
   | "demo"
   | "local"
   | "claw3d"
+  | "orcarouter"
   | "custom";
 export const STUDIO_GATEWAY_ADAPTER_TYPES = [
   "openclaw",
@@ -44,6 +45,7 @@ export const STUDIO_GATEWAY_ADAPTER_TYPES = [
   "demo",
   "local",
   "claw3d",
+  "orcarouter",
   "custom",
 ] as const;
 
@@ -285,6 +287,7 @@ const DEFAULT_OPENCLAW_GATEWAY_URL = "ws://localhost:18789";
 const DEFAULT_LOCAL_ADAPTER_GATEWAY_URL = "ws://localhost:18789";
 const DEFAULT_LOCAL_RUNTIME_URL = "http://localhost:7770";
 const DEFAULT_CLAW3D_RUNTIME_URL = "http://localhost:3000/api/runtime/custom";
+const DEFAULT_ORCAROUTER_URL = "https://api.orcarouter.ai";
 const DEFAULT_CUSTOM_RUNTIME_URL = "http://localhost:7770";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -817,6 +820,7 @@ const normalizeGatewayProfiles = (
     "demo",
     "local",
     "claw3d",
+    "orcarouter",
     "custom",
   ] as const) {
     const normalized = normalizeGatewayProfile(value[adapterType]);
@@ -884,6 +888,7 @@ const mergeGatewayProfiles = (
     "demo",
     "local",
     "claw3d",
+    "orcarouter",
     "custom",
   ] as const) {
     const profilePatch = patch[adapterType];
@@ -941,6 +946,7 @@ const normalizeGatewayAdapterType = (
     adapterType === "openclaw" ||
     adapterType === "local" ||
     adapterType === "claw3d" ||
+    adapterType === "orcarouter" ||
     adapterType === "custom"
   ) {
     return adapterType;
@@ -972,6 +978,8 @@ export const resolveDefaultStudioGatewayProfile = (
       return { url: DEFAULT_CLAW3D_RUNTIME_URL, token: "" };
     case "local":
       return { url: DEFAULT_LOCAL_RUNTIME_URL, token: "" };
+    case "orcarouter":
+      return { url: DEFAULT_ORCAROUTER_URL, token: "" };
     case "custom":
       return { url: DEFAULT_CUSTOM_RUNTIME_URL, token: "" };
     case "hermes":

--- a/tests/unit/officeFloors.test.ts
+++ b/tests/unit/officeFloors.test.ts
@@ -19,6 +19,7 @@ describe("office floor registry", () => {
       "hermes-first",
       "local-runtime",
       "claw3d-runtime",
+      "orcarouter-floor",
       "custom-second",
       "training",
       "traders-floor",
@@ -46,6 +47,7 @@ describe("office floor registry", () => {
       "hermes-first",
       "local-runtime",
       "claw3d-runtime",
+      "orcarouter-floor",
       "custom-second",
     ]);
   });
@@ -66,6 +68,7 @@ describe("office floor registry", () => {
       "hermes-first",
       "local-runtime",
       "claw3d-runtime",
+      "orcarouter-floor",
       "custom-second",
       "training",
       "traders-floor",


### PR DESCRIPTION
Adds **OrcaRouter** as a first-class backend in Claw3D, so users of this 3D office can point Studio at an OpenAI-compatible gateway that routes many models behind one endpoint — without treating OrcaRouter as an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This follows the project's existing named-profile pattern for the direct runtime seam (`local`, `claw3d`, `custom` all reuse `CustomRuntimeProvider`). `orcarouter` is the same shape, but with an OpenAI-conformant transport: the connect flow probes `/v1/models` instead of the Claw3D `/health` + `/state` + `/registry` triple, and the saved upstream token is forwarded as a `Bearer` token on every request through `/api/runtime/custom` (chat completions included). A dedicated OrcaRouter floor appears in the office nav when the backend is active.

Changes:
- Register `orcarouter` in the runtime and Studio adapter unions, the default profile table, and the UI backend presets/hints.
- Extend the custom-runtime HTTP transport and proxy route with optional token forwarding.
- Add `probeOpenAIConformantRuntime` and an `openAIConformant` provider option so the model catalog parses the OpenAI `data: [{ id }]` shape.
- Add the OrcaRouter floor and document the profile in `README.md` and `docs/runtime-profiles.md`.

Testing:
- `npm run lint` — no new issues (9 pre-existing errors, 26 pre-existing warnings unchanged).
- `npm run typecheck` — passes.
- `npm run test` — 1073 passed, 5 pre-existing failures (also fail on clean `main`).
- Live test against `https://api.orcarouter.ai` through the `/api/runtime/custom` proxy: `GET /v1/models` and `POST /v1/chat/completions` both returned 200 with the upstream token forwarded as Bearer.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
